### PR TITLE
Block if system runs in a container

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2748,6 +2748,12 @@ sub _blocker_mysql_upgrade_in_progress ($self) {
     return 0;
 }
 
+sub _blocker_is_container ($self) {
+    $self->has_blocker( 90, "cPanel thinks that this is a container-like environment, which this script cannot support at this time." ) if _is_container_envtype();
+
+    return 0;
+}
+
 sub _blocker_disk_space ($self) {
     $self->has_blocker( 99, q[disk space issue] ) unless _disk_space_check();
 
@@ -2892,6 +2898,7 @@ sub _blockers_check ($self) {
     $self->_blocker_invalid_ssh_config();
     $self->_blocker_old_jetbackup();
     $self->_blocker_mysql_upgrade_in_progress();
+    $self->_blocker_is_container();
     $self->_blocker_disk_space();
     $self->_blocker_system_update();
     $self->_blocker_bad_nics_naming();
@@ -3088,6 +3095,19 @@ sub _sshd_setup () {
     }
 
     return 1;
+}
+
+sub _is_container_envtype () {
+    require Cpanel::OSSys::Env;
+    my $envtype = Cpanel::OSSys::Env::get_envtype();
+
+    return scalar grep { $envtype eq $_ } qw(
+      virtuozzo
+      vzcontainer
+      lxc
+      virtualiron
+      vserver
+    );
 }
 
 sub _disk_space_check() {

--- a/t/blockers.t
+++ b/t/blockers.t
@@ -315,6 +315,12 @@ message_seen( 'ERROR', q[MySQL upgrade in progress. Please wait for the MySQL up
 no_messages_seen();
 $mf_mysql_upgrade->unlink;
 
+$cpev_mock->redefine( '_is_container_envtype' => 1 );
+is( $cpev->blockers_check(), 90, "Blocks when envtype indicates a container" );
+message_seen( 'ERROR', q[cPanel thinks that this is a container-like environment, which this script cannot support at this time.] );
+no_messages_seen();
+$cpev_mock->redefine( '_is_container_envtype' => 0 );
+
 $cpev_mock->redefine( _system_update_check => 0 );
 is( $cpev->blockers_check(), 101, 'System is not up to date' );
 message_seen( 'ERROR', 'System is not up to date' );


### PR DESCRIPTION
Leapp requires an initrd to modify the core packages of a system, so
container-like environments (e.g., VZ, LXC) do not work at this time.
Issue a blocker to prevent them from proceeding.

Reinforces conclusion reached in #106.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

