### PR TITLE
Clear Cpanel::OS' $instance cache because it's definitely wrong on rocky

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5448,6 +5448,7 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
+    Cpanel::OS::clear_cache_after_cloudlinux_update();    # I didn't pick the "clear cache but don't die" name...
 
     if ( Cpanel::OS::major() != 8 ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -954,6 +954,7 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
+    Cpanel::OS::clear_cache_after_cloudlinux_update(); # I didn't pick the "clear cache but don't die" name...
 
     if ( Cpanel::OS::major() != 8 ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();


### PR DESCRIPTION
By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

Should fix false positive failures we've been seeing, it cleared it up for me