### PR TITLE
Teach should_run_leapp to check for the CLI option

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6360,7 +6360,9 @@ sub setup_answer_file {
 sub should_run_leapp ($self) {
 
     # we store the no_leapp option, but prefer using a positive check instead
-    my $no_leapp = read_stage_file( 'no_leapp', 0 );
+    # we need to check to see if the no-leapp option is passed via CLI here too in order
+    # to allow users to run this script with the '--check --no-leapp' options
+    my $no_leapp = read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
     return !$no_leapp;
 }
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1696,7 +1696,9 @@ sub setup_answer_file {
 sub should_run_leapp ($self) {
 
     # we store the no_leapp option, but prefer using a positive check instead
-    my $no_leapp = read_stage_file( 'no_leapp', 0 );
+    # we need to check to see if the no-leapp option is passed via CLI here too in order
+    # to allow users to run this script with the '--check --no-leapp' options
+    my $no_leapp = read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
     return !$no_leapp;
 }
 

--- a/t/leapp_upgrade.t
+++ b/t/leapp_upgrade.t
@@ -32,7 +32,8 @@ $mock_elevate->redefine(
     setup_answer_file => sub {    # cannot use Test::MockFile with system touch...
         note "mocked setup_answer_file";
         return;
-    }
+    },
+    getopt => sub { return; },
 );
 
 my $mock_elevate_file = Test::MockFile->file('/var/cpanel/elevate');


### PR DESCRIPTION
Previously, the check used by blockers to determine if the script will run leapp was incompatible with the check option as it only read a file that was written just prior to running stage 1.  This updates the check to see if we should run leapp to also check to see if the --no-leapp option was passed via CLI in order to make the sub compatible with the check option.

Fixes #332

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

