### PR TITLE
Improve ea_current_to_profile output parser

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1393,15 +1393,7 @@ sub backup_ea4_profile () {
         return;
     }
 
-    my @cmd     = qw{ /usr/local/bin/ea_current_to_profile --target-os=AlmaLinux_8};
-    my $cmd_str = join( ' ', @cmd );
-    INFO("Running: $cmd_str");
-    my $json = Cpanel::SafeRun::Simple::saferunnoerror(@cmd) // '';
-    die qq[Unable to backup EA4 profile. Failure from $cmd_str] if $?;
-
-    chomp $json if defined $json;
-    die "Unable to backup EA4 profile running: $cmd_str" unless length $json && -f $json && -s _;
-    INFO("Backed up EA4 profile to $json");
+    my $json = _get_ea4_profile();
 
     my $data = { profile => $json };
 
@@ -1414,6 +1406,35 @@ sub backup_ea4_profile () {
     update_stage_file( { ea4 => $data } );
 
     return 1;
+}
+
+sub _get_ea4_profile {
+    my @cmd     = qw{ /usr/local/bin/ea_current_to_profile --target-os=AlmaLinux_8};
+    my $cmd_str = join( ' ', @cmd );
+    INFO("Running: $cmd_str");
+    my $output = Cpanel::SafeRun::Simple::saferunnoerror(@cmd) // '';
+    die qq[Unable to backup EA4 profile. Failure from $cmd_str] if $?;
+
+    my @lines = split( "\n", $output );
+
+    my $json;
+    if ( scalar @lines == 1 ) {
+        $json = $lines[0];
+    }
+    else {
+        foreach my $l ( reverse @lines ) {
+            next unless $l =~ m{^/.*\.json};
+            if ( -f $l ) {
+                $json = $l;
+                last;
+            }
+        }
+    }
+
+    die "Unable to backup EA4 profile running: $cmd_str" unless length $json && -f $json && -s _;
+    INFO("Backed up EA4 profile to $json");
+
+    return $json;
 }
 
 sub backup_ea_addons() {

--- a/t/ea4.t
+++ b/t/ea4.t
@@ -110,6 +110,62 @@ sub test_missing_ea4_profile : Test(3) ($self) {
     return;
 }
 
+sub test_get_ea4_profile : Test(10) ($self) {
+
+    my $profile = PROFILE_FILE;
+    my $output  = qq[$profile\n];
+
+    $self->{mock_profile}->contents('{}');
+
+    $self->{mock_saferun}->redefine(
+        saferunnoerror => sub {
+            note "saferunnoerror: ", $output;
+            return $output;
+        },
+    );
+
+    is( cpev::_get_ea4_profile(), PROFILE_FILE, "_get_ea4_profile" );
+    _message_run_ea_current_to_profile(1);
+
+    $output = <<'EOS';
+The following packages are not available on AlmaLinux_8 and have been removed from the profile
+    ea-php71
+    ea-php71-libc-client
+    ea-php71-pear
+    ea-php71-php-bcmath
+    ea-php71-php-calendar
+    ea-php71-php-cli
+    ea-php71-php-common
+    ea-php71-php-curl
+    ea-php71-php-devel
+    ea-php71-php-fpm
+    ea-php71-php-ftp
+    ea-php71-php-gd
+    ea-php71-php-iconv
+    ea-php71-php-imap
+    ea-php71-php-litespeed
+    ea-php71-php-mbstring
+    ea-php71-php-mysqlnd
+    ea-php71-php-pdo
+    ea-php71-php-posix
+    ea-php71-php-sockets
+    ea-php71-php-xml
+    ea-php71-php-zip
+    ea-php71-runtime
+
+/etc/cpanel/ea4/profiles/custom/current_state_at_2022-04-05_20:41:25_modified_for_AlmaLinux_8.json
+EOS
+
+    my $f      = q[/etc/cpanel/ea4/profiles/custom/current_state_at_2022-04-05_20:41:25_modified_for_AlmaLinux_8.json];
+    my $mock_f = Test::MockFile->file( $f, '{}' );
+
+    is( cpev::_get_ea4_profile(), $f, "_get_ea4_profile with noise..." );
+
+    _message_run_ea_current_to_profile($f);
+
+    return;
+}
+
 sub backup_non_existing_profile : Test(10) ($self) {
 
     like(
@@ -269,7 +325,9 @@ sub _message_run_ea_current_to_profile($success=0) {
     message_seen( 'INFO' => q[Running: /usr/local/bin/ea_current_to_profile --target-os=AlmaLinux_8] );
     return unless $success;
 
-    message_seen( 'INFO' => q[Backed up EA4 profile to ] . PROFILE_FILE );
+    my $f = $success eq 1 ? PROFILE_FILE : $success;
+
+    message_seen( 'INFO' => q[Backed up EA4 profile to ] . $f );
 
     return;
 }


### PR DESCRIPTION
When using some unsupported package the
ea_current_to_profile script is going to
add noise to the STDOUT... we need to improve
the output parsing logic to be able to get
a json file.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

