### PR TITLE
Add blocker if cPanel is not running version 110

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       PERL_USE_UNSAFE_INC: 1
       CPANEL_BIN_PATH: /usr/local/cpanel/3rdparty/bin
-      CPANEL_PERL: /usr/local/cpanel/3rdparty/perl/532/bin/perl
+      CPANEL_PERL: /usr/local/cpanel/3rdparty/perl/536/bin/perl
 
     runs-on: ubuntu-latest
 
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
 
     container:
-      image: cpanelos/perl-compiler:perl-v5.32.0
+      image: cpanelos/perl-compiler:perl-v5.36.0
 
     steps:
       - name: Checkout

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+2024-01-10 - version 20
+- #337 - Add blocker if cPanel is not running version 110
+
+2024-01-10 - version 19
+- Use canonical_dump() when building JSON for repo blocker reports
+
 2024-01-09 - version 18
 - #332 - Suppress additional checks when run with --check --no-leapp
 

--- a/changelog
+++ b/changelog
@@ -1,7 +1,5 @@
-2024-01-10 - version 20
+2024-??-?? - version 19
 - #337 - Add blocker if cPanel is not running version 110
-
-2024-01-10 - version 19
 - Use canonical_dump() when building JSON for repo blocker reports
 
 2024-01-09 - version 18

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -65,7 +65,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     package Elevate::Constants;
 
-    use constant MINIMUM_LTS_SUPPORTED => 102;
+    use constant MINIMUM_LTS_SUPPORTED => 110;
     use constant MAXIMUM_LTS_SUPPORTED => 110;
 
     use constant SERVICE_DIR  => '/etc/systemd/system/';
@@ -4856,7 +4856,7 @@ BEGIN {
     $Cpanel::Version::Tiny::major_version >= Elevate::Constants::MINIMUM_LTS_SUPPORTED
       or do {
         warn qq[You need to upgrade your cPanel server to version ] . Elevate::Constants::MINIMUM_LTS_SUPPORTED    #
-          . qq[or later before running this script.\n];
+          . qq[ or later before running this script.\n];
         exit 1;
       };
 }

--- a/lib/Elevate/Constants.pm
+++ b/lib/Elevate/Constants.pm
@@ -14,7 +14,7 @@ if their usage is self contained.
 
 =cut
 
-use constant MINIMUM_LTS_SUPPORTED => 102;
+use constant MINIMUM_LTS_SUPPORTED => 110;
 use constant MAXIMUM_LTS_SUPPORTED => 110;
 
 use constant SERVICE_DIR  => '/etc/systemd/system/';

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -192,7 +192,7 @@ BEGIN {
     $Cpanel::Version::Tiny::major_version >= Elevate::Constants::MINIMUM_LTS_SUPPORTED
       or do {
         warn qq[You need to upgrade your cPanel server to version ] . Elevate::Constants::MINIMUM_LTS_SUPPORTED    #
-          . qq[or later before running this script.\n];
+          . qq[ or later before running this script.\n];
         exit 1;
       };
 }

--- a/t/cpanel-setup
+++ b/t/cpanel-setup
@@ -3,7 +3,7 @@
 set -e
 
 ULC=/usr/local/cpanel
-VERSION=11.102.0.1
+VERSION=11.110.0.17
 REPO=$(pwd)
 
 yum clean all
@@ -31,17 +31,17 @@ echo "# ............. setup symlinks"
 ln -sf usr/local/cpanel/scripts /scripts
 ln -sf /bin/true /usr/local/cpanel/bin/build_locale_databases
 ln -sf /bin/true /usr/local/cpanel/scripts/restartsrv_tailwatchd
-ln -sf /usr/local/cpanel/3rdparty/perl/532/bin/perl /usr/local/cpanel/3rdparty/bin/perl
+ln -sf /usr/local/cpanel/3rdparty/perl/536/bin/perl /usr/local/cpanel/3rdparty/bin/perl
 
 echo "CPANEL=${VERSION}" > /etc/cpupdate.conf
 
 echo "# ............. /scripts/fix-cpanel-perl"
-rm -f /usr/local/cpanel/3rdparty/perl/532/bin/perl
+rm -f /usr/local/cpanel/3rdparty/perl/536/bin/perl
 /scripts/fix-cpanel-perl ||:
 
 echo "# ............. which perl"
 which perl
-ls -l /usr/local/cpanel/3rdparty/perl/532/bin/perl
+ls -l /usr/local/cpanel/3rdparty/perl/536/bin/perl
 
 echo "# ............. cpanm round 2"
 #perl bin/cpanm -n Params::Util


### PR DESCRIPTION
This is the last version to support c7, so we want to fix this script to only run on this version.  This will minimize testing and risk moving forward.

Fixes #337

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

