### PR TITLE
Break X::Tiny not perl to force fix-cpanel-perl to run

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5853,7 +5853,8 @@ sub run_stage_4 ($self) {
             $self->ssystem(qw{/usr/bin/dnf config-manager --enable powertools});
             $self->ssystem(qw{/usr/bin/dnf config-manager --enable epel});
 
-            $self->ssystem(qw{/usr/bin/rm -f /usr/local/cpanel/3rdparty/bin/perl});
+            # Break cpanel-perl (NOTE: This only works on perl 5.36)
+            $self->ssystem(qw{/usr/bin/rm -f /usr/local/cpanel/3rdparty/perl/536/cpanel-lib/X/Tiny.pm});
             {
                 local $ENV{'CPANEL_BASE_INSTALL'} = 1;    # Don't fix more than perl itself.
                 $self->ssystem(qw{/usr/local/cpanel/scripts/fix-cpanel-perl});

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -625,13 +625,15 @@ of your server before proceeding.
 EOS
 
     if ( !$self->getopt('non-interactive') ) {
-        if ( !IO::Prompt::prompt(
-            '-one_char',
-            '-yes_no',
-            '-tty',
-            -default => 'n',
-            "Do you wish to proceed with the upgrade process [y/N]: ",
-        ) ) {
+        if (
+            !IO::Prompt::prompt(
+                '-one_char',
+                '-yes_no',
+                '-tty',
+                -default => 'n',
+                "Do you wish to proceed with the upgrade process [y/N]: ",
+            )
+        ) {
             INFO("The update process has been canceled");
             exit 0;
         }
@@ -1118,7 +1120,8 @@ sub run_stage_4 ($self) {
             $self->ssystem(qw{/usr/bin/dnf config-manager --enable powertools});
             $self->ssystem(qw{/usr/bin/dnf config-manager --enable epel});
 
-            $self->ssystem(qw{/usr/bin/rm -f /usr/local/cpanel/3rdparty/bin/perl});
+            # Break cpanel-perl (NOTE: This only works on perl 5.36)
+            $self->ssystem(qw{/usr/bin/rm -f /usr/local/cpanel/3rdparty/perl/536/cpanel-lib/X/Tiny.pm});
             {
                 local $ENV{'CPANEL_BASE_INSTALL'} = 1;    # Don't fix more than perl itself.
                 $self->ssystem(qw{/usr/local/cpanel/scripts/fix-cpanel-perl});


### PR DESCRIPTION
Case RE-94

Changelog: Get fix-cpanel-perl to run after distro change without breaking perl.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

