### PR TITLE
Fix PostgreSQL user database check when feature disabled

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -557,6 +557,9 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
         my @users_with_dbs;
         foreach my $user (@users) {
+            my $feature_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Features has_feature name=postgres) );
+            my $feature_parsed = Cpanel::JSON::Load($feature_json);
+            next unless $feature_parsed->{result}{data};
             my $dbs_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Postgresql list_databases) );
             my $dbs_parsed = Cpanel::JSON::Load($dbs_json);
             if ( !$dbs_parsed->{result}->{status} ) {

--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -99,6 +99,9 @@ sub _has_mapped_postgresql_dbs ($self) {
     # Compile a list of users with PgSQL DBs:
     my @users_with_dbs;
     foreach my $user (@users) {
+        my $feature_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Features has_feature name=postgres) );
+        my $feature_parsed = Cpanel::JSON::Load($feature_json);
+        next unless $feature_parsed->{result}{data};
         my $dbs_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Postgresql list_databases) );
         my $dbs_parsed = Cpanel::JSON::Load($dbs_json);
         if ( !$dbs_parsed->{result}->{status} ) {


### PR DESCRIPTION
Case RE-188:

For each user, check if it has the feature enabled before listing the databases for that user.

Changelog: Fixed PostgreSQL user database check for users
  that have the feature disabled.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

