### PR TITLE
Document manual-reboots flag in help text

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5054,6 +5054,9 @@ Helps to upgrade CentOS 7 cPanel servers to AlmaLinux 8 or Rocky Linux 8.
                                       Once leapp has been run you should remove the file
                                       /waiting_for_distro_upgrade
 
+       --manual-reboots               The script will stop and require the user to reboot manually rather than
+                                      automatically rebooting when reboots are needed
+
        --help                         Display this documentation.
 
 =head1 COMMON USAGE

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -63,6 +63,9 @@ Helps to upgrade CentOS 7 cPanel servers to AlmaLinux 8 or Rocky Linux 8.
                                       Once leapp has been run you should remove the file
                                       /waiting_for_distro_upgrade
 
+       --manual-reboots               The script will stop and require the user to reboot manually rather than
+                                      automatically rebooting when reboots are needed
+
        --help                         Display this documentation.
 
 =head1 COMMON USAGE


### PR DESCRIPTION
Case RE-186: This flag is mentioned in the help text for the script and there are examples using it, but the flag is not explicitely documented. This change documents the flag.

Changelog: Document manual-reboots flag in help text

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

