### PR TITLE
Exempt EA4 OpenSSL devel packages from blocker

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3285,7 +3285,8 @@ sub _blocker_ea4_profile ($self) {
     my @incompatible_packages;
     foreach my $pkg ( sort keys $dropped_pkgs->%* ) {
         my $type = $dropped_pkgs->{$pkg} // '';
-        next if $type eq 'exp';    # use of experimental packages is a non blocker
+        next if $type eq 'exp';                          # use of experimental packages is a non blocker
+        next if $pkg =~ m/^ea-openssl(?:11)?-devel$/;    # ignore these packages, as they can be orphans
         push @incompatible_packages, $pkg;
     }
 


### PR DESCRIPTION
The EasyApache packages for the development files belonging to the OpenSSL builds used on CentOS 7 do not depend on the main packages being present. As such, it is possible for the `ea-openssl-devel` package to have become an orphan when `ea-openssl` was replaced with `ea-openssl11`.

Since the absence of these development packages do not cause problems for cPanel itself, allow the script to ignore the removal of these packages, at least for the purpose of the EA4 compatibility blocker.

Fixes #119.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

