### PR TITLE
Pass through the "check only" mode status properly to fix #274

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -240,7 +240,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     sub _build_blockers { [] }
 
-    sub check ($self) {    # do_check - main  entry point
+    sub check ( $self, %opts ) {    # do_check - main  entry point
 
         if ( $self->cpev->service->is_active ) {
             WARN("An elevation process is already in progress.");
@@ -251,7 +251,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
         my $blocker_file = $self->cpev->getopt('check') || ELEVATE_BLOCKER_FILE;
 
-        my $has_blockers = $self->_has_blockers(1);
+        my $has_blockers = $self->_has_blockers( $opts{'dry_run'} );
 
         $self->save( $blocker_file, { 'blockers' => $self->{'blockers'} } );
 
@@ -4832,8 +4832,8 @@ sub run ( $pkg, @args ) {
         return $self->check_status();
     }
 
-    return $self->do_cleanup()      if $self->getopt('clean');
-    return $self->blockers->check() if defined $self->getopt('check');
+    return $self->do_cleanup()                      if $self->getopt('clean');
+    return $self->blockers->check( 'dry_run' => 1 ) if defined $self->getopt('check');
 
     my $stage = get_stage();
 

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -75,7 +75,7 @@ our $_CHECK_MODE;    # for now global so we can use the helper (move it later to
 
 sub _build_blockers { [] }
 
-sub check ($self) {    # do_check - main  entry point
+sub check ($self, %opts) {    # do_check - main  entry point
 
     if ( $self->cpev->service->is_active ) {
         WARN("An elevation process is already in progress.");
@@ -87,7 +87,7 @@ sub check ($self) {    # do_check - main  entry point
     # If no argument passed to --check, use default path:
     my $blocker_file = $self->cpev->getopt('check') || ELEVATE_BLOCKER_FILE;
 
-    my $has_blockers = $self->_has_blockers(1);
+    my $has_blockers = $self->_has_blockers($opts{'dry_run'});
 
     $self->save( $blocker_file, { 'blockers' => $self->{'blockers'} } );
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -338,7 +338,7 @@ sub run ( $pkg, @args ) {
     }
 
     return $self->do_cleanup()      if $self->getopt('clean');
-    return $self->blockers->check() if defined $self->getopt('check');
+    return $self->blockers->check('dry_run' => 1) if defined $self->getopt('check');
 
     my $stage = get_stage();
 


### PR DESCRIPTION
See notes on internal case for more details. Suffice to say, the logic for doing the symlink just was never being ran due to the argument to _has_blockers previously always being '1' (check only... don't write out things we need to do later to /var/cpanel/elevate).

Should fix issues on Linode, did for me in testing

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

