### PR TITLE
Fixup BootKernel error message

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -386,6 +386,8 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Cpanel::Kernel::Status ();
 
     # use Cpanel::Exception      ();
+    use Cpanel::YAML ();
+    use Cpanel::JSON ();
 
     use Try::Tiny;
 
@@ -414,10 +416,31 @@ BEGIN {    # Suppress load of all of these at earliest point.
         }
         catch {
             my $ex = $_;
-            $self->has_blocker( "Unable to determine running and boot kernels due to the following error:\n" . Cpanel::Exception::get_string($ex) );
+            $self->has_blocker(
+                "Unable to determine running and boot kernels due to the following error:\n"    #
+                  . _to_str($ex)
+            );
         };
 
         return $ok ? 1 : 0;
+    }
+
+    sub _to_str ($e) {
+        $e //= '';
+
+        my $str = Cpanel::Exception::get_string($e);
+
+        if ( length $str ) {
+
+            my $hash = eval { Cpanel::YAML::Load($str) }    # parse yaml
+              // eval { Cpanel::JSON::Load($str) }          # or json output... we cannot predict
+              // {};
+            if ( ref $hash eq 'HASH' && $hash->{msg} ) {
+                $str = $hash->{msg};
+            }
+        }
+
+        return $str;
     }
 
     1;


### PR DESCRIPTION
Fix #305

Note, the 'Cpanel::Exception::get_string' can return either a yaml or json formatted string. This is hard to predict depending on the stack/version.

The '_to_str' helper is taking both into account.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

