### PR TITLE
Do not block when detecting kernel update required

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3338,9 +3338,25 @@ sub _system_update_check() {
 
     INFO("Checking if your system is up to date: ");
     ssystem(qw{/usr/bin/yum clean all});
-    if ( ssystem(qw{/usr/bin/yum check-update}) != 0 ) {
+
+    my $out = ssystem_capture_output(qw{/usr/bin/yum check-update -q});
+
+    if ( $out->{status} != 0 ) {
+
+        # not a blocker: only a warning
         WARN("Your system is not up to date please run: /usr/bin/yum update");
-        return;
+
+        my $is_blocker;
+        my $output = $out->{stdout} // [];
+        foreach my $line (@$output) {
+            next if $line =~ qr{^\s+$};
+            next if $line =~ qr{^kernel};    # do not block if we need to update kernel packages
+            $is_blocker = 1;
+            last;
+        }
+
+        # not a blocker when only kernels packages need to be updated
+        return if $is_blocker;
     }
 
     INFO("Checking /scripts/sysup");
@@ -3780,7 +3796,16 @@ sub read_redhat_release() {
     return $first_line;
 }
 
+sub ssystem_capture_output (@args) {
+    return _ssystem( \@args, 1 );
+}
+
 sub ssystem (@args) {
+    return _ssystem( \@args );
+}
+
+sub _ssystem ( $command, $should_capture_output = 0 ) {
+    my @args = @{ $command // [] };
     INFO( "Running: " . join( " ", @args ) );
     INFO();    # Buffer so they can more easily read the output.
 
@@ -3789,10 +3814,20 @@ sub ssystem (@args) {
         unshift @args, qw(/usr/bin/bash -c);
     }
 
-    my $program = shift @args;
+    my $capture_output = { stdout => [], stderr => [] };
+    my $program        = shift @args;
     my ( $callback_out, $callback_err ) = map {
         my $label = $_;
-        Cpanel::IOCallbackWriteLine->new( sub ($line) { chomp $line; INFO($line); } )
+        Cpanel::IOCallbackWriteLine->new(
+            sub ($line) {
+                chomp $line;
+                INFO($line);
+                if ($should_capture_output) {
+                    push $capture_output->{$label}->@*, $line;
+                }
+                return;
+            }
+        )
     } qw(stdout stderr);
     my $sr = Cpanel::SafeRun::Object->new(
         program      => $program,
@@ -3804,7 +3839,14 @@ sub ssystem (@args) {
     );
     INFO();    # Buffer so they can more easily read the output.
 
-    return $? = $sr->CHILD_ERROR;    ## no critic qw(Variables::RequireLocalizedPunctuationVars) -- emulate return behavior of system()
+    $? = $sr->CHILD_ERROR;    ## no critic qw(Variables::RequireLocalizedPunctuationVars) -- emulate return behavior of system()
+
+    if ($should_capture_output) {
+        $capture_output->{status} = $?;
+        return $capture_output;
+    }
+
+    return $?;
 }
 
 sub ssystem_and_die (@args) {

--- a/t/blocker_system_update_check.t
+++ b/t/blocker_system_update_check.t
@@ -1,0 +1,94 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockFile 0.032;
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+require $FindBin::Bin . '/../elevate-cpanel';
+
+my $cpev_mock = Test::MockModule->new('cpev');
+$cpev_mock->redefine( _init_logger => sub { die "should not call init_logger" } );
+
+{
+    note "checking _system_update_check";
+    my $status = 0;
+    my @cmds;
+    my @stdout;
+    $cpev_mock->redefine(
+        ssystem => sub (@args) {
+            push @cmds, [@args];
+            return $status;
+        },
+        ssystem_capture_output => sub (@args) {
+            push @cmds, [@args];
+            return { status => $status, stdout => \@stdout, stderr => [] };
+        },
+    );
+
+    ok cpev::_system_update_check(), '_system_update_check - success';
+    is \@cmds, [
+        [qw{/usr/bin/yum clean all}],
+        [qw{/usr/bin/yum check-update -q}],
+        ['/scripts/sysup']
+      ],
+      "check yum & sysup" or diag explain \@cmds;
+
+    @cmds   = ();
+    $status = 1;
+    @stdout = (
+
+        # no kernel update => blocker
+        'need-to-update-some-packages           1.1-3.el7.cloudlinux      cloudlinux-x86_64-server-update',
+        'accelerate-wp.x86_64                   1.1-3.el7.cloudlinux      cloudlinux-x86_64-server-updates',
+        'alt-libxml2.x86_64                     2.10.2-1.el7              cloudlinux-x86_64-server-updates',
+        'alt-php-config.noarch                  1-48.el7                  cloudlinux-x86_64-server-updates',
+        'alt-php-ssa.x86_64                     0.3-6.el7                 cloudlinux-x86_64-server-updates',
+        'alt-python27-cllib.x86_64              3.2.34-1.el7.cloudlinux   cloudlinux-x86_64-server-updates',
+        'cagefs.x86_64                          7.5.1.1-1.el7.cloudlinux  cloudlinux-x86_64-server-updates',
+        'cagefs-safebin.x86_64                  7.5.1.1-1.el7.cloudlinux  cloudlinux-x86_64-server-updates',
+        'copy-jdk-configs.noarch                3.3-11.el7_9              cloudlinux-x86_64-server-updates',
+        'cpanel-banners-plugin.noarch           1.0.0-8.12.1.cpanel       cpanel-plugins ',
+        'cpanel-monitoring-cpanel-plugin.noarch 1.0.2-29.31.1.cpanel      cpanel-plugins ',
+        'ea-openssl11.x86_64                    1:1.1.1s-1.el7.cloudlinux cl-ea4         ',
+    );
+
+    is cpev::_system_update_check(), undef, '_system_update_check - failure';
+    is \@cmds, [
+        [qw{/usr/bin/yum clean all}],
+        [qw{/usr/bin/yum check-update -q}],
+      ],
+      "check yum & warn; package update required outside of kernel" or diag explain \@cmds;
+
+    @stdout = (
+
+        # kernel update => not a blocker
+        'kernel                                  3.10.0-962.3.2.lve1.5.66.el7 cloudlinux-x86_64-server-updates',
+    );
+
+    @cmds   = ();
+    $status = 1;
+    is cpev::_system_update_check(), undef, '_system_update_check - failure';
+    is \@cmds, [
+        [qw{/usr/bin/yum clean all}],
+        [qw{/usr/bin/yum check-update -q}],
+        ['/scripts/sysup']
+      ],
+      "check yum & warn, only view kernel update needed, then check sysup; " or diag explain \@cmds;
+
+}
+
+done_testing();
+exit;

--- a/t/blockers.t
+++ b/t/blockers.t
@@ -504,37 +504,5 @@ no_messages_seen();
     is cpev::_sshd_setup() => 0, "sshd_config with commented PermitRootLogin=yes";
 }
 
-{
-    note "checking _system_update_check";
-    my $status = 0;
-    my @cmds;
-    $cpev_mock->unmock('_system_update_check');
-    $cpev_mock->redefine(
-        ssystem => sub {
-            push @cmds, [@_];
-            return $status;
-        }
-    );
-
-    ok cpev::_system_update_check(), '_system_update_check - success';
-    is \@cmds, [
-        [qw{/usr/bin/yum clean all}],
-        [qw{/usr/bin/yum check-update}],
-        ['/scripts/sysup']
-      ],
-      "check yum & sysup";
-
-    @cmds   = ();
-    $status = 1;
-
-    is cpev::_system_update_check(), undef, '_system_update_check - failure';
-    is \@cmds, [
-        [qw{/usr/bin/yum clean all}],
-        [qw{/usr/bin/yum check-update}],
-      ],
-      "check yum & abort";
-
-}
-
 done_testing();
 exit;

--- a/t/ssystem.t
+++ b/t/ssystem.t
@@ -1,0 +1,76 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockFile 0.032 qw<nostrict>;
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+require $FindBin::Bin . '/../elevate-cpanel';
+
+#my $cpev_mock = Test::MockModule->new('cpev');
+#$cpev_mock->redefine( _init_logger => sub { die "should not call init_logger" } );
+
+my $mock_log_file = Test::MockFile->file('/var/log/elevate-cpanel.log');
+
+my $cpev = bless {}, 'cpev';
+$cpev->_init_logger;
+
+is cpev::ssystem("/bin/true"),                       0, q[ssystem( "/bin/true" ) == 0];
+isnt my $status_false = cpev::ssystem("/bin/false"), 0, q[ssystem( "/bin/false" ) != 0];
+
+is cpev::ssystem(qw{ /bin/echo 12345}), 0, q[ssystem( "echo 12345" ) == 0];
+
+my $out = cpev::ssystem_capture_output("/bin/true");
+is $out, {
+    status => 0,
+    stdout => [],
+    stderr => [],
+  },
+  q[ssystem_capture_output( "/bin/true" )]
+  or diag explain $out;
+
+$out = cpev::ssystem_capture_output("/bin/false");
+is $out, {
+    status => $status_false,
+    stdout => [],
+    stderr => [],
+  },
+  q[ssystem_capture_output( "/bin/false" )]
+  or diag explain $out;
+
+$out = cpev::ssystem_capture_output(qw{/bin/echo 12345});
+is $out, {
+    'status' => 0,
+    'stderr' => [],
+    'stdout' => ['12345']
+  },
+  q[ssystem_capture_output( "/bin/echo 12345" )]
+  or diag explain $out;
+
+$out = cpev::ssystem_capture_output( qw{ /bin/echo -e }, 'a\nb\nc' );
+is $out, {
+    'status' => 0,
+    'stderr' => [],
+    'stdout' => [
+        'a',
+        'b',
+        'c'
+    ]
+  },
+  q[ssystem_capture_output( echo -e 'a\nb\nc' )]
+  or diag explain $out;
+
+done_testing();
+exit;


### PR DESCRIPTION
Fix #130

Adjust the '_system_update_check' to do not block
when only kernel updates are required from:
	yum check-update

If any other packages than a 'kernel*' is detected then this is still a blocker and we request the use to then run 'yum update' as before.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

