### PR TITLE
Restore config files for packages provided by the EA4 repo

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -55,6 +55,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Motd.pm'}                        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Notify.pm'}                      = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Roles/Run.pm'}                   = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/RPM.pm'}                         = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Script.pm'}                      = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Service.pm'}                     = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/SystemctlService.pm'}            = 'script/elevate-cpanel.PL.static';
@@ -2118,6 +2119,7 @@ EOS
     use Carp             ();
     use Simple::Accessor qw(
       cpev
+      rpm
     );
 
     # use Log::Log4perl qw(:easy);
@@ -2145,6 +2147,10 @@ EOS
                 return $sub->( $cpev, @args );
             }
         }
+    }
+
+    sub _build_rpm ($self) {
+        return Elevate::RPM->new( cpev => $self );
     }
 
     sub run_once ( $self, $subname ) {
@@ -2284,6 +2290,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::RPM       ();
 
     use Cwd ();
 
@@ -2312,6 +2319,7 @@ EOS
 
         $self->run_once('_backup_ea4_profile');
         $self->run_once('_backup_ea_addons');
+        $self->run_once('_backup_config_files');
         $self->run_once('_cleanup_rpm_db');
 
         return;
@@ -2321,6 +2329,8 @@ EOS
 
         $self->run_once('_restore_ea4_profile');
         $self->run_once('_restore_ea_addons');
+
+        $self->run_once('_restore_config_files');
 
         return;
     }
@@ -2460,6 +2470,46 @@ EOS
         }
 
         return 1;
+    }
+
+    sub _backup_config_files ($self) {
+
+        cpev::remove_from_stage_file('ea4_config_files');
+
+        my $ea4_regex        = qr/^EA4(:?-c7)?/a;
+        my $ea4_config_files = $self->rpm->get_config_files_for_repo($ea4_regex);
+
+        cpev::update_stage_file( { ea4_config_files => $ea4_config_files } );
+
+        return;
+    }
+
+    our %config_files_to_ignore = (
+        'ea-nginx' => {
+            '/etc/nginx/conf.d/ea-nginx.conf'   => 1,
+            '/etc/nginx/ea-nginx/settings.json' => 1,
+        },
+        'ea-apache24' => {
+            '/etc/apache2/conf/httpd.conf' => 1,
+        },
+    );
+
+    sub _restore_config_files ($self) {
+
+        my $config_files = cpev::read_stage_file('ea4_config_files');
+
+        foreach my $key ( sort keys %$config_files ) {
+            INFO("Restoring config files for package: '$key'");
+
+            my @config_files_to_restore = @{ $config_files->{$key} };
+            if ( exists $config_files_to_ignore{$key} ) {
+                @config_files_to_restore = grep { !$config_files_to_ignore{$key}{$_} } @config_files_to_restore;
+            }
+
+            $self->rpm->restore_config_files(@config_files_to_restore);
+        }
+
+        return;
     }
 
     1;
@@ -4409,6 +4459,79 @@ EOS
 
 }    # --- END lib/Elevate/Roles/Run.pm
 
+{    # --- BEGIN lib/Elevate/RPM.pm
+
+    package Elevate::RPM;
+
+    use cPstrict;
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    use Simple::Accessor qw{
+      cpev
+    };
+
+    sub _build_cpev {
+        die q[Missing cpev];
+    }
+
+    sub get_config_files_for_repo ( $self, $repo ) {
+
+        my @installed    = cpev::get_installed_rpms_in_repo($repo);
+        my $config_files = $self->_get_config_files( \@installed );
+
+        return $config_files;
+    }
+
+    sub _get_config_files ( $self, $pkgs ) {
+
+        my %config_files;
+        foreach my $pkg (@$pkgs) {
+
+            my $out = $self->cpev->ssystem_capture_output( '/usr/bin/rpm', '-qc', $pkg ) || {};
+
+            if ( $out->{status} != 0 ) {
+
+                WARN( <<~"EOS");
+            Failed to retrieve config files for $pkg.  If you have custom config files for this pkg,
+            then you will need to manually evaluate the configs and potentially move the rpmsave file back
+            into place.
+            EOS
+
+            }
+            else {
+
+                my @pkg_config_files = grep { $_ =~ m{^/} } @{ $out->{stdout} };
+
+                $config_files{$pkg} = \@pkg_config_files;
+            }
+        }
+
+        return \%config_files;
+    }
+
+    sub restore_config_files ( $self, @files ) {
+
+        my $suffix = '.rpmsave';
+
+        foreach my $file (@files) {
+            next unless length $file;
+
+            my $backup_file = $file . $suffix;
+
+            next unless -e $backup_file;
+
+            File::Copy::move( $backup_file, $file ) or WARN("Unable to restore config file $backup_file: $!");
+        }
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/RPM.pm
+
 {    # --- BEGIN lib/Elevate/Script.pm
 
     package Elevate::Script;
@@ -4491,13 +4614,12 @@ EOS
 
     use Elevate::Roles::Run ();    # for fatpck
 
-    use                            # hide
-      Simple::Accessor qw{
+    use Simple::Accessor qw{
       name
       file
       short_name
       cpev
-      };
+    };
 
     # use Elevate::Roles::Run();
     our @ISA;
@@ -4601,10 +4723,9 @@ EOS
 
     use Elevate::Roles::Run ();    # for fatpck
 
-    use                            # hide
-      Simple::Accessor qw{
+    use Simple::Accessor qw{
       name
-      };
+    };
 
     # use Elevate::Roles::Run();
     our @ISA;
@@ -5108,6 +5229,7 @@ use Elevate::Logger           ();
 use Elevate::Motd             ();
 use Elevate::Notify           ();
 use Elevate::Roles::Run       ();    # used as parent, but ensure fatpack
+use Elevate::RPM              ();
 use Elevate::Script           ();
 use Elevate::Service          ();
 use Elevate::SystemctlService ();

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -18,6 +18,7 @@ use cPstrict;
 use Carp             ();
 use Simple::Accessor qw(
   cpev
+  rpm
 );
 
 use Log::Log4perl qw(:easy);
@@ -45,6 +46,10 @@ BEGIN {
             return $sub->( $cpev, @args );
         }
     }
+}
+
+sub _build_rpm ($self) {
+    return Elevate::RPM->new( cpev => $self );
 }
 
 sub run_once ( $self, $subname ) {

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -13,6 +13,7 @@ Perform am EA4 backup pre-elevate then restore it after the elevation process.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::RPM       ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -42,6 +43,7 @@ sub pre_leapp ($self) {    # run to perform the backup
 
     $self->run_once('_backup_ea4_profile');
     $self->run_once('_backup_ea_addons');
+    $self->run_once('_backup_config_files');
     $self->run_once('_cleanup_rpm_db');
 
     return;
@@ -51,6 +53,19 @@ sub post_leapp ($self) {
 
     $self->run_once('_restore_ea4_profile');
     $self->run_once('_restore_ea_addons');
+
+    # This needs to happen last (after EA4 has been reinstalled)
+    #
+    # On a new install, the RPM behavior for %config is to move the preexisting config file
+    # to '.rpmorig' and replace the config file with config file provided by the RPM
+    #
+    # On a new install, the RPM behavior for %config(noreplace) is to remove the preexisting
+    # config file and place the config file provided by the RPM at '.rpmnew'
+    #
+    # There should not be any need to restart services to pick up the new config files since the last
+    # step of stage 5 is to reboot the server so the services will be restarted and pick up the configs
+    # after this anyway
+    $self->run_once('_restore_config_files');
 
     return;
 }
@@ -197,6 +212,46 @@ sub _restore_ea4_profile ($self) {
     }
 
     return 1;
+}
+
+sub _backup_config_files ($self) {
+
+    cpev::remove_from_stage_file('ea4_config_files');
+
+    my $ea4_regex        = qr/^EA4(:?-c7)?/a;
+    my $ea4_config_files = $self->rpm->get_config_files_for_repo($ea4_regex);
+
+    cpev::update_stage_file( { ea4_config_files => $ea4_config_files } );
+
+    return;
+}
+
+our %config_files_to_ignore = (
+    'ea-nginx' => {
+        '/etc/nginx/conf.d/ea-nginx.conf'   => 1,
+        '/etc/nginx/ea-nginx/settings.json' => 1,
+    },
+    'ea-apache24' => {
+        '/etc/apache2/conf/httpd.conf' => 1,
+    },
+);
+
+sub _restore_config_files ($self) {
+
+    my $config_files = cpev::read_stage_file('ea4_config_files');
+
+    foreach my $key ( sort keys %$config_files ) {
+        INFO("Restoring config files for package: '$key'");
+
+        my @config_files_to_restore = @{ $config_files->{$key} };
+        if ( exists $config_files_to_ignore{$key} ) {
+            @config_files_to_restore = grep { !$config_files_to_ignore{$key}{$_} } @config_files_to_restore;
+        }
+
+        $self->rpm->restore_config_files(@config_files_to_restore);
+    }
+
+    return;
 }
 
 1;

--- a/lib/Elevate/RPM.pm
+++ b/lib/Elevate/RPM.pm
@@ -1,0 +1,83 @@
+package Elevate::RPM;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::RPM
+
+Logic wrapping the 'rpm' system binary
+
+=cut
+
+use cPstrict;
+
+use Log::Log4perl qw(:easy);
+
+use Simple::Accessor qw{
+  cpev
+};
+
+sub _build_cpev {
+    die q[Missing cpev];
+}
+
+sub get_config_files_for_repo ( $self, $repo ) {
+
+    my @installed    = cpev::get_installed_rpms_in_repo($repo);
+    my $config_files = $self->_get_config_files( \@installed );
+
+    return $config_files;
+}
+
+sub _get_config_files ( $self, $pkgs ) {
+
+    my %config_files;
+    foreach my $pkg (@$pkgs) {
+
+        my $out = $self->cpev->ssystem_capture_output( '/usr/bin/rpm', '-qc', $pkg ) || {};
+
+        if ( $out->{status} != 0 ) {
+
+            # warn and move on if rpm -qc fails
+            WARN( <<~"EOS");
+            Failed to retrieve config files for $pkg.  If you have custom config files for this pkg,
+            then you will need to manually evaluate the configs and potentially move the rpmsave file back
+            into place.
+            EOS
+
+        }
+        else {
+
+            # rpm -qc will return absolute paths if the package has config files
+            # In the event that package does not contain any files, it will return
+            # "(contains no files)"
+            # We need to filter anything that is not an absolute path out
+            my @pkg_config_files = grep { $_ =~ m{^/} } @{ $out->{stdout} };
+
+            $config_files{$pkg} = \@pkg_config_files;
+        }
+    }
+
+    return \%config_files;
+}
+
+sub restore_config_files ( $self, @files ) {
+
+    # %config and %config(noreplace) both get moved to '.rpmsave' when removing an RPM
+    my $suffix = '.rpmsave';
+
+    foreach my $file (@files) {
+        next unless length $file;
+
+        my $backup_file = $file . $suffix;
+
+        next unless -e $backup_file;
+
+        File::Copy::move( $backup_file, $file ) or WARN("Unable to restore config file $backup_file: $!");
+    }
+
+    return;
+}
+
+1;

--- a/lib/Elevate/Service.pm
+++ b/lib/Elevate/Service.pm
@@ -21,13 +21,12 @@ use Log::Log4perl qw(:easy);
 
 use Elevate::Roles::Run ();    # for fatpck
 
-use                            # hide
-  Simple::Accessor qw{
+use Simple::Accessor qw{
   name
   file
   short_name
   cpev
-  };
+};
 
 use parent qw{
   Elevate::Roles::Run

--- a/lib/Elevate/SystemctlService.pm
+++ b/lib/Elevate/SystemctlService.pm
@@ -19,10 +19,9 @@ use Log::Log4perl qw(:easy);
 
 use Elevate::Roles::Run ();    # for fatpck
 
-use                            # hide
-  Simple::Accessor qw{
+use Simple::Accessor qw{
   name
-  };
+};
 
 use parent qw{
   Elevate::Roles::Run

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -285,6 +285,7 @@ use Elevate::Logger           ();
 use Elevate::Motd             ();
 use Elevate::Notify           ();
 use Elevate::Roles::Run       ();    # used as parent, but ensure fatpack
+use Elevate::RPM              ();
 use Elevate::Script           ();
 use Elevate::Service          ();
 use Elevate::SystemctlService ();


### PR DESCRIPTION
Case RE-38: Previously, we did restore any custom configuration files for packages provided by EA4.  This could lead to things like the PHP memory_limit being reset to default and custom modsec rules no longer being applied after the server was elevated.  This change restores custom configuration files for packages provided by the EA4 repo so that customizations will stick after the server has been elevated.

Changelog: Restore config files for packages provided by the EA4 repo

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

