### PR TITLE
Do not remove alt-pcre802 post elevate

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6763,7 +6763,7 @@ sub run_stage_4 ($self) {
 
     my @known_modules_that_dont_convert = qw{libtermkey msgpack btrfs-progs elevate-release
       leapp leapp-data-almalinux leapp-data-rocky leapp-data-cloudlinux leapp-upgrade-el7toel8
-      python2-leapp alt-pcre802 alt-pcre802-devel};
+      python2-leapp};
     my @to_remove = grep { Cpanel::Pkgr::is_installed($_) } @known_modules_that_dont_convert;
 
     INFO("Removing known cruft that various 3rdparties leave behind. Also removing leapp.");

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1190,7 +1190,7 @@ sub run_stage_4 ($self) {
 
     my @known_modules_that_dont_convert = qw{libtermkey msgpack btrfs-progs elevate-release
       leapp leapp-data-almalinux leapp-data-rocky leapp-data-cloudlinux leapp-upgrade-el7toel8
-      python2-leapp alt-pcre802 alt-pcre802-devel};
+      python2-leapp};
     my @to_remove = grep { Cpanel::Pkgr::is_installed($_) } @known_modules_that_dont_convert;
 
     INFO("Removing known cruft that various 3rdparties leave behind. Also removing leapp.");


### PR DESCRIPTION
Case RE-206:  It was found that there are ea-php51 and ea-php52 packages including ea-php51 and ea-php52 that are dependent on alt-pcre802 and alt-pcre802-devel.  As such, we are going to refrain from removing this two packages after elevate for now.  RE-213 was created to follow up with a more thorough fix for this issue as we should refactor this logic so that the leapp packages are separated from the rest of the el7 packages that we should be able to safely remove.

Changelog:  Do not remove 'alt-pcre802' post elevate

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

