### PR TITLE
Turn off screen appender when run as service

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -237,7 +237,7 @@ sub run ($self) {
 
     local $| = 1;
 
-    _init_logger();
+    $self->_init_logger();
 
     if ( $self->getopt('start') ) {
         die qq[Unsupported option with --start\n] if $self->getopt('continue') || $self->getopt('service');
@@ -3322,21 +3322,31 @@ sub ssystem_and_die (@args) {
     die "command failed. Fix it and run command.";
 }
 
-sub _init_logger ( $debug_level = 'DEBUG') {
+sub _init_logger ( $self, $debug_level = 'DEBUG' ) {
     my $log_file = LOG_FILE;
 
     my $config = <<~"EOF";
-        log4perl.logger = DEBUG, Screen, File
-        log4perl.appender.Screen=Log::Log4perl::Appender::Screen
-        log4perl.appender.Screen.stderr=0
-        log4perl.appender.Screen.layout=Log::Log4perl::Layout::PatternLayout
-        log4perl.appender.Screen.layout.ConversionPattern=* %d{dd-HH:mm:ss} (%L) [%p] %m%n
         log4perl.appender.File=Log::Log4perl::Appender::File
         log4perl.appender.File.filename=$log_file
         log4perl.appender.File.syswrite=1
         log4perl.appender.File.layout=Log::Log4perl::Layout::PatternLayout
         log4perl.appender.File.layout.ConversionPattern=* %d{dd-HH:mm:ss} (%L) [%p] %m%n
     EOF
+
+    if ( $self->getopt('service') ) {
+        $config .= <<~"EOF";
+        log4perl.logger = $debug_level, File
+        EOF
+    }
+    else {
+        $config .= <<~"EOF";
+        log4perl.appender.Screen=Log::Log4perl::Appender::Screen
+        log4perl.appender.Screen.stderr=0
+        log4perl.appender.Screen.layout=Log::Log4perl::Layout::PatternLayout
+        log4perl.appender.Screen.layout.ConversionPattern=* %d{dd-HH:mm:ss} (%L) [%p] %m%n
+        log4perl.logger = $debug_level, Screen, File
+        EOF
+    }
 
     Log::Log4perl->init( \$config );
 


### PR DESCRIPTION
Only log to file when elevate-cpanel is passed `--service` argument.

Fixes #88.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

