### PR TITLE
Incorporate running --check into running --start

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 2024-??-?? - version 19
 - #337 - Add blocker if cPanel is not running version 110
 - Use canonical_dump() when building JSON for repo blocker reports
+- #348 - Incorporate running --check into running --start
 
 2024-01-09 - version 18
 - #332 - Suppress additional checks when run with --check --no-leapp

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -250,7 +250,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     sub _build_blockers { [] }
 
-    sub check ( $self, %opts ) {    # do_check - main  entry point
+    sub check ($self) {    # do_check - main  entry point
 
         if ( $self->cpev->service->is_active ) {
             WARN("An elevation process is already in progress.");
@@ -261,7 +261,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
         my $blocker_file = $self->cpev->getopt('check') || ELEVATE_BLOCKER_FILE;
 
-        my $has_blockers = $self->_has_blockers( $opts{'dry_run'} );
+        my $has_blockers = $self->_has_blockers(1);
 
         $self->save( $blocker_file, { 'blockers' => $self->{'blockers'} } );
 
@@ -5044,8 +5044,8 @@ sub run ( $pkg, @args ) {
         return $self->check_status();
     }
 
-    return $self->do_cleanup()                      if $self->getopt('clean');
-    return $self->blockers->check( 'dry_run' => 1 ) if defined $self->getopt('check');
+    return $self->do_cleanup()      if $self->getopt('clean');
+    return $self->blockers->check() if defined $self->getopt('check');
 
     my $stage = get_stage();
 
@@ -5198,6 +5198,9 @@ sub start ($self) {
         EOS
 
     }
+
+    # Check for blockers before starting the migration
+    return 1 if ( $self->blockers->check() );
 
     $self->give_last_chance();
 
@@ -5587,13 +5590,6 @@ sub run_stage_1 ($self) {
     local $SIG{'HUP'} = $abort;
 
     return 1 unless _sanity_check();
-
-    if ( $self->blockers->check() ) {
-
-        # we have not yet install the service yet, clear the stage file
-        $self->service->remove;
-        return 1;
-    }
 
     print_box( "Starting stage 1 of " . VALID_STAGES . ": Installing " . $self->service->name . " service" );
 

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -75,7 +75,7 @@ our $_CHECK_MODE;    # for now global so we can use the helper (move it later to
 
 sub _build_blockers { [] }
 
-sub check ( $self, %opts ) {    # do_check - main  entry point
+sub check ($self) {    # do_check - main  entry point
 
     if ( $self->cpev->service->is_active ) {
         WARN("An elevation process is already in progress.");
@@ -87,7 +87,7 @@ sub check ( $self, %opts ) {    # do_check - main  entry point
     # If no argument passed to --check, use default path:
     my $blocker_file = $self->cpev->getopt('check') || ELEVATE_BLOCKER_FILE;
 
-    my $has_blockers = $self->_has_blockers( $opts{'dry_run'} );
+    my $has_blockers = $self->_has_blockers(1);
 
     $self->save( $blocker_file, { 'blockers' => $self->{'blockers'} } );
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -380,8 +380,8 @@ sub run ( $pkg, @args ) {
         return $self->check_status();
     }
 
-    return $self->do_cleanup()                      if $self->getopt('clean');
-    return $self->blockers->check( 'dry_run' => 1 ) if defined $self->getopt('check');
+    return $self->do_cleanup()      if $self->getopt('clean');
+    return $self->blockers->check() if defined $self->getopt('check');
 
     my $stage = get_stage();
 
@@ -534,6 +534,9 @@ sub start ($self) {
         EOS
 
     }
+
+    # Check for blockers before starting the migration
+    return 1 if ( $self->blockers->check() );
 
     $self->give_last_chance();
 
@@ -923,13 +926,6 @@ sub run_stage_1 ($self) {
     local $SIG{'HUP'} = $abort;
 
     return 1 unless _sanity_check();
-
-    if ( $self->blockers->check() ) {
-
-        # we have not yet install the service yet, clear the stage file
-        $self->service->remove;
-        return 1;
-    }
 
     print_box( "Starting stage 1 of " . VALID_STAGES . ": Installing " . $self->service->name . " service" );
 


### PR DESCRIPTION
Fixes #348. When running start, first perform a full check for blockers, display them all to the user,
and do not start the migration if any are found.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

