### PR TITLE
Improve stop and disable function from Systemctl

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4373,12 +4373,16 @@ EOS
 
     sub stop ($self) {
 
+        return unless $self->is_active;
+
         $self->ssystem( '/usr/bin/systemctl', 'stop', $self->name );
 
         return;
     }
 
     sub disable ( $self, %opts ) {
+
+        return unless $self->is_enabled;
 
         my $now = $opts{'now'} // 1;    # by default disable it now...
 

--- a/lib/Elevate/SystemctlService.pm
+++ b/lib/Elevate/SystemctlService.pm
@@ -86,12 +86,16 @@ sub remove ($self) {
 
 sub stop ($self) {
 
+    return unless $self->is_active;
+
     $self->ssystem( '/usr/bin/systemctl', 'stop', $self->name );
 
     return;
 }
 
 sub disable ( $self, %opts ) {
+
+    return unless $self->is_enabled;
 
     my $now = $opts{'now'} // 1;    # by default disable it now...
 


### PR DESCRIPTION
When the service is not installed, we still try to blindly stop and disable the service.

This was raising confusing error messages.
This change is adding a protection to the stop and disable functions to abort earlier when not needed.
