### PR TITLE
Do not return from EA4 blocker check prematurely

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+2024-XX-XX - version 20
+- RE-93 - Do not return from EA4 blocker check prematurely
+
 2024-01-16 - version 19
 - #337 - Add blocker if cPanel is not running version 110
 - #341 - Use canonical_dump() when building JSON for repo blocker reports

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -822,7 +822,7 @@ EOS
 
         INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 
-        return unless $self->cpev->component('EA4')->backup;          # _backup_ea4_profile();
+        $self->cpev->component('EA4')->backup;                        # _backup_ea4_profile();
         my $stash        = cpev::read_stage_file();                   # FIXME - move it to a function
         my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
         return unless scalar keys $dropped_pkgs->%*;

--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -38,7 +38,7 @@ sub _blocker_ea4_profile ($self) {
 
     INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 
-    return unless $self->cpev->component('EA4')->backup;          # _backup_ea4_profile();
+    $self->cpev->component('EA4')->backup;                        # _backup_ea4_profile();
     my $stash        = cpev::read_stage_file();                   # FIXME - move it to a function
     my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
     return unless scalar keys $dropped_pkgs->%*;

--- a/t/blocker-ea4.t
+++ b/t/blocker-ea4.t
@@ -31,7 +31,7 @@ my $mock_cpev          = Test::MockModule->new('cpev');
     my $mock_isea4 = Test::MockFile->file( '/etc/cpanel/ea4/is_ea4' => 1 );
     my $type       = '';
 
-    $mock_compoment_ea4->redefine( backup => 1 );
+    $mock_compoment_ea4->redefine( backup => sub { return; } );
     my $mock_cpev = Test::MockModule->new('cpev');
     $mock_cpev->redefine(
         _read_stage_file => sub {
@@ -65,7 +65,7 @@ my $mock_cpev          = Test::MockModule->new('cpev');
 }
 
 {
-    $mock_compoment_ea4->redefine( backup => 1 );
+    $mock_compoment_ea4->redefine( backup => sub { return; } );
 
     my $ea_info_check = sub {
         message_seen( 'INFO' => "Checking EasyApache profile compatibility with AlmaLinux 8." );


### PR DESCRIPTION
Case RE-93:  The EA4 blocker check would return after backing up the EA4 profile.  This early return occurred every time since the logic backing up the EA4 profile returned undef which resulted in a non-functional EA4 blocker check.  This change removes the early return which allows the EA4 blocker check to complete.

Fixes #253

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

