### PR TITLE
Remove output stream labels from ssystem()

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3302,7 +3302,7 @@ sub ssystem (@args) {
     my $program = shift @args;
     my ( $callback_out, $callback_err ) = map {
         my $label = $_;
-        Cpanel::IOCallbackWriteLine->new( sub ($line) { chomp $line; INFO("{$label} $line"); } )
+        Cpanel::IOCallbackWriteLine->new( sub ($line) { chomp $line; INFO($line); } )
     } qw(stdout stderr);
     my $sr = Cpanel::SafeRun::Object->new(
         program      => $program,


### PR DESCRIPTION
It was decided that labelling whether output lines came from stdandard
out or standard error for commands run through `ssystem` is not worth
the additional noise. Remove these labels from the log output.

Fixes #89.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

