### PR TITLE
Update elevate for jetbackup to be aware of JetBackup 5.3

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2949,7 +2949,7 @@ EOS
 
         my $tier     = $data->{tier};
         my @packages = $data->{packages}->@*;
-        $self->ssystem( qw{/usr/bin/yum -y reinstall  --disablerepo=* --enablerepo=jetapps}, "--enablerepo=$tier", @packages );
+        $self->ssystem( qw{/usr/bin/yum -y update --enablerepo=jetapps}, "--enablerepo=$tier", @packages );
 
         return;
     }

--- a/lib/Elevate/Components/JetBackup.pm
+++ b/lib/Elevate/Components/JetBackup.pm
@@ -55,7 +55,7 @@ sub post_leapp ($self) {
 
     my $tier     = $data->{tier};
     my @packages = $data->{packages}->@*;
-    $self->ssystem( qw{/usr/bin/yum -y reinstall  --disablerepo=* --enablerepo=jetapps}, "--enablerepo=$tier", @packages );
+    $self->ssystem( qw{/usr/bin/yum -y update --enablerepo=jetapps}, "--enablerepo=$tier", @packages );
 
     return;
 }


### PR DESCRIPTION
Case RE-103: Their versioning scheme changed so reinstall would do the
incorrect thing. We now need to do yum update jetbackup not reinstall.
    
Changelog: Update elevate for jetbackup to be aware of JetBackup 5.3