### PR TITLE
Move disabling of MySQL repos after removing packages

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -656,8 +656,6 @@ sub run_stage_2($self) {
     ssystem_and_die(qw{/scripts/update-packages});
     ssystem_and_die(qw{/usr/bin/yum -y update});
 
-    disable_known_yum_repositories();
-
     disable_all_cpanel_services();
 
     setup_outdated_services();
@@ -1520,6 +1518,7 @@ sub pre_leapp_update_backup_and_cleanup {
     run_once('backup_ea_addons');
     run_once('backup_pecl_packages');
     run_once('cleanup_mysql_packages');
+    run_once('disable_known_yum_repositories');
 
     run_once(
         arch_rpms => sub {


### PR DESCRIPTION
Currently, MySQL repositories are being removed during stage 2, but
MySQL packages are being removed in stage 3 prior to invoking leapp.
This is likely to be causing problems. Instead, defer disabing the repos
until after the packages have been removed.

Fixes #66.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

