### PR TITLE
Sanity check before/after leapp process

### DIFF
--- a/docs-website-src/config.toml
+++ b/docs-website-src/config.toml
@@ -35,16 +35,21 @@ sectionPagesMenu = "main"
     weight = 2
 
   [[menu.left]]
-    name = "Using the script"
-    url = "/#using-the-script"
+    name = "Risks"
+    url = "/#risks"
     weight = 3
 
   [[menu.left]]
-    name = "Risks"
-    url = "/#risks"
+    name = "Using the script"
+    url = "/#using-the-script"
     weight = 4
+
+  [[menu.left]]
+    name = "SumUp of upgrade process"
+    url = "/#SumUp-of-upgrade-process"
+    weight = 5
 
   [[menu.left]]
     name = "Copyright"
     url = "/#copyright"
-    weight = 5
+    weight = 6

--- a/docs-website-src/content/_index.md
+++ b/docs-website-src/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "cPanel ELevate CentOS 7 to AlmaLinux 8"
-date: 2022-03-15T08:53:47-05:00
+date: 2022-12-07T08:53:47-05:00
 draft: false
 layout: single
 ---
@@ -158,6 +158,84 @@ You can upgrade to **Rocky Linux 8** by running:
 # In case of errors, once fixed you can continue the migration process
 /scripts/elevate-cpanel --continue
 ```
+
+## SumUp of upgrade process
+
+The elevate process is divided in multiple `stages`.
+Each `stage` is repsonsible for one part of the upgrade.
+Between each stage a `reboot` is performed before doing a final reboot at the very end.
+
+### Stage 1
+
+Start the elevation process by installing the `elevate-cpanel` service responsible of the multiple reboots.
+
+### Stage 2
+
+Update the current distro packages.
+Disable cPanel services and setup motd.
+
+### Stage 3
+
+Setup the `elevate-release-latest-el7` repo and install leapp packages.
+Prepare the cPanel packages for the update.
+
+Remove some known conflicting packages and backup some existing configurations. (these packages will be reinstalled druing the next stage).
+
+Provide answers to a few leapp questions.
+
+Attempt to perform the `leapp` upgrade.
+
+In case of failure you probably want to reply to a few extra questions or remove some conflicting packages.
+
+### Stage 4
+
+At this stage we should now run Alamalinux 8 (or RockyLinux 8).
+Update cPanel product for the new distro.
+
+Restore removed packages during the previous stage.
+
+### Stage 5
+
+This is the final stage of the upgrade process.
+Perform some sanity checks and cleanup.
+Remove the `elevate-cpanel` service used during the upgrade process.
+
+A final reboot is performed at the end of this stage.
+
+## FAQ
+
+### How to check the current status?
+
+You can check the current status of the elevation process by running:
+```
+/scripts/elevate-cpanel --status
+```
+
+### How to check elevate log?
+
+The main log from the `/scripts/elevate-cpanel` can be read by running:
+```
+/scripts/elevate-cpanel --log
+```
+
+### Where to find leapp issues?
+
+If you need more details why the leapp process failed you can access logs at:
+```
+        /var/log/leapp/leapp-report.txt
+        /var/log/leapp/leapp-report.json
+```
+
+### How to continue the elevation process?
+
+After addressing the reported issues, you can continue an existing elevation process by running:
+```
+/scripts/elevate-cpanel --continue
+```
+
+### I need more help?
+
+You can report an issue to the [Github Issues page](https://github.com/cpanel/elevate/issues)
 
 ## Copyright
 

--- a/docs-website-src/themes/cptheme/layouts/partials/left_menu.html
+++ b/docs-website-src/themes/cptheme/layouts/partials/left_menu.html
@@ -15,6 +15,9 @@
                     <li>{{ $text }}</li>
                 </a>
                 {{ end }}
+                <li>
+                    <a class="btn btn-primary" role="button" href="{{ .Site.BaseURL }}/#FAQ">FAQ</a>
+                </li>
                 <li><a class="btn btn-primary" role="button" href="{{ .Site.BaseURL }}/blockers">Known Blockers</a></li>
                 <li><a class="btn btn-primary" role="button" href="{{ .Site.BaseURL }}/whitepaper">White Paper</a></li>
             </ul>

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -670,12 +670,19 @@ sub _run_service ($self) {
 
     print_box( "Starting stage $stage of " . VALID_STAGES ) if $stage > 1;
 
-    return
-        $stage == 1 ? $self->run_stage_1()
-      : $stage == 2 ? $self->run_stage_2()
-      : $stage == 3 ? $self->run_stage_3()
-      : $stage == 4 ? $self->run_stage_4()
-      : $stage == 5 ? $self->run_stage_5()
+    # sanity check
+    if ( Cpanel::OS::major() == 8 && 2 <= $stage && $stage <= 3 ) {
+        WARN( "Detected " . Cpanel::OS::pretty_distro() . " while running stage $stage: swtiching to stage 4" );
+        $stage = 4;
+        _update_stage_number($stage);
+    }
+
+    return $stage == 1
+      ? $self->run_stage_1()                                                       # Sanity check & install elevate service
+      : $stage == 2 ? $self->run_stage_2()                                         # Update the current distro packages then reboot
+      : $stage == 3 ? $self->run_stage_3()                                         # Prep leapp & run leapp process
+      : $stage == 4 ? $self->run_stage_4()                                         # reboot on AlmaLinux 8: restore packages
+      : $stage == 5 ? $self->run_stage_5()                                         # Final checks and cleanup
       :               die "Unknown stage '$stage'. I don't know how to proceed";
 
 }
@@ -846,7 +853,7 @@ Remove some known conflicting packages. (Reinstall later).
 Provide answers to a few leapp questions.
 
 Attempt to perform the leapp upgrade itself.
-In case of failure you probably want to reply to a few extra questions or remove some conflictiong packages.
+In case of failure you probably want to reply to a few extra questions or remove some conflicting packages.
 
 =cut
 
@@ -930,8 +937,30 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
-    Cpanel::OS::major() == 8 or die("Upgrade to $pretty_distro_name did not succeed. Please restore from backup.");
+
+    if ( Cpanel::OS::major() != 8 ) {
+        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $current_distro     = Cpanel::OS::pretty_distro();
+
+        if ( Cpanel::OS::major() == 7 ) {
+            WARN("Detected $current_distro from stage 4, reverting back to stage 3.");
+            _update_stage_number(3);
+        }
+
+        die( <<~"END");
+        Server is currently running $current_distro after leapp upgrade.
+        Upgrade to $pretty_distro_name did not succeed.
+
+        Please review your upgrade logs and correct the problem.
+        `leapp` logs are located at:
+            /var/log/leapp/leapp-report.txt
+            /var/log/leapp/leapp-report.json
+
+        Once you believe you have corrected the problem you can continue the upgrade process
+        by running:
+            /scripts/elevate-cpanel --continue
+        END
+    }
 
     my $stash = read_stage_file();
 
@@ -3759,7 +3788,10 @@ sub get_stage {
 
 sub bump_stage ( $by = 1 ) {
 
-    my $stage_id = get_stage() + $by;
+    return _update_stage_number( get_stage() + $by );
+}
+
+sub _update_stage_number ($stage_id) {
 
     update_stage_file( { stage_number => $stage_id } );
 


### PR DESCRIPTION
Add 'FAQ' and 'SumUp' sections to the website.
Enforce sanity check for stage 2,3 and 4.

If the leapp process failed we end up in Stage 4
without being on a AlmaLinux 8 yet... thus reset
the stage to 3 to avoid being locked.

Reversely we cannot run stage 2 or 3 while being
on major version 8.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

