### PR TITLE
Improved error message when calling missing functions

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -90,7 +90,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     use cPstrict;
 
-    use Carp;
+    use Carp ();
 
     use Simple::Accessor qw(
       blockers
@@ -126,8 +126,8 @@ BEGIN {    # Suppress load of all of these at earliest point.
         foreach my $subname (@_DELEGATE_TO_CPEV) {
             no strict 'refs';
             *$subname = sub ( $self, @args ) {
-                my $cpev = $self->cpev;
-                my $sub  = $cpev->can($subname) or die qq[cpev does not support $subname];
+                my $cpev = $self->cpev          or Carp::confess(qq[Cannot find cpev object to call function $subname]);
+                my $sub  = $cpev->can($subname) or Carp::confess(qq[cpev does not support $subname]);
                 return $sub->( $cpev, @args );
             }
         }
@@ -1916,6 +1916,7 @@ EOS
 
     use cPstrict;
 
+    use Carp             ();
     use Simple::Accessor qw(
       cpev
     );
@@ -1939,8 +1940,8 @@ EOS
         foreach my $subname (@_DELEGATE_TO_CPEV) {
             no strict 'refs';
             *$subname = sub ( $self, @args ) {
-                my $cpev = $self->cpev;
-                my $sub  = $cpev->can($subname) or die qq[cpev does not support $subname];
+                my $cpev = $self->cpev          or Carp::confess(qq[Cannot find cpev to call $subname]);
+                my $sub  = $cpev->can($subname) or Carp::confess(qq[cpev does not support $subname]);
                 return $sub->( $cpev, @args );
             }
         }
@@ -1949,11 +1950,11 @@ EOS
     sub run_once ( $self, $subname ) {
 
         my $cpev     = $self->cpev;
-        my $run_once = $cpev->can('run_once') or die qq[cpev does not support 'run_once'];
+        my $run_once = $cpev->can('run_once') or Carp::confess(qq[cpev does not support 'run_once']);
 
         my $label = ref($self) . "::$subname";
 
-        my $sub = $self->can($subname) or die qq[$self does not support '$subname'];
+        my $sub = $self->can($subname) or Carp::confess(qq[$self does not support '$subname']);
 
         my $code = sub {
             return $sub->($self);

--- a/lib/Elevate/Blockers/Base.pm
+++ b/lib/Elevate/Blockers/Base.pm
@@ -12,7 +12,7 @@ This is the base package used by all blockers.
 
 use cPstrict;
 
-use Carp;
+use Carp ();
 
 use Simple::Accessor qw(
   blockers
@@ -50,8 +50,8 @@ BEGIN {
     foreach my $subname (@_DELEGATE_TO_CPEV) {
         no strict 'refs';
         *$subname = sub ( $self, @args ) {
-            my $cpev = $self->cpev;
-            my $sub  = $cpev->can($subname) or die qq[cpev does not support $subname];
+            my $cpev = $self->cpev          or Carp::confess(qq[Cannot find cpev object to call function $subname]);
+            my $sub  = $cpev->can($subname) or Carp::confess(qq[cpev does not support $subname]);
             return $sub->( $cpev, @args );
         }
     }

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -15,6 +15,7 @@ before / after the elevation process.
 
 use cPstrict;
 
+use Carp             ();
 use Simple::Accessor qw(
   cpev
 );
@@ -38,8 +39,8 @@ BEGIN {
     foreach my $subname (@_DELEGATE_TO_CPEV) {
         no strict 'refs';
         *$subname = sub ( $self, @args ) {
-            my $cpev = $self->cpev;
-            my $sub  = $cpev->can($subname) or die qq[cpev does not support $subname];
+            my $cpev = $self->cpev          or Carp::confess(qq[Cannot find cpev to call $subname]);
+            my $sub  = $cpev->can($subname) or Carp::confess(qq[cpev does not support $subname]);
             return $sub->( $cpev, @args );
         }
     }
@@ -48,11 +49,11 @@ BEGIN {
 sub run_once ( $self, $subname ) {
 
     my $cpev     = $self->cpev;
-    my $run_once = $cpev->can('run_once') or die qq[cpev does not support 'run_once'];
+    my $run_once = $cpev->can('run_once') or Carp::confess(qq[cpev does not support 'run_once']);
 
     my $label = ref($self) . "::$subname";
 
-    my $sub = $self->can($subname) or die qq[$self does not support '$subname'];
+    my $sub = $self->can($subname) or Carp::confess(qq[$self does not support '$subname']);
 
     my $code = sub {
         return $sub->($self);


### PR DESCRIPTION
Refs: #264

Improve the error message when trying to call a missing function or when cpev object is undefined so we can understand and fix the error.
