### PR TITLE
Record version in stage file

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1230,10 +1230,11 @@ sub elevation_startup_marker ( $self, $sum = 'unknown' ) {
     update_stage_file(
         {
             '_elevate_process' => {
-                script_md5         => $sum,
-                cpanel_build       => $Cpanel::Version::Tiny::VERSION_BUILD,
-                started_at         => _bq_now(),
-                redhat_release_pre => read_redhat_release(),
+                script_md5            => $sum,
+                cpanel_build          => $Cpanel::Version::Tiny::VERSION_BUILD,
+                started_at            => _bq_now(),
+                redhat_release_pre    => read_redhat_release(),
+                elevate_version_start => VERSION,
             }
         }
     );
@@ -1246,8 +1247,9 @@ sub elevation_success_marker ($self) {
     update_stage_file(
         {
             '_elevate_process' => {
-                finished_at         => _bq_now(),
-                redhat_release_post => read_redhat_release(),
+                finished_at            => _bq_now(),
+                redhat_release_post    => read_redhat_release(),
+                elevate_version_finish => VERSION,
             }
         }
     );

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2758,8 +2758,10 @@ sub restore_perl_xs ($path) {
     if ( $path eq DISTRO_PERL_XS_PATH ) {
         my $rpms = $stash->{'restore'}->{ DISTRO_PERL_XS_PATH() }->{'rpm'};
 
-        my @cmd = ( '/usr/bin/dnf', '-y', '--enablerepo=epel', '--enablerepo=powertools', 'install', sort keys %$rpms );
-        ssystem(@cmd);
+        if ( scalar keys %$rpms ) {    # If there are no XS modules to replace, there is no point to running the dnf install:
+            my @cmd = ( '/usr/bin/dnf', '-y', '--enablerepo=epel', '--enablerepo=powertools', 'install', sort keys %$rpms );
+            ssystem(@cmd);
+        }
     }
 
     my $cpan_modules = $stash->{$path}->{'cpan'} // return;

--- a/t/elevate-marker.t
+++ b/t/elevate-marker.t
@@ -56,12 +56,14 @@ my $data = eval { Cpanel::JSON::LoadFile( $marker_file->path ) } // {};
 
 is $data, {
     '_elevate_process' => {
-        'cpanel_build'        => match qr{^[\d.]+$}a,
-        'finished_at'         => match qr/^\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}$/a,
-        'script_md5'          => 'deadbeef',
-        'started_at'          => match qr/^\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}$/a,
-        'redhat_release_pre'  => 'RHEL Before C7',
-        'redhat_release_post' => 'RHEL After A8',
+        'cpanel_build'           => match qr{^[\d.]+$}a,
+        'finished_at'            => match qr/^\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}$/a,
+        'script_md5'             => 'deadbeef',
+        'started_at'             => match qr/^\d{4}-\d{1,2}-\d{1,2}[ T]\d{1,2}:\d{1,2}:\d{1,2}$/a,
+        'redhat_release_pre'     => 'RHEL Before C7',
+        'redhat_release_post'    => 'RHEL After A8',
+        'elevate_version_start'  => cpev::VERSION,
+        'elevate_version_finish' => cpev::VERSION,
     }
   },
   "stage file was stored to marker location with some data"


### PR DESCRIPTION
Create the `elevate_version_start` and `elevate_version_finish` keys in the stage file, recording the version of elevate-cpanel at the same time as the starting and ending timestamps and OS versions.

Implements #202.

Additionally, fix a minor bug when elevate-cpanel detects no XS-based RPM-sourced Perl modules to reinstall.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

