### PR TITLE
Use BigQuery timestamps for start/end markers

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -877,6 +877,11 @@ sub run_stage_5($self) {
     return REBOOT_NEEDED;
 }
 
+sub _bq_now () {
+    require POSIX;
+    return POSIX::strftime( '%FT%T', gmtime );
+}
+
 sub elevation_startup_marker ( $self, $sum = 'unknown' ) {
 
     # store some generic informations about the update process
@@ -885,7 +890,7 @@ sub elevation_startup_marker ( $self, $sum = 'unknown' ) {
             '_elevate_process' => {
                 script_md5         => $sum,
                 cpanel_build       => $Cpanel::Version::Tiny::VERSION_BUILD,
-                started_at         => scalar gmtime(),
+                started_at         => _bq_now(),
                 redhat_release_pre => read_redhat_release(),
             }
         }
@@ -899,7 +904,7 @@ sub elevation_success_marker($self) {
     update_stage_file(
         {
             '_elevate_process' => {
-                finished_at         => scalar gmtime(),
+                finished_at         => _bq_now(),
                 redhat_release_post => read_redhat_release(),
             }
         }

--- a/t/elevate-marker.t
+++ b/t/elevate-marker.t
@@ -57,9 +57,9 @@ my $data = eval { Cpanel::JSON::LoadFile( $marker_file->path ) } // {};
 is $data, {
     '_elevate_process' => {
         'cpanel_build'        => match qr{^[\d.]+$}a,
-        'finished_at'         => D(),
+        'finished_at'         => match qr/^\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}$/a,
         'script_md5'          => 'deadbeef',
-        'started_at'          => D(),
+        'started_at'          => match qr/^\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}$/a,
         'redhat_release_pre'  => 'RHEL Before C7',
         'redhat_release_post' => 'RHEL After A8',
     }


### PR DESCRIPTION
Change the timestamps recorded for the start and end markers in the
stage file, to ease the process of analyzing data about conversions.

Implements #91.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

