### PR TITLE
exit gracefully if the script fails

### DIFF
--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -39,8 +39,12 @@ BEGIN {
         no strict 'refs';
         *$subname = sub ( $self, @args ) {
             my $cpev = $self->cpev;
-            my $sub  = $cpev->can($subname) or die qq[cpev does not support $subname];
-            return $sub->( $cpev, @args );
+            if(defined $cpev) {
+              my $sub  = $cpev->can($subname) or die qq[cpev does not support $subname];
+              return $sub->( $cpev, @args );
+            } else {
+              die "cpev $subname not available";
+            }
         }
     }
 }


### PR DESCRIPTION
exit gracefully if the script fails, otherwise it may fail with:
[FATAL] Can't call method "can" on an undefined value at /usr/local/cpanel/scripts/elevate-cpanel line 1787

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

