### PR TITLE
Keep KernelCare registered on RPM removal

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -929,6 +929,8 @@ sub remove_kernelcare_if_needed {
 
     return unless -x q[/usr/bin/kcarectl];
 
+    # This environment variable signals to the KernelCare RPM scriptlets not to deregister on package removal.
+    local $ENV{KCARE_KEEP_REGISTRATION} = '1';
     remove_rpms_from_repos('kernelcare');
 
     update_stage_file( { 'reinstall' => { 'kernelcare' => 1 } } );


### PR DESCRIPTION
The KernelCare RPM preuninstall scriptlet automatically deregisters
key-based licenses from the server. This can be avoided by setting a
particular environment variable.

By submitting pull requests to this repo, you agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

