### PR TITLE
Add blocker for python36 and test

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1346,10 +1346,10 @@ EOS
         my $pkg = Cpanel::Pkgr::what_provides('python36');
         return unless $pkg && Cpanel::Pkgr::is_installed($pkg);
         return $self->has_blocker( <<~"END" );
-    python36 packages have been detected as installed.
-    These can interfere with the elevation process.
-    Please remove these packages before elevation:
-    yum remove python36*
+    A package providing python36 has been detected as installed.
+    This can interfere with the elevation process.
+    Please remove it before elevation:
+    yum remove $pkg
     END
     }
 

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -26,6 +26,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Blockers/JetBackup.pm'}       = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/NICs.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/OVH.pm'}             = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/Python.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Repositories.pm'}    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/SSH.pm'}             = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/WHM.pm'}             = 'script/elevate-cpanel.PL.static';
@@ -186,6 +187,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Elevate::Blockers::JetBackup     ();
     use Elevate::Blockers::NICs          ();
     use Elevate::Blockers::OVH           ();
+    use Elevate::Blockers::Python        ();
     use Elevate::Blockers::ElevateScript ();
     use Elevate::Blockers::SSH           ();
     use Elevate::Blockers::WHM           ();
@@ -220,6 +222,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       BootKernel
       Grub2
       OVH
+      Python
     };
 
     use constant ELEVATE_BLOCKER_FILE => '/var/cpanel/elevate-blockers';
@@ -1327,6 +1330,33 @@ EOS
 
 }    # --- END lib/Elevate/Blockers/OVH.pm
 
+{    # --- BEGIN lib/Elevate/Blockers/Python.pm
+
+    package Elevate::Blockers::Python;
+
+    use cPstrict;
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    use Cpanel::Pkgr ();
+
+    sub check ($self) {
+        my $pkg = Cpanel::Pkgr::what_provides('python36');
+        return unless $pkg && Cpanel::Pkgr::is_installed($pkg);
+        return $self->has_blocker( <<~"END" );
+    python36 packages have been detected as installed.
+    These can interfere with the elevation process.
+    Please remove these packages before elevation:
+    yum remove python36*
+    END
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Blockers/Python.pm
+
 {    # --- BEGIN lib/Elevate/Blockers/Repositories.pm
 
     package Elevate::Blockers::Repositories;
@@ -1452,7 +1482,7 @@ EOS
             EOS
             }
 
-            if ( !Elevate::Blockers::Base->is_check_mode() ) {    # autofix when --check is not used
+            if ( !$self->is_check_mode() ) {    # autofix when --check is not used
                 $self->_autofix_yum_repos();
 
                 $status_hr = $self->_check_yum_repos();
@@ -4517,6 +4547,7 @@ use Elevate::Blockers::IsContainer   ();
 use Elevate::Blockers::JetBackup     ();
 use Elevate::Blockers::NICs          ();
 use Elevate::Blockers::OVH           ();    # using a constant
+use Elevate::Blockers::Python        ();
 use Elevate::Blockers::Repositories  ();    # using a constant
 use Elevate::Blockers::SSH           ();
 use Elevate::Blockers::WHM           ();

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -28,6 +28,7 @@ use Elevate::Blockers::IsContainer   ();
 use Elevate::Blockers::JetBackup     ();
 use Elevate::Blockers::NICs          ();
 use Elevate::Blockers::OVH           ();
+use Elevate::Blockers::Python        ();
 use Elevate::Blockers::ElevateScript ();
 use Elevate::Blockers::SSH           ();
 use Elevate::Blockers::WHM           ();
@@ -63,6 +64,7 @@ our @BLOCKERS = qw{
   BootKernel
   Grub2
   OVH
+  Python
 };
 
 use constant ELEVATE_BLOCKER_FILE => '/var/cpanel/elevate-blockers';

--- a/lib/Elevate/Blockers/Python.pm
+++ b/lib/Elevate/Blockers/Python.pm
@@ -20,10 +20,10 @@ sub check ($self) {
     my $pkg = Cpanel::Pkgr::what_provides('python36');
     return unless $pkg && Cpanel::Pkgr::is_installed($pkg);
     return $self->has_blocker( <<~"END" );
-    python36 packages have been detected as installed.
-    These can interfere with the elevation process.
-    Please remove these packages before elevation:
-    yum remove python36*
+    A package providing python36 has been detected as installed.
+    This can interfere with the elevation process.
+    Please remove it before elevation:
+    yum remove $pkg
     END
 }
 

--- a/lib/Elevate/Blockers/Python.pm
+++ b/lib/Elevate/Blockers/Python.pm
@@ -1,0 +1,30 @@
+package Elevate::Blockers::Python;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::Python
+
+Blocker to check if Conflicting python interpreters are installed.
+
+=cut
+
+use cPstrict;
+
+use parent qw{Elevate::Blockers::Base};
+
+use Cpanel::Pkgr  ();
+
+sub check ($self) {
+    my $pkg = Cpanel::Pkgr::what_provides('python36');
+    return unless $pkg && Cpanel::Pkgr::is_installed($pkg);
+    return $self->has_blocker( <<~"END" );
+    python36 packages have been detected as installed.
+    These can interfere with the elevation process.
+    Please remove these packages before elevation:
+    yum remove python36*
+    END
+}
+
+1;

--- a/lib/Elevate/Blockers/Repositories.pm
+++ b/lib/Elevate/Blockers/Repositories.pm
@@ -130,7 +130,7 @@ sub _blocker_invalid_yum_repos ($self) {
             EOS
         }
 
-        if ( !Elevate::Blockers::Base->is_check_mode() ) {    # autofix when --check is not used
+        if ( !$self->is_check_mode() ) {    # autofix when --check is not used
             $self->_autofix_yum_repos();
 
             # perform a second check to make sure we are in good shape

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -208,6 +208,7 @@ use Elevate::Blockers::IsContainer   ();
 use Elevate::Blockers::JetBackup     ();
 use Elevate::Blockers::NICs          ();
 use Elevate::Blockers::OVH           ();    # using a constant
+use Elevate::Blockers::Python        ();
 use Elevate::Blockers::Repositories  ();    # using a constant
 use Elevate::Blockers::SSH           ();
 use Elevate::Blockers::WHM           ();

--- a/t/blocker-Python.t
+++ b/t/blocker-Python.t
@@ -9,7 +9,6 @@ use lib "$FindBin::Bin/../lib";
 use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
 use Test2::Plugin::NoWarnings;
-use Test::Cpanel::Policy;
 use Test::MockModule qw{strict};
 
 use Elevate::Blockers::Python ();

--- a/t/blocker-Python.t
+++ b/t/blocker-Python.t
@@ -36,10 +36,10 @@ $mocks{'Elevate::Blockers::Base'}->redefine(
 my $expected = {
     'id'  => 'Elevate::Blockers::Python::check',
     'msg' => <<~"END",
-    python36 packages have been detected as installed.
-    These can interfere with the elevation process.
-    Please remove these packages before elevation:
-    yum remove python36*
+    A package providing python36 has been detected as installed.
+    This can interfere with the elevation process.
+    Please remove it before elevation:
+    yum remove python3
     END
 };
 is( $obj->check, $expected, "Got expected blocker returned when found" );

--- a/t/blocker-Python.t
+++ b/t/blocker-Python.t
@@ -1,0 +1,48 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+use cPstrict;
+
+use FindBin;
+
+use lib "$FindBin::Bin/../lib";
+
+use Test2::Bundle::Extended;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test::Cpanel::Policy;
+use Test::MockModule qw{strict};
+
+use Elevate::Blockers::Python ();
+
+{
+    package bogus::cpev;
+    sub _abort_on_first_blocker { return 0 }
+}
+
+my %mocks = map { $_ => Test::MockModule->new($_); } qw{
+    Cpanel::Pkgr
+    Elevate::Blockers
+    Elevate::Blockers::Base
+};
+$mocks{'Cpanel::Pkgr'}->redefine( "what_provides" => '', "is_installed" => 1 );
+my $obj = bless {}, 'Elevate::Blockers::Python';
+ok( !$obj->check(), "Returns early on no provider of python36" );
+$mocks{'Cpanel::Pkgr'}->redefine( "what_provides" => 'python3', "is_installed" => 0 );
+ok( !$obj->check(), "Returns early on python36 not installed" );
+$mocks{'Cpanel::Pkgr'}->redefine( "is_installed" => 1 );
+$mocks{'Elevate::Blockers'}->redefine("new" => sub { return bless {}, $_[0] });
+$mocks{'Elevate::Blockers::Base'}->redefine(
+    "cpev" => sub { return bless {}, 'bogus::cpev' },
+);
+my $expected = {
+    'id'  => 'Elevate::Blockers::Python::check',
+    'msg' => <<~"END",
+    python36 packages have been detected as installed.
+    These can interfere with the elevation process.
+    Please remove these packages before elevation:
+    yum remove python36*
+    END
+};
+is( $obj->check, $expected, "Got expected blocker returned when found" );
+
+done_testing();


### PR DESCRIPTION
Also fix explosion due to bad caller of Base in InvalidYumRepo check

A part of me says "a real shame we gotta do this" as it appears? `python3` is installed by default on c7. That said, only place where this could harm things is if for some reason a customer has cpanel-yarn/cpanel-node/etc. packages which are all generally development packages and not something customers would have installed (as they, oddly enough, depend on python3).

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

