### PR TITLE
Fix reporting of final MySQL upgrade status

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1604,8 +1604,8 @@ sub reinstall_mysql_packages {
         my $c = 0;
 
         while (1) {
-            $c = ( $c + 1 ) % 10;
-            my $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 background_mysql_upgrade_status }, "upgrade_id=$id" );
+            $c   = ( $c + 1 ) % 10;
+            $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 background_mysql_upgrade_status }, "upgrade_id=$id" );
             die qq[Fail to restore MySQL $mysql_version: cannot check upgrade_id=$id] if $?;
 
             if ( $out =~ m{\sstate:\s*inprogress} ) {


### PR DESCRIPTION
Nested definition of `$out` in `reinstall_mysql_packages` is causing
that function to report less useful information in the case of a MySQL
upgrade failure. Report the more useful final status of the upgrade,
rather than the initial return value of the API call which kicked off
the process.

Fixes #75.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

