### PR TITLE
Block if the running and boot kernels differ

### DIFF
--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -51,6 +51,9 @@ You can discover many of these issues by downloading `elevate-cpanel` and runnin
   * **MariaDB**: If you have already switched to MariaDB, you have no way of reaching MySQL. Be sure you are on 10.3 or better before moving to AlmaLinux 8 / Rocky 8.
 * Some **EA4 packages** are not supported on AlmaLinux 8 / Rocky 8.
   * Example: PHP versions 5.4 through 7.1 are available on CentOS 7 but not AlmaLinux 8 / Rocky 8. You would need to remove these packages before the upgrading to AlmaLinux 8 / Rocky 8. Doing so might impact your system users. Proceed with caution.
+* The system **must** be able to control the boot process by changing the GRUB2 configuration.
+  * The reason for this is that the framework which performs the upgrade of distro-provided software needs to be able to run a custom early boot environment (initrd) in order to safely upgrade the distro.
+  * We check for this by seeing whether the kernel the system is currently running is the same version as that which the system believes is the default boot option.
 
 # Other Known Issues
 

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -14,6 +14,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Constants.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Base.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers.pm'}                 = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/BootKernel.pm'}      = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Databases.pm'}       = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/DiskSpace.pm'}       = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Distros.pm'}         = 'script/elevate-cpanel.PL.static';
@@ -216,6 +217,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       JetBackup
       NICs
       EA4
+      BootKernel
       Grub2
       OVH
     };
@@ -327,6 +329,58 @@ BEGIN {    # Suppress load of all of these at earliest point.
     1;
 
 }    # --- END lib/Elevate/Blockers.pm
+
+{    # --- BEGIN lib/Elevate/Blockers/BootKernel.pm
+
+    package Elevate::Blockers::BootKernel;
+
+    use cPstrict;
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    use Elevate::Constants ();
+
+    use Cpanel::Kernel::Status ();
+
+    # use Cpanel::Exception ();
+
+    use Try::Tiny;
+
+    sub check ($self) {
+        my $ok = 0;
+        try {
+            my ( $running_version, $boot_version ) = Cpanel::Kernel::Status::reboot_status()->@{ 'running_version', 'boot_version' };
+            $ok = $running_version eq $boot_version;
+
+            $self->has_blocker( <<~EOS ) if !$ok;
+        The version of the running kernel ($running_version) does not match that of
+        the default boot entry ($boot_version). This could be due to the kernel
+        being changed by an update, meaning that a reboot should resolve this.
+        However, this also could be an indication that the system does not have
+        control over which kernel and early boot environment (initrd) is used upon
+        reboot, something which is required in order to upgrade the operating
+        system with this script.
+
+        If you have already rebooted your system but are still seeing this message,
+        your server may have been configured to boot into a particular kernel
+        directly, rather than to an instance of the GRUB2 boot loader which can be
+        configured at run time from within your system. This often happens to
+        virtualized servers, but physical servers also can have this problem under
+        certain configurations. Your provider may have a solution available to
+        allow booting into GRUB2; contact them for further information.
+        EOS
+        }
+        catch {
+            my $ex = $_;
+            $self->has_blocker( "Unable to determine running and boot kernels due to the following error:\n" . Cpanel::Exception::get_string($ex) );
+        };
+
+        return $ok ? 1 : 0;
+    }
+
+}    # --- END lib/Elevate/Blockers/BootKernel.pm
 
 {    # --- BEGIN lib/Elevate/Blockers/Databases.pm
 
@@ -4453,6 +4507,7 @@ use Cpanel::Yum::Vars           ();
 # - fatpack blockers
 use Elevate::Blockers::Base          ();
 use Elevate::Blockers                ();
+use Elevate::Blockers::BootKernel    ();
 use Elevate::Blockers::Databases     ();
 use Elevate::Blockers::DiskSpace     ();
 use Elevate::Blockers::Distros       ();

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -60,6 +60,7 @@ our @BLOCKERS = qw{
   JetBackup
   NICs
   EA4
+  BootKernel
   Grub2
   OVH
 };

--- a/lib/Elevate/Blockers/BootKernel.pm
+++ b/lib/Elevate/Blockers/BootKernel.pm
@@ -1,0 +1,57 @@
+package Elevate::Blockers::BootKernel;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::BootKernel
+
+Blocker to determine whether the running kernel is the same one configured for
+boot. This is being used as a proxy for determining whether the system has any
+control over which kernel and initrd is booted via GRUB, which is necessary for
+leapp to function.
+
+=cut
+
+use cPstrict;
+
+use parent qw{Elevate::Blockers::Base};
+
+use Elevate::Constants ();
+
+use Cpanel::Kernel::Status ();
+use Cpanel::Exception ();
+
+use Try::Tiny;
+
+sub check ($self) {
+    my $ok = 0;
+    try {
+        my ($running_version, $boot_version) = Cpanel::Kernel::Status::reboot_status()->@{ 'running_version', 'boot_version' };
+        $ok = $running_version eq $boot_version;
+
+        $self->has_blocker( <<~EOS ) if !$ok;
+        The version of the running kernel ($running_version) does not match that of
+        the default boot entry ($boot_version). This could be due to the kernel
+        being changed by an update, meaning that a reboot should resolve this.
+        However, this also could be an indication that the system does not have
+        control over which kernel and early boot environment (initrd) is used upon
+        reboot, something which is required in order to upgrade the operating
+        system with this script.
+
+        If you have already rebooted your system but are still seeing this message,
+        your server may have been configured to boot into a particular kernel
+        directly, rather than to an instance of the GRUB2 boot loader which can be
+        configured at run time from within your system. This often happens to
+        virtualized servers, but physical servers also can have this problem under
+        certain configurations. Your provider may have a solution available to
+        allow booting into GRUB2; contact them for further information.
+        EOS
+    }
+    catch {
+        my $ex = $_;
+        $self->has_blocker("Unable to determine running and boot kernels due to the following error:\n" . Cpanel::Exception::get_string($ex));
+    };
+
+    return $ok ? 1 : 0;
+}

--- a/lib/Elevate/Blockers/BootKernel.pm
+++ b/lib/Elevate/Blockers/BootKernel.pm
@@ -31,21 +31,20 @@ sub check ($self) {
         $ok = $running_version eq $boot_version;
 
         $self->has_blocker( <<~EOS ) if !$ok;
-        The version of the running kernel ($running_version) does not match that of
+        The running kernel version ($running_version) does not match that of
         the default boot entry ($boot_version). This could be due to the kernel
         being changed by an update, meaning that a reboot should resolve this.
-        However, this also could be an indication that the system does not have
-        control over which kernel and early boot environment (initrd) is used upon
-        reboot, something which is required in order to upgrade the operating
-        system with this script.
+        However, this also could indicate that the system does not have control
+        over which kernel and early boot environment (initrd) is used upon
+        reboot, which is required to upgrade the operating system with this
+        script.
 
-        If you have already rebooted your system but are still seeing this message,
-        your server may have been configured to boot into a particular kernel
-        directly, rather than to an instance of the GRUB2 boot loader which can be
-        configured at run time from within your system. This often happens to
-        virtualized servers, but physical servers also can have this problem under
-        certain configurations. Your provider may have a solution available to
-        allow booting into GRUB2; contact them for further information.
+        If this message remains after a reboot, your server may have been
+        configured to boot into a particular kernel directly rather than to an
+        instance of the GRUB2 boot loader. This often happens to virtualized
+        servers, but physical servers also can have this problem under certain
+        configurations. Your provider may have a solution to allow booting into
+        GRUB2; contact them for further information.
         EOS
     }
     catch {

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -196,6 +196,7 @@ use Cpanel::Yum::Vars           ();
 # - fatpack blockers
 use Elevate::Blockers::Base          ();
 use Elevate::Blockers                ();
+use Elevate::Blockers::BootKernel    ();
 use Elevate::Blockers::Databases     ();
 use Elevate::Blockers::DiskSpace     ();
 use Elevate::Blockers::Distros       ();


### PR DESCRIPTION
The leapp framework requires the ability to instruct the boot loader to load the OS with a custom initrd. If this is not possible, the upgrade will not work. However, since we cannot directly determine whether we can affect the boot loader without rebooting[*], use kernel versions as a proxy.

[*] It is possible to guarantee agency over the boot loader by adding a dummy kernel parameter, which could be detected after reboot with `/proc/cmdline`; however, this method was considered to be overkill.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

