### PR TITLE
Recommend proper MariaDB version for cPanel v110

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2838,13 +2838,17 @@ sub _blocker_old_mysql ( $self, $mysql_version = '' ) {
         EOS
     }
     elsif ( $mysql_version eq '10.2' ) {
+
+        # cPanel 110 no longer supports upgrades from something else to 10.3. Suggest 10.5 in that case:
+        my $upgrade_version = $Cpanel::Version::Tiny::major_version <= 108 ? '10.3' : '10.5';
+
         $self->has_blocker( 12, <<~"EOS");
         You are using MariaDB server 10.2, this version is not available for $pretty_distro_name.
-        You first need to update MariaDB server to 10.3 or later.
+        You first need to update MariaDB server to $upgrade_version or later.
 
-        You can update to version 10.3 using the following command:
+        You can update to version $upgrade_version using the following command:
 
-            /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade version=10.3
+            /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade version=$upgrade_version
 
         Once the MariaDB upgrade is finished, you can then retry to elevate to $pretty_distro_name.
         EOS

--- a/t/blockers.t
+++ b/t/blockers.t
@@ -239,7 +239,7 @@ $0 = '/usr/local/cpanel/scripts/elevate-cpanel';
 is( $cpev->blockers_check(), 12, "the script location is correct but MariaDB 10.2 is installed." );
 message_seen(
     'ERROR',
-    "You are using MariaDB server 10.2, this version is not available for AlmaLinux 8.\nYou first need to update MariaDB server to 10.3 or later.\n\nYou can update to version 10.3 using the following command:\n\n    /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade version=10.3\n\nOnce the MariaDB upgrade is finished, you can then retry to elevate to AlmaLinux 8.\n"
+    qr"You are using MariaDB server 10\.2, this version is not available for AlmaLinux 8\.\nYou first need to update MariaDB server to 10\.\d or later\.\n\nYou can update to version 10\.\d using the following command:\n\n    /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade version=10\.\d\n\nOnce the MariaDB upgrade is finished, you can then retry to elevate to AlmaLinux 8\.\n"
 );
 no_messages_seen();
 


### PR DESCRIPTION
cPanel version 110 will no longer allow upgrading from MariaDB 10.2 to 10.3, regardless of current OS. Thus, in this case, recommend upgrading to 10.5 instead.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

