### PR TITLE
Remove cPanel version check in the BEGIN block

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4936,13 +4936,6 @@ BEGIN {
         warn(qq[This script is designed to only run on cPanel servers.\n]);
         exit 1;
     };
-
-    $Cpanel::Version::Tiny::major_version >= Elevate::Constants::MINIMUM_LTS_SUPPORTED
-      or do {
-        warn qq[You need to upgrade your cPanel server to version ] . Elevate::Constants::MINIMUM_LTS_SUPPORTED    #
-          . qq[ or later before running this script.\n];
-        exit 1;
-      };
 }
 
 use Log::Log4perl qw(:easy);

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -200,13 +200,6 @@ BEGIN {
         warn(qq[This script is designed to only run on cPanel servers.\n]);
         exit 1;
     };
-
-    $Cpanel::Version::Tiny::major_version >= Elevate::Constants::MINIMUM_LTS_SUPPORTED
-      or do {
-        warn qq[You need to upgrade your cPanel server to version ] . Elevate::Constants::MINIMUM_LTS_SUPPORTED    #
-          . qq[ or later before running this script.\n];
-        exit 1;
-      };
 }
 
 use Log::Log4perl qw(:easy);


### PR DESCRIPTION
Case RE-56:

Fixes #347. Invoking the script with --check (or --start) will run a more thorough and informative version check as well as checking for any other issues of concern.

Changelog: Removed the simple version check from the BEGIN
  block of the script since this happens during the check
  operation.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

