### PR TITLE
Vet elasticsearch-7.x repoid

### DIFF
--- a/lib/Elevate/Blockers/Repositories.pm
+++ b/lib/Elevate/Blockers/Repositories.pm
@@ -82,6 +82,7 @@ use constant VETTED_YUM_REPO => qw{
   droplet-agent
   EA4
   elasticsearch
+  elasticsearch-7.x
   elevate
   elevate-source
   epel


### PR DESCRIPTION
The officially recommended repo file for ElasticSearch uses `elasticsearch` as the YUM repo ID; however, a third-party document seems to use `elasticsearch-7.x` for whatever reason. The contents of the file are more or less equivalent.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

