### PR TITLE
Export EA profile to target A8

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1335,10 +1335,11 @@ sub backup_ea4_profile () {
         return;
     }
 
-    my $cmd = '/usr/local/bin/ea_current_to_profile';
-    INFO("Running: $cmd");
-    my $json = Cpanel::SafeRun::Simple::saferunnoerror($cmd) // '';
-    die qq[Failure from $cmd] if $?;
+    my @cmd     = qw{ /usr/local/bin/ea_current_to_profile --target-os=AlmaLinux_8};
+    my $cmd_str = join( ' ', @cmd );
+    INFO("Running: $cmd_str");
+    my $json = Cpanel::SafeRun::Simple::saferunnoerror(@cmd) // '';
+    die qq[Failure from $cmd_str] if $?;
 
     chomp $json;
     die "Unable to backup EA4 profile to $json" unless length $json && -f $json && -s _;


### PR DESCRIPTION
Fix #62

```
[root@elevateit ~]# grep -C5 -n ea_current_to_profile /var/log/elevate-cpanel.log
359-
360-
361-* 24-19:32:54 (3097) [INFO] Running: /usr/bin/ln -snf usr/local/cpanel/scripts /scripts
362-
363-
364:* 24-19:32:55 (1340) [INFO] Running: /usr/local/bin/ea_current_to_profile --target-os=AlmaLinux_8
365-* 24-19:32:57 (1346) [INFO] Backed up EA4 profile to /etc/cpanel/ea4/profiles/custom/current_state_at_2022-03-24_19:32:57.json
366-* 24-19:33:05 (1473) [INFO] # Cleanup MySQL packages ; using version 8.0
367-* 24-19:33:07 (1899) [INFO] Removing packages for Mysql-connectors-community, Mysql-tools-community, Mysql80-community, Mysql-tools-preview
368-* 24-19:33:07 (3097) [INFO] Running: /usr/bin/yum -y erase mysql-community-client mysql-community-client-plugins mysql-community-common mysql-community-devel mysql-community-icu-data-files mysql-community-libs mysql-community-libs-compat mysql-community-server
369-
```

