### PR TITLE
Fix typo in distro detection fallback

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -598,7 +598,7 @@ sub save_blocker_file ( $path, $stash ) {
 
 # We are OK if can_be_elevated or if
 sub bail_out_on_inappropriate_distro () {
-    if ( !( eval { Cpanel::OS::can_be_elevated() } // ( Cpanel::OS::distro() eq 'Centos' && Cpanel::OS::major() == 7 ) ) ) {
+    if ( !( eval { Cpanel::OS::can_be_elevated() } // ( Cpanel::OS::distro() eq 'centos' && Cpanel::OS::major() == 7 ) ) ) {
         FATAL qq[This script is designed to only run on CentOS 7 servers.\n];
         exit 1;
     }


### PR DESCRIPTION
Check `Cpanel::OS::distro()` against `centos` rather than `Centos`.

Fixes #114.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

