### PR TITLE
Avoid renaming network interfaces

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1686,7 +1686,8 @@ sub _do_leapp_upgrade {
     INFO("Running leapp upgrade");
 
     my $ok = eval {
-        local $ENV{LEAPP_OVL_SIZE} = 3000;
+        local $ENV{LEAPP_OVL_SIZE}            = 3000;
+        local $ENV{LEAPP_NO_NETWORK_RENAMING} = 1;
         ssystem_and_die( { keep_env => 1 }, qw{/usr/bin/leapp upgrade} );
         1;
     };


### PR DESCRIPTION
Refs: #190

Setting that environment variable to 1
while running the leapp upgrade would
avoid renaming interfaces which could lead
to a server being unavaiable.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

