### PR TITLE
Block when cP accts have DBs on distro PgSQL

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -467,8 +467,10 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     use cPstrict;
 
-    use Cpanel::OS            ();
-    use Cpanel::Version::Tiny ();
+    use Cpanel::OS              ();
+    use Cpanel::Version::Tiny   ();
+    use Cpanel::JSON            ();
+    use Cpanel::SafeRun::Simple ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -477,9 +479,13 @@ BEGIN {    # Suppress load of all of these at earliest point.
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
+    use constant POSTGRESQL_ACK_TOUCH_FILE => q[/var/cpanel/acknowledge_postgresql_for_elevate];
+
     sub check ($self) {
+        my $ok = 1;
         $self->_warning_if_postgresql_installed;
-        my $ok = $self->_blocker_old_mysql;
+        $ok = 0 unless $self->_blocker_acknowledge_postgresql_datadir;
+        $ok = 0 unless $self->_blocker_old_mysql;
         $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
         $self->_warning_mysql_not_enabled();
         return $ok;
@@ -496,6 +502,68 @@ BEGIN {    # Suppress load of all of these at earliest point.
         WARN("You have postgresql-server version $old_version installed. This will be upgraded irreversibly to version 10.0 when you switch to $pretty_distro_name");
 
         return 2;
+    }
+
+    sub _blocker_acknowledge_postgresql_datadir ($self) {
+
+        return 0 unless Cpanel::Pkgr::is_installed('postgresql-server');
+
+        my $touch_file = POSTGRESQL_ACK_TOUCH_FILE;
+        return 0 if -e $touch_file;
+
+        my @users_with_dbs = $self->_has_mapped_postgresql_dbs();
+        return 0 unless scalar @users_with_dbs;
+
+        my $message = <<~"EOS";
+    One or more users on your system have associated PostgreSQL databases.
+    ELevate may upgrade the software packages associated with PostgreSQL
+    automatically, but if it does, it will *NOT* automatically update the
+    PostgreSQL data directory to work with the new version. Without an update
+    to the data directory, the upgraded PostgreSQL software will not start, in
+    order to ensure that your data does not become corrupted.
+
+    For more information about PostgreSQL upgrades, please consider the
+    following resources:
+
+    https://cpanel.github.io/elevate/blockers/#postgresql
+    https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/using-databases#migrating-to-a-rhel-8-version-of-postgresql_using-postgresql
+    https://www.postgresql.org/docs/10/pgupgrade.html
+
+    When you are ready to acknowledge that you have prepared to update the
+    PostgreSQL data directory, or that this warning does not apply to you,
+    please touch the following file to continue with the ELevate process:
+
+    > touch $touch_file
+
+    The following user(s) have PostgreSQL databases associated with their cPanel accounts:
+    EOS
+
+        $message .= join "\n", sort(@users_with_dbs);
+
+        return $self->has_blocker($message);
+    }
+
+    sub _has_mapped_postgresql_dbs ($self) {
+
+        local $ENV{HTTP_COOKIE} = 'session_locale=en';
+
+        my $users_json   = Cpanel::SafeRun::Simple::saferunnoerror(qw(/usr/local/cpanel/bin/whmapi1 --output=json list_users));
+        my $users_parsed = Cpanel::JSON::Load($users_json);
+        die "WHM API1 list_users call returned result 0: $users_parsed->{metadata}->{reason}" unless $users_parsed->{metadata}->{result};
+        my @users = grep { $_ ne "root" } $users_parsed->{data}->{users}->@*;
+
+        my @users_with_dbs;
+        foreach my $user (@users) {
+            my $dbs_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Postgresql list_databases) );
+            my $dbs_parsed = Cpanel::JSON::Load($dbs_json);
+            if ( !$dbs_parsed->{result}->{status} ) {
+                return if ( $dbs_parsed->{result}->{errors}->[0] // '' ) eq 'This server does not support this functionality.';    # sanity check
+                die( "UAPI Postgresql::list_databases call returned status 0 for user $user:\n" . join( "\n", $dbs_parsed->{result}->{errors}->@* ) );
+            }
+            push @users_with_dbs, $user if scalar $dbs_parsed->{result}->{data}->@*;
+        }
+
+        return @users_with_dbs;
     }
 
     sub _blocker_old_mysql ( $self, $mysql_version = undef ) {

--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -12,16 +12,22 @@ Blockers for datbase: MySQL, PostgreSQL...
 
 use cPstrict;
 
-use Cpanel::OS            ();
-use Cpanel::Version::Tiny ();
+use Cpanel::OS              ();
+use Cpanel::Version::Tiny   ();
+use Cpanel::JSON            ();
+use Cpanel::SafeRun::Simple ();
 
 use parent qw{Elevate::Blockers::Base};
 
 use Log::Log4perl qw(:easy);
 
+use constant POSTGRESQL_ACK_TOUCH_FILE => q[/var/cpanel/acknowledge_postgresql_for_elevate];
+
 sub check ($self) {
+    my $ok = 1;
     $self->_warning_if_postgresql_installed;
-    my $ok = $self->_blocker_old_mysql;
+    $ok = 0 unless $self->_blocker_acknowledge_postgresql_datadir;
+    $ok = 0 unless $self->_blocker_old_mysql;
     $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
     $self->_warning_mysql_not_enabled();
     return $ok;
@@ -38,6 +44,71 @@ sub _warning_if_postgresql_installed ($self) {
     WARN("You have postgresql-server version $old_version installed. This will be upgraded irreversibly to version 10.0 when you switch to $pretty_distro_name");
 
     return 2;
+}
+
+sub _blocker_acknowledge_postgresql_datadir ($self) {
+
+    return 0 unless Cpanel::Pkgr::is_installed('postgresql-server');
+
+    my $touch_file = POSTGRESQL_ACK_TOUCH_FILE;
+    return 0 if -e $touch_file;
+
+    my @users_with_dbs = $self->_has_mapped_postgresql_dbs();
+    return 0 unless scalar @users_with_dbs;
+
+    my $message = <<~"EOS";
+    One or more users on your system have associated PostgreSQL databases.
+    ELevate may upgrade the software packages associated with PostgreSQL
+    automatically, but if it does, it will *NOT* automatically update the
+    PostgreSQL data directory to work with the new version. Without an update
+    to the data directory, the upgraded PostgreSQL software will not start, in
+    order to ensure that your data does not become corrupted.
+
+    For more information about PostgreSQL upgrades, please consider the
+    following resources:
+
+    https://cpanel.github.io/elevate/blockers/#postgresql
+    https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/using-databases#migrating-to-a-rhel-8-version-of-postgresql_using-postgresql
+    https://www.postgresql.org/docs/10/pgupgrade.html
+
+    When you are ready to acknowledge that you have prepared to update the
+    PostgreSQL data directory, or that this warning does not apply to you,
+    please touch the following file to continue with the ELevate process:
+
+    > touch $touch_file
+
+    The following user(s) have PostgreSQL databases associated with their cPanel accounts:
+    EOS
+
+    $message .= join "\n", sort(@users_with_dbs);
+
+    return $self->has_blocker($message);
+}
+
+sub _has_mapped_postgresql_dbs ($self) {
+
+    # Normalize locale:
+    local $ENV{HTTP_COOKIE} = 'session_locale=en';
+
+    # Get a list of cPanel users:
+    my $users_json   = Cpanel::SafeRun::Simple::saferunnoerror(qw(/usr/local/cpanel/bin/whmapi1 --output=json list_users));
+    my $users_parsed = Cpanel::JSON::Load($users_json);
+    die "WHM API1 list_users call returned result 0: $users_parsed->{metadata}->{reason}" unless $users_parsed->{metadata}->{result};
+    my @users = grep { $_ ne "root" } $users_parsed->{data}->{users}->@*;
+
+    # Compile a list of users with PgSQL DBs:
+    my @users_with_dbs;
+    foreach my $user (@users) {
+        my $dbs_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Postgresql list_databases) );
+        my $dbs_parsed = Cpanel::JSON::Load($dbs_json);
+        if ( !$dbs_parsed->{result}->{status} ) {
+            return if ( $dbs_parsed->{result}->{errors}->[0] // '' ) eq 'This server does not support this functionality.';    # sanity check
+            die( "UAPI Postgresql::list_databases call returned status 0 for user $user:\n" . join( "\n", $dbs_parsed->{result}->{errors}->@* ) );
+        }
+        push @users_with_dbs, $user if scalar $dbs_parsed->{result}->{data}->@*;
+    }
+
+    return @users_with_dbs;
 }
 
 sub _blocker_old_mysql ( $self, $mysql_version = undef ) {


### PR DESCRIPTION
This patch is requested by cPanel Support to try to prevent users of PostgreSQL on cPanel from being surprised that their databases are unavailable once the ELevate process completes; see CPANEL-43203 for previous discussion.

----

Modify the Databases blocker to add a condition which checks for the following three conditions:

1. a `postgresql-server` package is installed;
2. the file `/var/cpanel/acknowledge_postgresql_for_elevate` does not exist;
3. one or more cPanel users have a PostgreSQL database mapped to them.

If all three are true, issue a blocker. In the blocker message, indicate which cPanel accounts have relevant databases, point the admin to resources which explain how to update the PostgreSQL data directory, and instruct the admin on how to acknowledge the blocking warning using the touch file. Additionally, modify the "Blockers" documentation page with the same resources as well as a potential way to use distro-provided tools to perform the update of the data directory and resolve the issue.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

