### PR TITLE
Disable LiteSpeed during elevation

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1137,6 +1137,7 @@ sub disable_all_cpanel_services {
       dnsadmin dovecot exim ipaliases mailman
       mysqld pdns proftpd queueprocd spamd
       crond tailwatchd
+      lsws
       /;
     my @disabled_services;
 


### PR DESCRIPTION
We are going to perform multiple reboots
druing the elevation process where the system
is going to be unstable.

Avoid starting LiteSpeed during that time.

By submitting pull requests to this repo, you agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

