### PR TITLE
Restore nixstats service

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -115,8 +115,9 @@ use Carp           ();
 use File::Basename ();
 use File::Copy     ();
 use File::Find     ();
-use File::Temp     ();
+use File::Path     ();
 use File::Slurper  ();
+use File::Temp     ();
 use Hash::Merge    ();
 
 use Cpanel::Config::Httpd       ();
@@ -134,6 +135,7 @@ use Cpanel::Yum::Vars           ();
 
 use constant CHKSRVD_SUSPEND_FILE => q[/var/run/chkservd.suspend];
 use constant ELEVATE_STAGE_FILE   => '/var/cpanel/elevate';
+use constant ELEVATE_BACKUP_DIR   => "/root/.elevate.backup";
 use constant SHORT_SERVICE_NAME   => 'elevate-cpanel';
 use constant SERVICE_NAME         => SHORT_SERVICE_NAME . '.service';
 use constant SERVICE_FILE         => '/etc/systemd/system/' . SERVICE_NAME;
@@ -775,6 +777,7 @@ sub run_stage_5($self) {
     unlink SERVICE_FILE;
     unlink PID_FILE;
     unlink CHKSRVD_SUSPEND_FILE;
+    File::Path::remove_tree(ELEVATE_BACKUP_DIR) if -d ELEVATE_BACKUP_DIR;
     cleanup_motd();
 
     my $postinstall_recommendations = read_stage_file()->{'a_postinstall_recommendation'} // [];
@@ -1347,6 +1350,7 @@ sub remove_custom_stuff_for_later_reinstall {
     run_once('remove_wordpress_toolkit');
     run_once('remove_influxdb');
     run_once('remove_jetbackup');
+    run_once('remove_nixstats');
 
     return;
 }
@@ -1539,6 +1543,7 @@ sub reinstall_custom_stuff {
     run_once('kernel_check');
     run_once('restore_kernel_care');
     run_once('restore_imunify_features');
+    run_once('restore_nixstats');
 
     return;
 }
@@ -1842,6 +1847,108 @@ sub reinstall_influxdb {
     return unless read_stage_file()->{'reinstall'}->{'influxdb'};
     INFO("Re-installing telegraf for influxdb");
     ssystem_and_die(qw{/usr/bin/yum -y reinstall telegraf});
+
+    return;
+}
+
+sub has_nixstats {
+    return -e q[/etc/systemd/system/nixstatsagent.service] || -e q[/usr/local/bin/nixstatsagent];
+}
+
+sub remove_nixstats {
+
+    return unless has_nixstats();
+
+    INFO("Removing nixstats");
+
+    my $backup_dir = ELEVATE_BACKUP_DIR . "/nixstats";
+
+    File::Path::make_path($backup_dir);
+    LOGDIE("Fail to create backup directory: $backup_dir") unless -d $backup_dir;
+
+    my @to_backup = qw{ /etc/nixstats-token.ini /etc/nixstats.ini };
+
+    # files we need to restore later
+    my $to_restore = {};
+
+    foreach my $f (@to_backup) {
+        next unless -f $f;
+        my $name   = File::Basename::basename($f);
+        my $backup = "$backup_dir/$name";
+        File::Copy::move( $f, $backup );
+
+        $to_restore->{$backup} = $f;
+    }
+
+    my $service = q[nixstatsagent];
+
+    my $is_enabled = _is_service_enabled($service);
+
+    ssystem( qw{/usr/bin/systemctl disable}, $service ) if $is_enabled;
+    ssystem( qw{/usr/bin/systemctl stop},    $service );
+
+    ssystem(qw{/usr/bin/rm -f /usr/local/bin/nixstatsagent});
+
+    my $data = {
+        service_enabled => $is_enabled,
+        to_restore      => $to_restore,
+    };
+
+    update_stage_file( { 'reinstall' => { 'nixstats' => $data } } );
+
+    return;
+}
+
+sub restore_nixstats {
+    my $data = read_stage_file()->{'reinstall'}->{'nixstats'};
+    return unless ref $data;
+
+    INFO("Restoring nixstats");
+
+    # we reinstall nixstats using a non existing user id
+    #   this avoid adding some polution to their account
+    #   by creating a server we are then going to replace just after
+    # alternatively we could use the user from the nixstats-token.ini file
+    my $user = q[deadbeefdeadbeefdeadbeef];
+
+    my $installer_script = _fetch_a_script( 'https://www.nixstats.com/nixstatsagent.sh', 'nixstatsagent' );
+
+    ssystem( '/usr/bin/bash', $installer_script, $user );
+
+    unlink $installer_script;
+
+    my $service = q[nixstatsagent];
+
+    # Stopping the agent
+    ssystem( qw{/usr/bin/systemctl stop}, $service );
+
+    # Restoring backup files
+    my $to_restore = $data->{to_restore};
+
+    foreach my $src ( sort keys %$to_restore ) {
+        my $destination = $to_restore->{$src};
+
+        File::Copy::copy( $src, $destination );
+    }
+
+    # restoring the state of the service before elevation
+    if ( $data->{service_enabled} ) {
+        ssystem( qw{/usr/bin/systemctl enable}, $service );
+    }
+    else {    # leave it disabled
+        ssystem( qw{/usr/bin/systemctl disable}, $service );
+    }
+
+    # do not really need to start/stop the daemon, we are about to reboot
+    #   but start it for sanity purpose
+
+    ssystem( qw{/usr/bin/systemctl start}, $service );
+    if ( $? == 0 ) {
+        INFO("nixstatsagent restored");
+    }
+    else {
+        WARN("Failed to start nixstatsagent.service");
+    }
 
     return;
 }


### PR DESCRIPTION
Fix #16

Backup configuration files and restore
them after reinstalling the nixstats monitoring
daemon.
