### PR TITLE
Impose maximum LTS version, change version recommendation to v110

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -65,6 +65,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     package Elevate::Constants;
 
     use constant MINIMUM_LTS_SUPPORTED => 102;
+    use constant MAXIMUM_LTS_SUPPORTED => 110;
 
     use constant SERVICE_DIR  => '/etc/systemd/system/';
     use constant SERVICE_NAME => 'elevate-cpanel.service';
@@ -1827,9 +1828,17 @@ EOS
     }
 
     sub _blocker_is_newer_than_lts ($self) {
-        if ( $Cpanel::Version::Tiny::major_version <= Elevate::Constants::MINIMUM_LTS_SUPPORTED - 2 ) {
+        my $major = $Cpanel::Version::Tiny::major_version;
+        if ( $major <= Elevate::Constants::MINIMUM_LTS_SUPPORTED - 2 || $major > Elevate::Constants::MAXIMUM_LTS_SUPPORTED ) {
             my $pretty_distro_name = $self->upgrade_to_pretty_name();
-            return $self->has_blocker( sprintf( "This version %s does not support upgrades to %s. Please upgrade to cPanel version %s or better.", $Cpanel::Version::Tiny::VERSION_BUILD, $pretty_distro_name, Elevate::Constants::MINIMUM_LTS_SUPPORTED ) );
+            return $self->has_blocker(
+                sprintf(
+                    "This version %s does not support upgrades to %s. Please ensure the cPanel version is %s.",
+                    $Cpanel::Version::Tiny::VERSION_BUILD,
+                    $pretty_distro_name,
+                    Elevate::Constants::MAXIMUM_LTS_SUPPORTED,
+                )
+            );
         }
 
         return 0;

--- a/lib/Elevate/Blockers/WHM.pm
+++ b/lib/Elevate/Blockers/WHM.pm
@@ -56,9 +56,17 @@ sub _blocker_is_invalid_cpanel_whm ($self) {
 }
 
 sub _blocker_is_newer_than_lts ($self) {
-    if ( $Cpanel::Version::Tiny::major_version <= Elevate::Constants::MINIMUM_LTS_SUPPORTED - 2 ) {
+    my $major = $Cpanel::Version::Tiny::major_version;
+    if ( $major <= Elevate::Constants::MINIMUM_LTS_SUPPORTED - 2 || $major > Elevate::Constants::MAXIMUM_LTS_SUPPORTED ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();
-        return $self->has_blocker( sprintf( "This version %s does not support upgrades to %s. Please upgrade to cPanel version %s or better.", $Cpanel::Version::Tiny::VERSION_BUILD, $pretty_distro_name, Elevate::Constants::MINIMUM_LTS_SUPPORTED ) );
+        return $self->has_blocker(
+            sprintf(
+                "This version %s does not support upgrades to %s. Please ensure the cPanel version is %s.",
+                $Cpanel::Version::Tiny::VERSION_BUILD,
+                $pretty_distro_name,
+                Elevate::Constants::MAXIMUM_LTS_SUPPORTED,
+            )
+        );
     }
 
     return 0;

--- a/lib/Elevate/Constants.pm
+++ b/lib/Elevate/Constants.pm
@@ -15,6 +15,7 @@ if their usage is self contained.
 =cut
 
 use constant MINIMUM_LTS_SUPPORTED => 102;
+use constant MAXIMUM_LTS_SUPPORTED => 110;
 
 use constant SERVICE_DIR  => '/etc/systemd/system/';
 use constant SERVICE_NAME => 'elevate-cpanel.service';

--- a/t/blocker-whm.t
+++ b/t/blocker-whm.t
@@ -91,7 +91,7 @@ my $whm  = $cpev->get_blocker('WHM');
             id  => q[Elevate::Blockers::WHM::_blocker_is_newer_than_lts],
             msg => qr{
                     \QThis version 11.109.0.9999 does not support upgrades to AlmaLinux 8.\E \s+
-                    \QPlease upgrade to cPanel version 102 or better.\E
+                    \QPlease ensure the cPanel version is 110.\E
                 }xms,
         },
         q{cPanel version must be above the known LTS.}


### PR DESCRIPTION
For now I still tolerate the older versions, as there's no reason to break this. Still, if we're telling folks to upgrade, we may as well tell them to go to the last one we're gonna support for c7.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

