### PR TITLE
Block if BLS is not disabled in /etc/default/grub

### DIFF
--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -51,3 +51,9 @@ You can discover many of these issues by downloading `elevate-cpanel` and runnin
   * **MariaDB**: If you have already switched to MariaDB, you have no way of reaching MySQL. Be sure you are on 10.3 or better before moving to AlmaLinux 8.
 * Some **EA4 packages** are not supported on AlmaLinux 8.
   * Example: PHP versions 5.4 through 7.1 are available on CentOS 7 but not AlmaLinux 8. You would need to remove these packages before the upgrading to AlmaLinux 8. Doing so might impact your system users. Proceed with caution.
+
+## Workarounds
+
+* Some providers of virtualized environments boot into a version of the GRUB2 boot loader which does not understand (or does not properly parse) the [Boot Loader Specification (BLS)](https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault) files which AlmaLinux 8 prefers to use to instruct the boot loader how to load the kernel and start the operating system. This can cause the system to fail to boot correctly in the middle of the upgrade process. To work around this issue, you must perform one of the following to proceed with the upgrade:
+  * Disable the use of BLS when rebuilding boot loader entries by modifying the file `/etc/default/grub` to contain the line `GRUB_ENABLE_BLSCFG=false`.
+  * Run the script with the `--skip-disable-blscfg` flag. If your provider uses the instance of GRUB2 provided by the OS, or if your provider uses an instance of GRUB2 which does support BLS, this should work without issue. If you do encounter the described issue, see [issue #101](https://github.com/cpanel/elevate/issues/101) for further details.

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -49,6 +49,7 @@ Helps to upgrade CentOS 7 cPanel servers to AlmaLinux 8.
        --status                       Check the current elevation status
        --clean                        Cleanup scripts and files created by elevate-cpanel
 
+       --skip-disable-blscfg          Skip the check for BLS configuration of the boot loader being disabled.
        --skip-elevate-version-check   Skip the check for whether this script is up to date.
        --skip-cpanel-version-check    Skip the check for whether cPanel is up to date.
                                       This option is intended only for testing!
@@ -153,20 +154,21 @@ use Hash::Merge     ();
 use LWP::Simple     ();
 use Term::ANSIColor ();
 
-use Cpanel::Config::Httpd       ();
-use Cpanel::Config::LoadCpConf  ();
-use Cpanel::HTTP::Client        ();
-use Cpanel::JSON                ();
-use Cpanel::OS                  ();
-use Cpanel::PID                 ();
-use Cpanel::Pkgr                ();
-use Cpanel::RestartSrv::Systemd ();
-use Cpanel::SafeRun::Simple     ();
-use Cpanel::SafeRun::Errors     ();
-use Cpanel::Update::Tiers       ();
-use Cpanel::Version::Tiny       ();
-use Cpanel::Version::Compare    ();
-use Cpanel::Yum::Vars           ();
+use Cpanel::Config::Httpd                       ();
+use Cpanel::Config::LoadCpConf                  ();
+use Cpanel::HTTP::Client                        ();
+use Cpanel::JSON                                ();
+use Cpanel::OS                                  ();
+use Cpanel::PID                                 ();
+use Cpanel::Pkgr                                ();
+use Cpanel::RestartSrv::Systemd                 ();
+use Cpanel::SafeRun::Simple                     ();
+use Cpanel::SafeRun::Errors                     ();
+use Cpanel::Transaction::File::LoadConfigReader ();
+use Cpanel::Update::Tiers                       ();
+use Cpanel::Version::Tiny                       ();
+use Cpanel::Version::Compare                    ();
+use Cpanel::Yum::Vars                           ();
 
 use constant CHKSRVD_SUSPEND_FILE => q[/var/run/chkservd.suspend];
 use constant ELEVATE_BLOCKER_FILE => '/var/cpanel/elevate-blockers';
@@ -194,6 +196,9 @@ use constant IMUNIFY_LICENSE_BACKUP => ELEVATE_BACKUP_DIR . '/imunify-backup-lic
 use constant SBIN_IP => q[/sbin/ip];
 
 use constant YUM_REPOS_D => q[/etc/yum.repos.d];
+
+# Test::MockModule doesn't like redefining constants
+sub DEFAULT_GRUB_FILE () { return '/etc/default/grub' }
 
 use constant DISABLE_MYSQL_YUM_REPOS => qw{
   Mysql57.repo
@@ -234,7 +239,7 @@ use constant VETTED_YUM_REPO => qw{
 use constant REBOOT_NEEDED => 4242;    # just one unique id
 
 sub _OPTIONS {
-    return qw( service start clean continue manual-reboots status log check:s skip-cpanel-version-check skip-elevate-version-check );
+    return qw( service start clean continue manual-reboots status log check:s skip-cpanel-version-check skip-elevate-version-check skip-disable-blscfg );
 }
 
 exit( __PACKAGE__->new(@ARGV)->run() // 0 ) if !caller;
@@ -2888,6 +2893,42 @@ sub _latest_checksum () {
     return $rv;
 }
 
+sub _blocker_blscfg ($self) {
+
+    if ( !$self->getopt('skip-disable-blscfg') ) {
+        my $etc_default_grub = Cpanel::Transaction::File::LoadConfigReader->new(
+            path      => DEFAULT_GRUB_FILE,
+            delimiter => '=',
+            comment   => '^\s*#',
+        );
+
+        my $grub_enable_blscfg = $etc_default_grub->get_entry('GRUB_ENABLE_BLSCFG');
+        return $self->has_blocker( 106, <<~EOS ) if !$grub_enable_blscfg || $grub_enable_blscfg ne 'false';
+        This system is currently configured so that the entries for the boot loader
+        will be stored in BLS format upon upgrade. This is ordinarily fine, but some
+        providers boot into their own copy of GRUB2, and theirs may not understand the
+        BLS format. If this is the case, the system will not be able to boot through
+        normal means in the middle of the upgrade process.
+
+        The safe option is to add or change the following line in /etc/default/grub so
+        that it reads:
+
+        GRUB_ENABLE_BLSCFG=false
+
+        You can switch to BLS format at your own risk at a later time after the upgrade
+        by running the /usr/sbin/grub2-switch-to-blscfg command.
+
+        Alternatively, if you know that your provider properly works with BLS boot
+        entries, you may bypass this blocker by invoking this script with the
+        --skip-disable-blscfg flag. If you do encounter this particular issue while
+        using this flag, please consider reporting the problem and the name of your
+        server provider to: https://github.com/cpanel/elevate/issues/101
+        EOS
+    }
+
+    return 0;
+}
+
 sub _blockers_check ($self) {
 
     my $cpconf = Cpanel::Config::LoadCpConf::loadcpconf();
@@ -2916,6 +2957,7 @@ sub _blockers_check ($self) {
     $self->_blocker_bad_nics_naming();
     $self->_blocker_ea4_profile();
     $self->_blocker_script_updated();
+    $self->_blocker_blscfg();
 
     return 0;
 }


### PR DESCRIPTION
By default, the upgrade process has been converting normal GRUB2 boot
loader entries into files compatible with a subset of the Boot Loader
Specification. (A [Fedora wiki entry
<https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault>](https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault)
describes the details.) However, server providers may boot into a
version of GRUB2 which does not understand BLS or does not properly
parse these files. If this happens, the upgrade process will cause the
system to no longer boot without manual intervention.

BLS is (currently) optional for AlmaLinux 8, and it is possible to
suppress this conversion by explicitly setting `GRUB_ENABLE_BLSCFG` to
`false` in `/etc/default/grub` prior to the upgrade. Therefore, block
upgrades if this is not set, but also provide a command line flag to
bypass this workaround. Also, explicitly mention the URL of issue #101
in the blocker, so that more information can be gathered.

Fixes #101.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

