### PR TITLE
Always show ELevate is in progress when it is.

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6134,7 +6134,6 @@ sub run_stage_5 ($self) {
     unlink CHKSRVD_SUSPEND_FILE;
     my $el_backup_dir = Elevate::Constants::ELEVATE_BACKUP_DIR;
     File::Path::remove_tree($el_backup_dir) if -d $el_backup_dir;
-    Elevate::Motd->cleanup();
 
     $self->run_component_once( 'Grub2' => 'post_leapp' );
 
@@ -6144,6 +6143,7 @@ sub run_stage_5 ($self) {
     INFO("Updating all packages before final reboot");
     $self->ssystem(qw{/usr/bin/dnf -y --allowerasing update});
 
+    Elevate::Motd->cleanup();
     my $pretty_distro_name = $self->upgrade_to_pretty_name();
     print_box("Great SUCCESS! Your upgrade to $pretty_distro_name is complete.");
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1190,7 +1190,6 @@ sub run_stage_5 ($self) {
     unlink CHKSRVD_SUSPEND_FILE;
     my $el_backup_dir = Elevate::Constants::ELEVATE_BACKUP_DIR;
     File::Path::remove_tree($el_backup_dir) if -d $el_backup_dir;
-    Elevate::Motd->cleanup();
 
     $self->run_component_once( 'Grub2' => 'post_leapp' );
 
@@ -1200,6 +1199,7 @@ sub run_stage_5 ($self) {
     INFO("Updating all packages before final reboot");
     $self->ssystem(qw{/usr/bin/dnf -y --allowerasing update});
 
+    Elevate::Motd->cleanup();
     my $pretty_distro_name = $self->upgrade_to_pretty_name();
     print_box("Great SUCCESS! Your upgrade to $pretty_distro_name is complete.");
 


### PR DESCRIPTION
Case RE-2: Previously, if you ran the ELevate script, got to step 5, and went to your server after the reboot, you could potentially not be informed that ELevate was still running. This commit fixes it so the MOTD will not be updated until the script is complete.

Changelog: Always show ELevate MOTD when ELevate is running.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

