### PR TITLE
Address BLS by detecting and updating provider workarounds for GRUB2 prefix

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -141,18 +141,22 @@ use parent qw( Cpanel::HelpfulScript );
 use Log::Log4perl qw(:easy);
 
 use Config;
-use Carp            ();
-use Digest::SHA     ();
-use File::Basename  ();
-use File::Copy      ();
-use File::Find      ();
-use File::Path      ();
-use File::Slurper   ();
-use File::Temp      ();
-use Hash::Merge     ();
-use LWP::Simple     ();
-use Term::ANSIColor ();
+use Carp                  ();
+use Digest::SHA           ();
+use File::Basename        ();
+use File::Copy            ();
+use File::Copy::Recursive ();
+use File::Find            ();
+use File::Path            ();
+use File::Slurper         ();
+use File::Spec            ();
+use File::Temp            ();
+use Hash::Merge           ();
+use LWP::Simple           ();
+use Term::ANSIColor       ();
 
+use Cpanel::AccessIds::SetUids  ();
+use Cpanel::Binaries            ();
 use Cpanel::Config::Httpd       ();
 use Cpanel::Config::LoadCpConf  ();
 use Cpanel::HTTP::Client        ();
@@ -163,6 +167,7 @@ use Cpanel::Pkgr                ();
 use Cpanel::RestartSrv::Systemd ();
 use Cpanel::SafeRun::Simple     ();
 use Cpanel::SafeRun::Errors     ();
+use Cpanel::SafeRun::Object     ();
 use Cpanel::Update::Tiers       ();
 use Cpanel::Version::Tiny       ();
 use Cpanel::Version::Compare    ();
@@ -194,6 +199,8 @@ use constant IMUNIFY_LICENSE_BACKUP => ELEVATE_BACKUP_DIR . '/imunify-backup-lic
 use constant SBIN_IP => q[/sbin/ip];
 
 use constant YUM_REPOS_D => q[/etc/yum.repos.d];
+
+use constant DEFAULT_GRUB_FILE => '/etc/default/grub';
 
 use constant DISABLE_MYSQL_YUM_REPOS => qw{
   Mysql57.repo
@@ -232,6 +239,13 @@ use constant VETTED_YUM_REPO => qw{
 }, DISABLE_MYSQL_YUM_REPOS;
 
 use constant REBOOT_NEEDED => 4242;    # just one unique id
+
+use constant {
+    GRUB2_WORKAROUND_NONE      => 0,
+    GRUB2_WORKAROUND_OLD       => 1,
+    GRUB2_WORKAROUND_NEW       => 2,
+    GRUB2_WORKAROUND_UNCERTAIN => -1,
+};
 
 sub _OPTIONS {
     return qw( service start clean continue manual-reboots status log check:s skip-cpanel-version-check skip-elevate-version-check );
@@ -694,6 +708,9 @@ sub run_stage_2 ($self) {
     setup_motd();
 
     run_once('remove_kernelcare_if_needed');
+
+    run_once('update_grub2_workaround_if_needed');    # required part
+    run_once('merge_grub_directories_if_needed');     # best-effort part
 
     return REBOOT_NEEDED;
 }
@@ -2472,7 +2489,7 @@ sub blockers_check ( $self, $all = 0 ) {
             ERROR( $error->{msg} );
             return $error->{id} // 401;
         }
-        WARN("Unkown error while checking blockers: $error");
+        WARN("Unknown error while checking blockers: $error");
         return 127;    # unknown error
     }
 
@@ -2888,6 +2905,238 @@ sub _latest_checksum () {
     return $rv;
 }
 
+sub _blocker_blscfg ($self) {
+
+    my $grub_enable_blscfg = _parse_shell_variable( DEFAULT_GRUB_FILE, 'GRUB_ENABLE_BLSCFG' );
+
+    return $self->has_blocker( 106, <<~EOS ) if defined $grub_enable_blscfg && $grub_enable_blscfg ne 'true';
+    Disabling the BLS boot entry format prevents the resulting system from
+    adding kernel updates to any boot loader configuration, because the old
+    utility responsible for maintaining native GRUB2 boot loader entries was
+    removed and replaced with a wrapper around the new utility, which only
+    understands BLS format. This means that the old kernel will be used on
+    reboot, unless the GRUB2 configuration file is manually edited to load the
+    new kernel. Furthermore, after a few kernel updates, the DNF package
+    manager may begin to remove old kernels, including the one still used in
+    the configuration file. If that happens, the system will fail to come back
+    after a subsequent reboot.
+
+    The safe option is to remove the following line in /etc/default/grub:
+
+    GRUB_ENABLE_BLSCFG=false
+
+    or to change it so that it is set to "true" instead.
+    EOS
+
+    return 0;
+}
+
+sub _parse_shell_variable ( $path, $varname ) {
+
+    my ( undef, $dir, $file ) = File::Spec->splitpath($path);
+    $dir = File::Spec->canonpath($dir);
+
+    # drop privileges and run bash in restricted mode
+    my $bash_sr = Cpanel::SafeRun::Object->new(
+        program => Cpanel::Binaries::path('bash'),
+        args    => [
+            '--restricted',
+            '-c',
+            qq(set -ux ; [ "x\$PWD" = "x$dir" ] || exit 72 ; source $file ; echo "\$$varname"),
+        ],
+        before_exec => sub {
+            chdir $dir;
+            Cpanel::AccessIds::SetUids::setuids('nobody');
+        },
+    );
+
+    return undef if $bash_sr->CHILD_ERROR && $bash_sr->error_code == 127;
+    $bash_sr->die_if_error();    # bail out if something else went wrong
+
+    my $value = $bash_sr->stdout;
+    chomp $value;
+    return $value;
+}
+
+sub GRUB2_PREFIX_DEBIAN { return '/boot/grub' }
+sub GRUB2_PREFIX_RHEL   { return '/boot/grub2' }
+
+sub _blocker_grub2_workaround ($self) {
+    my $state = _grub2_workaround_state();
+    if ( $state == GRUB2_WORKAROUND_OLD ) {
+        my ( $deb, $rhel ) = ( GRUB2_PREFIX_DEBIAN, GRUB2_PREFIX_RHEL );
+        WARN( <<~EOS );
+        $deb/grub.cfg is currently a symlink to $rhel/grub.cfg. Your provider
+        may have added this to support booting your server using their own
+        instance of the GRUB2 bootloader, one which looks for its
+        configuration, boot entries, and modules in a different location from
+        where your operating system stores this data. In order to allow the
+        process to complete successfully, the upgrade process will rename the
+        current $deb directory, re-create $deb as a symlink to $rhel,
+        and then copy as much of the old $deb into $rhel as possible.
+        EOS
+        update_stage_file( { 'grub2_workaround' => { 'needs_workaround_update' => 1 } } ) if $self->{_abort_on_first_blocker};    # don't update stage file if this is just a check
+    }
+    elsif ( $state == GRUB2_WORKAROUND_UNCERTAIN ) {
+
+        return $self->has_blocker( 107, <<~EOS );
+        The configuration of the GRUB2 bootloader does not match the
+        expectations of this script. For more information, see the output of
+        the script when run at the console:
+
+        /scripts/elevate-cpanel --check
+
+        If your GRUB2 configuration has not been customized, consider reporting
+        this limitation to https://github.com/cpanel/elevate/issues
+        EOS
+    }
+
+    return 0;
+}
+
+# TODO: This should probably return warnings/errors rather than directly printing to the log.
+sub _grub2_workaround_state () {
+
+    # If /boot/grub DNE, user probably didn't want a workaround:
+    return GRUB2_WORKAROUND_NONE if !-e GRUB2_PREFIX_DEBIAN;
+
+    if ( -l GRUB2_PREFIX_DEBIAN ) {
+        my $dest = Cwd::realpath(GRUB2_PREFIX_DEBIAN);
+        if ( !defined($dest) ) {
+            ERROR( GRUB2_PREFIX_DEBIAN . " is a symlink but realpath() failed: $!" ) unless defined($dest);
+            return GRUB2_WORKAROUND_UNCERTAIN;
+        }
+
+        # If /boot/grub symlink pointing to /boot/grub2, the updated workaround is present:
+        if ( $dest eq GRUB2_PREFIX_RHEL ) {
+            return GRUB2_WORKAROUND_NEW if -d $dest;
+            ERROR( GRUB2_PREFIX_DEBIAN . " does not ultimately link to /boot/grub2." );
+            return GRUB2_WORKAROUND_UNCERTAIN;    # ...unless /boot/grub2 isn't a directory.
+        }
+    }
+
+    # If /boot/grub neither symlink nor directory, we don't know what is going on:
+    elsif ( !-d GRUB2_PREFIX_DEBIAN ) {
+        ERROR( GRUB2_PREFIX_DEBIAN . " is neither symlink nor directory." );
+        return GRUB2_WORKAROUND_UNCERTAIN;
+    }
+
+    my ( $grub_cfg, $grub2_cfg ) = map { $_ . "/grub.cfg" } ( GRUB2_PREFIX_DEBIAN, GRUB2_PREFIX_RHEL );
+
+    # If /boot/grub/grub.cfg DNE, user probably didn't want a workaround:
+    return GRUB2_WORKAROUND_NONE if !-e $grub_cfg;
+
+    if ( -l $grub_cfg ) {
+        my $dest_cfg = Cwd::realpath($grub_cfg);
+        if ( !defined($dest_cfg) ) {
+            ERROR("$grub_cfg is a symlink but realpath() failed: $!");
+            return GRUB2_WORKAROUND_UNCERTAIN;
+        }
+
+        # If /boot/grub/grub.cfg is a symlink pointing to /boot/grub2/grub.cfg, the old workaround is present:
+        if ( $dest_cfg eq $grub2_cfg ) {
+            return GRUB2_WORKAROUND_OLD if -f $dest_cfg;
+            ERROR("$dest_cfg is not a regular file.");
+            return GRUB2_WORKAROUND_UNCERTAIN;    # ...unless /boot/grub2/grub.cfg isn't a regular file.
+        }
+    }
+
+    # If /boot/grub/grub.cfg exists but isn't a symlink, we don't know what is going on:
+    ERROR("$grub_cfg exists but is not a symlink which ultimately links to $grub2_cfg.");
+    return GRUB2_WORKAROUND_UNCERTAIN;
+}
+
+sub update_grub2_workaround_if_needed () {
+
+    my $stage_info = read_stage_file();
+    my $grub2_info = $stage_info->{'grub2_workaround'};
+    if ( $grub2_info && $grub2_info->{'needs_workaround_update'} ) {
+        my $grub_dir  = GRUB2_PREFIX_DEBIAN;
+        my $grub2_dir = GRUB2_PREFIX_RHEL;
+
+        my $grub_bak;
+        if ( $grub2_info->{'backup_dir'} ) {
+            $grub_bak = $grub2_info->{'backup_dir'};
+        }
+        else {
+            $grub_bak = $grub2_info->{'backup_dir'} = $grub_dir . '-' . time;
+            update_stage_file( { 'grub2_workaround' => $grub2_info } );
+        }
+
+        rename $grub_dir, $grub_bak or LOGDIE("Unable to rename $grub_dir to $grub_bak: $!");    # failure on cross-device move is a feature
+        symlink $grub2_dir, $grub_dir or do {
+            rename $grub_bak, $grub_dir;                                                         # undo previous change on failure
+            LOGDIE("Unable to create symlink $grub_dir to point to $grub2_dir");                 # symlink() doesn't set $!
+        };
+
+    }
+
+    return;
+}
+
+sub merge_grub_directories_if_needed () {
+    my $stage_info = read_stage_file();
+    my $grub2_info = $stage_info->{'grub2_workaround'};
+    if ( $grub2_info && $grub2_info->{'needs_workaround_update'} ) {
+        my $grub_dir  = GRUB2_PREFIX_DEBIAN;
+        my $grub2_dir = GRUB2_PREFIX_RHEL;
+        my $grub_bak  = $grub2_info->{'backup_dir'};
+
+        my ( $skipped_copy, $failed_copy ) = ( 0, 0 );
+
+        # If something goes wrong here, we should give up on the copy but allow the upgrade to continue.
+        # Therefore, don't use LOGDIE() inside of the eval block.
+        eval {
+            my %grub2_entries;
+
+            opendir my $grub2_dir_fh, $grub2_dir or die "Unable to open directory $grub2_dir: $!";
+            while ( my $entry = readdir $grub2_dir_fh ) {
+                $grub2_entries{$entry} = 1;
+            }
+            closedir $grub2_dir_fh;
+
+            opendir my $grub_bak_fh, $grub_bak or die "Unable to open directory $grub_bak: $!";
+            while ( my $entry = readdir $grub_bak_fh ) {
+
+                next if $entry eq '.';
+                next if $entry eq '..';
+
+                # grub.cfg in the backup dir is the old symlink, so ignore it separately to avoid warnings:
+                next if $entry eq "grub.cfg";
+
+                if ( exists $grub2_entries{$entry} ) {
+                    $skipped_copy++;
+                    WARN("\"$grub_bak/$entry\" is not being copied to \"$grub2_dir/$entry\" because the destination already exists.");
+                    next;
+                }
+
+                if ( !File::Copy::Recursive::rcopy( "$grub_bak/$entry", "$grub2_dir/$entry" ) ) {
+                    $failed_copy++;
+                    WARN("Copying \"$grub_bak/$entry\" into \"$grub2_dir\" failed.");
+                }
+            }
+            closedir $grub_bak_fh;
+        };
+        WARN("Unable to copy the contents of \"$grub_bak\" into \"$grub2_dir\": $@") if $@;
+
+        my $log_file = LOG_FILE;
+        add_final_notification( <<~EOS ) if ( $skipped_copy > 0 || $failed_copy > 0 );
+        After converting "$grub_dir" from a directory to a symlink to
+        "$grub2_dir", the upgrade process chose not to copy $skipped_copy
+        entries from the old directory due to name conflicts, and it failed to
+        copy $failed_copy entries due to system errors. The previous contents
+        of "$grub_dir" are now located at "$grub_bak". See $log_file for
+        further information.
+
+        If you did not add these files or otherwise customize the boot loader
+        configuration, you may ignore this message.
+        EOS
+
+    }
+
+    return;
+}
+
 sub _blockers_check ($self) {
 
     my $cpconf = Cpanel::Config::LoadCpConf::loadcpconf();
@@ -2916,6 +3165,8 @@ sub _blockers_check ($self) {
     $self->_blocker_bad_nics_naming();
     $self->_blocker_ea4_profile();
     $self->_blocker_script_updated();
+    $self->_blocker_blscfg();
+    $self->_blocker_grub2_workaround();
 
     return 0;
 }

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -958,7 +958,7 @@ sub run_once ( $label, $code = undef ) {
     my $stash = read_stage_file();
     $stash->{'_run_once'} //= {};
 
-    my $full_label = $current_stage . '_' . $label;
+    my $full_label = $stage_name . '_' . $label;
 
     # already run one time successfully
     if ( $stash->{'_run_once'}->{$full_label} ) {

--- a/t/blockers_parse_shell_variable.t
+++ b/t/blockers_parse_shell_variable.t
@@ -1,0 +1,42 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use cPstrict;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use File::Temp ();
+
+my $cpev_mock = Test::MockModule->new('cpev');
+my $cpev      = bless {}, 'cpev';
+
+subtest "test behavior when the directory doesn't exist" => sub {
+    my $exception = dies { cpev::_parse_shell_variable( '/this/path/does/not/exist', 'GRUB_ENABLE_BLSCFG' ) };
+    isa_ok( $exception, 'Cpanel::Exception::ProcessFailed::Error' );
+    is( eval { $exception->get('error_code') }, 72, "expected return status" );
+};
+
+my $test_file = File::Temp->new;
+$test_file->autoflush(1);
+
+chown( scalar getpwnam('nobody'), scalar getgrnam('nobody'), $test_file );
+
+is( cpev::_parse_shell_variable( $test_file->filename, 'GRUB_ENABLE_BLSCFG' ), undef, "_parse_shell_variable returns undef if the variable does not exist in the file" );
+
+$test_file->print("GRUB_ENABLE_BLSCFG=true\n");
+is( cpev::_parse_shell_variable( $test_file->filename, 'GRUB_ENABLE_BLSCFG' ), 'true', "_parse_shell_variable handles bare values" );
+
+$test_file->seek( 0, 0 );
+$test_file->print("GRUB_ENABLE_BLSCFG=\"true\"\n");
+is( cpev::_parse_shell_variable( $test_file->filename, 'GRUB_ENABLE_BLSCFG' ), 'true', "_parse_shell_variable handles double-quoted values" );
+
+done_testing;

--- a/t/grub2_workaround.t
+++ b/t/grub2_workaround.t
@@ -1,0 +1,187 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use cPstrict;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use File::Temp ();
+
+subtest 'Testing _grub2_workaround_state' => sub {
+    my $cpev_mock = Test::MockModule->new('cpev');
+    my $cpev      = bless {}, 'cpev';
+
+    my $mocked_boot;
+    $cpev_mock->redefine(
+        GRUB2_PREFIX_DEBIAN => sub { return "$mocked_boot/grub" },
+        GRUB2_PREFIX_RHEL   => sub { return "$mocked_boot/grub2" },
+    );
+
+    {
+        $mocked_boot = File::Temp->newdir();
+        mkdir "$mocked_boot/grub2";
+        system touch => "$mocked_boot/grub2/grub.cfg";
+
+        is( cpev::_grub2_workaround_state(), cpev::GRUB2_WORKAROUND_NONE, "no workaround detected when /boot/grub does not exist" );
+    }
+
+    {
+        $mocked_boot = File::Temp->newdir();
+        mkdir "$mocked_boot/grub2";
+        mkdir "$mocked_boot/grub";
+        system touch => "$mocked_boot/grub2/grub.cfg";
+        symlink "../grub2/grub.cfg", "$mocked_boot/grub/grub.cfg";
+
+        is( cpev::_grub2_workaround_state(), cpev::GRUB2_WORKAROUND_OLD, "old workaround detected when /boot/grub is a directory and /boot/grub/grub.cfg points to /boot/grub2/grub.cfg" );
+    }
+
+    {
+        $mocked_boot = File::Temp->newdir();
+        mkdir "$mocked_boot/grub2";
+        system touch => "$mocked_boot/grub2/grub.cfg";
+        symlink "grub2", "$mocked_boot/grub";
+
+        is( cpev::_grub2_workaround_state(), cpev::GRUB2_WORKAROUND_NEW, "new workaround detected when /boot/grub is a symlink to /boot/grub2" );
+    }
+
+    return;
+};
+
+subtest 'Testing update_grub2_workaround_if_needed' => sub {
+    {
+        my $cpev_mock = Test::MockModule->new('cpev');
+        my $cpev      = bless {}, 'cpev';
+
+        $cpev_mock->redefine(
+            read_stage_file     => { grub2_workaround => { needs_workaround_update => 0 } },
+            GRUB2_PREFIX_DEBIAN => sub { die "GRUB2_PREFIX_DEBIAN referenced unexpectedly!" },
+            GRUB2_PREFIX_RHEL   => sub { die "GRUB2_PREFIX_RHEL referenced unexpectedly!" },
+        );
+
+        try_ok { cpev::update_grub2_workaround_if_needed() } "calling the function short-circuits when workaround update is not requested";
+    }
+
+    subtest "needs workaround, clean run" => sub {
+        my $cpev_mock = Test::MockModule->new('cpev');
+        my $cpev      = bless {}, 'cpev';
+
+        my $mocked_boot = File::Temp->newdir();
+        mkdir "$mocked_boot/grub";
+        mkdir "$mocked_boot/grub2";
+        system touch => "$mocked_boot/grub2/grub.cfg";
+        symlink "../grub2/grub.cfg", "$mocked_boot/grub/grub.cfg";
+
+        my $stage_update;
+        $cpev_mock->redefine(
+            read_stage_file     => { grub2_workaround => { needs_workaround_update => 1 } },
+            update_stage_file   => sub { $stage_update = $_[0]; return 1; },
+            GRUB2_PREFIX_DEBIAN => "$mocked_boot/grub",
+            GRUB2_PREFIX_RHEL   => "$mocked_boot/grub2",
+        );
+
+        my $now = CORE::time();
+
+        ok( -d "$mocked_boot/grub",       "precondition: /boot/grub is a directory" );
+        ok( !-e "$mocked_boot/grub-$now", "precondition: /boot/grub-$now (backup directory) does not exist" );
+
+        {
+            no warnings qw(once);
+            local *CORE::GLOBAL::time = sub { return $now };
+            try_ok { cpev::update_grub2_workaround_if_needed() } "calling the function doesn't die";
+        }
+
+        ok( -l "$mocked_boot/grub",      "postcondition: /boot/grub is symlink" );
+        ok( -d "$mocked_boot/grub-$now", "postcondition: /boot/grub-$now is a directory" );
+
+        is( $stage_update, { grub2_workaround => { needs_workaround_update => 1, backup_dir => "$mocked_boot/grub-$now" } }, "the stage file was updated as expected" );
+
+        return;
+    };
+
+    subtest "needs workaround, recovery run" => sub {
+        my $cpev_mock = Test::MockModule->new('cpev');
+        my $cpev      = bless {}, 'cpev';
+
+        my $mocked_boot = File::Temp->newdir();
+        mkdir "$mocked_boot/grub";
+        mkdir "$mocked_boot/grub2";
+        system touch => "$mocked_boot/grub2/grub.cfg";
+        symlink "../grub2/grub.cfg", "$mocked_boot/grub/grub.cfg";
+
+        my $now = CORE::time();
+        my $stage_update;
+        $cpev_mock->redefine(
+            read_stage_file     => { grub2_workaround => { needs_workaround_update => 1, backup_dir => "$mocked_boot/grub-$now" } },
+            update_stage_file   => sub { die 'this should not reached' },
+            GRUB2_PREFIX_DEBIAN => "$mocked_boot/grub",
+            GRUB2_PREFIX_RHEL   => "$mocked_boot/grub2",
+        );
+
+        # The filesystem setup looks the same, because failure to perform symlink() rolls back the rename():
+        ok( -d "$mocked_boot/grub",       "precondition: /boot/grub is a directory" );
+        ok( !-e "$mocked_boot/grub-$now", "precondition: /boot/grub-$now (backup directory) does not exist" );
+
+        try_ok { cpev::update_grub2_workaround_if_needed() } "calling the function doesn't die";
+
+        ok( -l "$mocked_boot/grub",      "postcondition: /boot/grub is symlink" );
+        ok( -d "$mocked_boot/grub-$now", "postcondition: /boot/grub-$now is a directory" );
+
+        return;
+    };
+};
+
+subtest 'Testing merge_grub_directories_if_needed' => sub {
+    {
+        my $cpev_mock = Test::MockModule->new('cpev');
+        my $cpev      = bless {}, 'cpev';
+
+        $cpev_mock->redefine(
+            read_stage_file     => { grub2_workaround => { needs_workaround_update => 0 } },
+            GRUB2_PREFIX_DEBIAN => sub { die "GRUB2_PREFIX_DEBIAN referenced unexpectedly!" },
+            GRUB2_PREFIX_RHEL   => sub { die "GRUB2_PREFIX_RHEL referenced unexpectedly!" },
+        );
+
+        try_ok { cpev::merge_grub_directories_if_needed() } "calling the function short-circuits when workaround update is not requested";
+    }
+
+    my $cpev_mock = Test::MockModule->new('cpev');
+    my $cpev      = bless {}, 'cpev';
+
+    my $now = CORE::time();
+
+    my $mocked_boot = File::Temp->newdir();
+    mkdir "$mocked_boot/grub2";
+    mkdir "$mocked_boot/grub-$now";
+    system touch => "$mocked_boot/grub2/grub.cfg";
+    system touch => "$mocked_boot/grub-$now/splash.xpm.gz";
+    symlink "../grub2/grub.cfg", "$mocked_boot/grub-$now/grub.cfg";
+    symlink "grub2",             "$mocked_boot/grub";
+
+    $cpev_mock->redefine(
+        read_stage_file     => { grub2_workaround => { needs_workaround_update => 1, backup_dir => "$mocked_boot/grub-$now" } },
+        GRUB2_PREFIX_DEBIAN => "$mocked_boot/grub",
+        GRUB2_PREFIX_RHEL   => "$mocked_boot/grub2",
+    );
+
+    ok( -f "$mocked_boot/grub2/grub.cfg",       "precondition: /boot/grub2/grub.cfg is a regular file" );
+    ok( !-e "$mocked_boot/grub2/splash.xpm.gz", "precondition: detritus in /boot/grub-$now isn't present in /boot/grub2" );
+
+    try_ok { cpev::merge_grub_directories_if_needed() } "calling the function doesn't die";
+
+    ok( -f "$mocked_boot/grub2/grub.cfg",      "postcondition: /boot/grub2/grub.cfg is still a regular file" );
+    ok( -f "$mocked_boot/grub2/splash.xpm.gz", "postcondition: detritus is now present in /boot/grub2" );
+
+    return;
+
+};
+
+done_testing;

--- a/t/lib/Test/Elevate.pm
+++ b/t/lib/Test/Elevate.pm
@@ -15,8 +15,10 @@ use Log::Log4perl;
 my @MESSAGES_SEEN;
 
 BEGIN {
-    use Test::MockFile 0.032;
-    Test::MockFile::authorized_strict_mode_for_package('Cpanel::Logger');
+    if ($INC{'Test/MockFile.pm'}) {
+        my $auth_pkg = Test::MockFile->can('authorized_strict_mode_for_package');
+        $auth_pkg->('Cpanel::Logger') if $auth_pkg;
+    }
     require $FindBin::Bin . q[/../elevate-cpanel];
     $INC{'cpev.pm'} = '__TEST__';
 }


### PR DESCRIPTION
At least one server provider of note boots their default Linux images using a version of GRUB2 which looks for its configuration, boot entries, and modules at `/boot/grub`, which is the Debian convention; however, the RHEL convention is to install GRUB2 things into `/boot/grub2`. In images for older distros (such as CentOS 7), they had been working around this by creating a symlink at `/boot/grub/grub.cfg` which points to `/boot/grub2/grub.cfg`, which allows booting when the boot entries are in native GRUB2 configuration. However, in newer distros, they have changed this workaround to symlink the entirety of `/boot/grub` to point to `/boot/grub2`. The reason for this is that BLS is implemented through the use of a GRUB2 module, and the symlink of only the configuration file neglects to give their instance of GRUB2 access to load any of the modules installed on the operating system's filesystem, while the symlink of the entire directory does grant this access.

Attempt to detect this workaround based on the types and structure of these files, directories, and symlinks. Block if we cannot clearly identify whether or not one of these workarounds is in place. Update the workaround during stage 2 if the older variant is found and, as a courtesy, try to copy non-conflicting files, etc. from the old `/boot/grub` into `/boot/grub2`.

Additionally, fix what is probably a mistake in the names of the entries in the stash file created by `run_once()`.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

