### PR TITLE
Also update the kernel command line arguments in the GRUB environment file

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -216,7 +216,7 @@ use constant IGNORE_OUTDATED_SERVICES_FILE => q[/etc/cpanel/local/ignore_outdate
 use constant LEAPP_REPORT_JSON => q[/var/log/leapp/leapp-report.json];
 use constant LEAPP_REPORT_TXT  => q[/var/log/leapp/leapp-report.txt];
 
-use constant OVH_MONITORING_TOUCH_FILE => q[/var/cpanel/acknowledge_ovh_monitoring_for_elevate];
+use constant OVH_MONITORING_TOUCH_FILE      => q[/var/cpanel/acknowledge_ovh_monitoring_for_elevate];
 use constant NOC_RECOMMENDATIONS_TOUCH_FILE => q[/var/cpanel/elevate-noc-recommendations];
 
 use constant IMUNIFY_AGENT          => '/usr/bin/imunify360-agent';
@@ -756,7 +756,7 @@ sub present_noc_recommendations () {
 
     my $can_read_file = open( my $fh, '<', NOC_RECOMMENDATIONS_TOUCH_FILE );
 
-    if ($can_read_file || $! != Errno::ENOENT) {
+    if ( $can_read_file || $! != Errno::ENOENT ) {
         WARN "Provider advisory file potentially present but unable to be opened for reading ($!): using default notice." unless $can_read_file;
 
         my $msg;

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -228,6 +228,8 @@ use constant SBIN_IP => q[/sbin/ip];
 use constant YUM_REPOS_D => q[/etc/yum.repos.d];
 
 use constant DEFAULT_GRUB_FILE => '/etc/default/grub';
+use constant GRUB_EDITENV      => '/usr/bin/grub2-editenv';
+use constant GRUB_ENV_FILE     => '/boot/grub2/grubenv';
 
 use constant DISABLE_MYSQL_YUM_REPOS => qw{
   Mysql57.repo
@@ -1147,6 +1149,26 @@ sub check_and_fix_grub ($self) {
     # add net.ifnames=0 if needed
     return unless $grub_conf =~ s/GRUB_CMDLINE_LINUX="(.+?)"/GRUB_CMDLINE_LINUX="$1 net.ifnames=0"/m;
     File::Slurper::write_binary( DEFAULT_GRUB_FILE, $grub_conf );
+
+    # Also save net.ifnames=0 to the GRUB environment:
+    my $grubenv = Cpanel::SafeRun::Simple::saferunnoerror( GRUB_EDITENV, GRUB_ENV_FILE, 'list' );
+    foreach my $line ( split "\n", $grubenv ) {
+        my ( $name, $value ) = split "=", $line, 2;
+        next unless $name eq "kernelopts";
+
+        if ( $value !~ m/\bnet\.ifnames=/a ) {
+            $line .= ( $line && $line !~ m/ $/ ? " " : "" ) . 'net.ifnames=0';
+            Cpanel::SafeRun::Object->new_or_die(
+                program => GRUB_EDITENV,
+                args    => [
+                    GRUB_ENV_FILE,
+                    "set",
+                    $line,
+                ],
+            );
+            last;
+        }
+    }
 
     return 1;
 }


### PR DESCRIPTION
Kernels installed after ELevate has upgraded the system do not hard-code their command line arguments into the individual bootloader entry but instead refer to a variable in GRUB's persistent environment, stored in `/boot/grub2/grubenv`. Although a full `grub2-mkconfig` does appear to update the `kernelopts` GRUB environment variable from `GRUB_CMDLINE_LINUX` in the contents of `/etc/default/grub`, the only time this is run when a kernel is installed, it specifically excludes environment variable updates. The only other thing that explicitly touches the GRUB environment is to change the `saved_entry` variable to update the default boot option.

Since a full `grub2-mkconfig` is overkill just to update the environment, use the `grub2-editenv` utility to update the appropriate variable.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

