### PR TITLE
Fix #287

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -445,7 +445,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
         $self->_warning_if_postgresql_installed;
         my $ok = $self->_blocker_old_mysql;
         $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
-
+        $self->_warning_mysql_not_enabled();
         return $ok;
     }
 
@@ -530,6 +530,15 @@ BEGIN {    # Suppress load of all of these at earliest point.
             return $self->has_blocker(q[MySQL upgrade in progress. Please wait for the MySQL upgrade to finish.]);
         }
 
+        return 0;
+    }
+
+    sub _warning_mysql_not_enabled ($self) {
+        require Cpanel::Services::Enabled;
+        my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
+
+        cpev::update_stage_file( { 'mysql-enabled' => $enabled } );
+        WARN( "MySQL is disabled. This must be enabled for MySQL upgrade to succeed.\n" . "We temporarily will enable it when it is needed to be enabled,\n" . "but we reccomend starting the process with MySQL enabled." ) if !$enabled;
         return 0;
     }
 
@@ -3078,6 +3087,7 @@ EOS
     sub _reinstall_mysql_packages {
 
         my $mysql_version = cpev::read_stage_file( 'mysql-version', '' ) or return;
+        my $enabled       = cpev::read_stage_file( 'mysql-enabled', '' ) or return;
 
         INFO("Restoring MySQL $mysql_version");
 
@@ -3086,12 +3096,9 @@ EOS
         INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
         File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file ) or WARN("Couldn't restore $cnf_file.rpmsave: $!");
 
-        require Cpanel::Services::Enabled;
-        my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
         if ( !$enabled ) {
             INFO("MySQL is not enabled. This will cause the MySQL upgrade tool to fail. Temporarily enabling it to ensure the upgrade succeeds.");
             Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=1});
-
         }
 
         my $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade}, "version=$mysql_version" );
@@ -3111,7 +3118,7 @@ EOS
                 $c   = ( $c + 1 ) % 10;
                 $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 background_mysql_upgrade_status }, "upgrade_id=$id" );
                 if ($?) {
-                    Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0}) if !$enabled;
+                    last if !$enabled;
                     die qq[Failed to restore MySQL $mysql_version: cannot check upgrade_id=$id];
                 }
 

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3086,6 +3086,14 @@ EOS
         INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
         File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file ) or WARN("Couldn't restore $cnf_file.rpmsave: $!");
 
+        require Cpanel::Services::Enabled;
+        my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
+        if ( !$enabled ) {
+            INFO("MySQL is not enabled. This will cause the MySQL upgrade tool to fail. Temporarily enabling it to ensure the upgrade succeeds.");
+            Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=1});
+
+        }
+
         my $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade}, "version=$mysql_version" );
         die qq[Failed to restore MySQL $mysql_version] if $?;
 
@@ -3102,7 +3110,10 @@ EOS
             while (1) {
                 $c   = ( $c + 1 ) % 10;
                 $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 background_mysql_upgrade_status }, "upgrade_id=$id" );
-                die qq[Failed to restore MySQL $mysql_version: cannot check upgrade_id=$id] if $?;
+                if ($?) {
+                    Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0}) if !$enabled;
+                    die qq[Failed to restore MySQL $mysql_version: cannot check upgrade_id=$id];
+                }
 
                 if ( $out =~ m{\sstate:\s*inprogress} ) {
                     print ".";
@@ -3117,7 +3128,8 @@ EOS
                 last;
             }
 
-            print "\n" if $c;    # clear the last "." from above
+            print "\n"                                                                                                          if $c;          # clear the last "." from above
+            Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0}) if !$enabled;
 
             if ( $status eq 'success' ) {
                 INFO("MySQL $mysql_version restored");

--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -23,7 +23,7 @@ sub check ($self) {
     $self->_warning_if_postgresql_installed;
     my $ok = $self->_blocker_old_mysql;
     $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
-
+    $self->_warning_mysql_not_enabled();
     return $ok;
 }
 
@@ -113,5 +113,17 @@ sub _blocker_mysql_upgrade_in_progress ($self) {
 
     return 0;
 }
+
+sub _warning_mysql_not_enabled ($self) {
+    require Cpanel::Services::Enabled;
+    my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
+
+    cpev::update_stage_file( { 'mysql-enabled' => $enabled } );
+    WARN("MySQL is disabled. This must be enabled for MySQL upgrade to succeed.\n"
+      . "We temporarily will enable it when it is needed to be enabled,\n"
+      . "but we reccomend starting the process with MySQL enabled."
+    ) if !$enabled;
+    return 0;
+ }
 
 1;

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -72,6 +72,17 @@ sub _reinstall_mysql_packages {
     INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
     File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file ) or WARN("Couldn't restore $cnf_file.rpmsave: $!");
 
+    # Apparently the APITool is in fact unable to figure out that --output=json means I want JSON in this context,
+    # so just load the modules directly and do what the API does to gather the data I want.
+    require Cpanel::Services::Enabled;
+    my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
+    if( !$enabled ) {
+        INFO("MySQL is not enabled. This will cause the MySQL upgrade tool to fail. Temporarily enabling it to ensure the upgrade succeeds.");
+        Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=1} );
+        # Pray it goes ok, as what exactly do you want me to do if this reports failure? May as well just move forward in this case without checking.
+
+    }
+
     my $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade}, "version=$mysql_version" );
     die qq[Failed to restore MySQL $mysql_version] if $?;
 
@@ -88,7 +99,10 @@ sub _reinstall_mysql_packages {
         while (1) {
             $c   = ( $c + 1 ) % 10;
             $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 background_mysql_upgrade_status }, "upgrade_id=$id" );
-            die qq[Failed to restore MySQL $mysql_version: cannot check upgrade_id=$id] if $?;
+            if($?) {
+                Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0} ) if !$enabled;
+                die qq[Failed to restore MySQL $mysql_version: cannot check upgrade_id=$id];
+            }
 
             if ( $out =~ m{\sstate:\s*inprogress} ) {
                 print ".";
@@ -104,6 +118,7 @@ sub _reinstall_mysql_packages {
         }
 
         print "\n" if $c;    # clear the last "." from above
+        Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0} ) if !$enabled;
 
         if ( $status eq 'success' ) {
             INFO("MySQL $mysql_version restored");


### PR DESCRIPTION
Since this is a bug in cPanel v110 or earlier, there's really no reasonable expectation to fix this anywhere but "in the mix" so just enable MySQL before performing the upgrade so that it does not fail. If it was disabled previously, re-disable it upon upgrade completion, however that winds up falling out.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

