### PR TITLE
Passing self to restore_perl_xs for use with ssystem call - Fixes #243

### DIFF
--- a/lib/Elevate/Components/PerlXS.pm
+++ b/lib/Elevate/Components/PerlXS.pm
@@ -34,8 +34,8 @@ sub pre_leapp ($self) {
 
 sub post_leapp ($self) {
 
-    restore_perl_xs(DISTRO_PERL_XS_PATH);
-    restore_perl_xs( $Config{'installsitearch'} );
+    $self->restore_perl_xs(DISTRO_PERL_XS_PATH);
+    $self->restore_perl_xs( $Config{'installsitearch'} );
 
     return;
 }
@@ -109,7 +109,7 @@ sub purge_perl_xs ( $self, $path ) {
     return;
 }
 
-sub restore_perl_xs ($path) {
+sub restore_perl_xs ( $self, $path ) {
     my $stash = cpev::read_stage_file();
 
     if ( $path eq DISTRO_PERL_XS_PATH ) {
@@ -117,7 +117,7 @@ sub restore_perl_xs ($path) {
 
         if ( scalar keys %$rpms ) {    # If there are no XS modules to replace, there is no point to running the dnf install:
             my @cmd = ( '/usr/bin/dnf', '-y', '--enablerepo=epel', '--enablerepo=powertools', 'install', sort keys %$rpms );
-            __PACKAGE__->ssystem(@cmd);
+            $self->ssystem(@cmd);
         }
     }
 


### PR DESCRIPTION
By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

Ran into this issue with several servers where `$self->cpev` is undefined in `lib/Elevate/Components/Base.pm`
This causes #243 

To resolve this we can just call `restore_perl_xs` in the same way `purge_perl_xs` is called.
Then `cpev` will be defined on `$self` and prevent the error:

```
Can't call method "can" on an undefined value at /usr/local/cpanel/scripts/elevate-cpanel line 1787.
```

I am not super familiar with perl so please let me know if this is not possible due to some other reason.