### PR TITLE
Fix PostgreSQL user database check when feature disabled

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -476,11 +476,13 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     use cPstrict;
 
-    use Cpanel::OS              ();
-    use Cpanel::Pkgr            ();
-    use Cpanel::Version::Tiny   ();
-    use Cpanel::JSON            ();
-    use Cpanel::SafeRun::Simple ();
+    use Cpanel::OS                         ();
+    use Cpanel::Pkgr                       ();
+    use Cpanel::Version::Tiny              ();
+    use Cpanel::JSON                       ();
+    use Cpanel::SafeRun::Simple            ();
+    use Cpanel::DB::Map::Collection::Index ();
+    use Cpanel::Exception                  ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -556,25 +558,16 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     sub _has_mapped_postgresql_dbs ($self) {
 
-        local $ENV{HTTP_COOKIE} = 'session_locale=en';
-
-        my $users_json   = Cpanel::SafeRun::Simple::saferunnoerror(qw(/usr/local/cpanel/bin/whmapi1 --output=json list_users));
-        my $users_parsed = Cpanel::JSON::Load($users_json);
-        die "WHM API1 list_users call returned result 0: $users_parsed->{metadata}->{reason}" unless $users_parsed->{metadata}->{result};
-        my @users = grep { $_ ne "root" } $users_parsed->{data}->{users}->@*;
-
-        my @users_with_dbs;
-        foreach my $user (@users) {
-            my $dbs_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Postgresql list_databases) );
-            my $dbs_parsed = Cpanel::JSON::Load($dbs_json);
-            if ( !$dbs_parsed->{result}->{status} ) {
-                return if ( $dbs_parsed->{result}->{errors}->[0] // '' ) eq 'This server does not support this functionality.';    # sanity check
-                die( "UAPI Postgresql::list_databases call returned status 0 for user $user:\n" . join( "\n", $dbs_parsed->{result}->{errors}->@* ) );
-            }
-            push @users_with_dbs, $user if scalar $dbs_parsed->{result}->{data}->@*;
+        my $dbindex = eval { Cpanel::DB::Map::Collection::Index->new( { db => 'PGSQL' } ); };
+        if ( my $exception = $@ ) {
+            ERROR( 'Unable to read the database index file:  ' . Cpanel::Exception::get_string($exception) );
+            $self->has_blocker("Unable to read the database index file; you may need to rebuild it by running: /usr/local/cpanel/bin/dbindex");
+            return ();
         }
 
-        return @users_with_dbs;
+        my %user_hash = map { $dbindex->{dbindex}{$_} => 1 } keys %{ $dbindex->{dbindex} };
+
+        return ( keys %user_hash );
     }
 
     sub _blocker_old_mysql ( $self, $mysql_version = undef ) {

--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -12,11 +12,13 @@ Blockers for datbase: MySQL, PostgreSQL...
 
 use cPstrict;
 
-use Cpanel::OS              ();
-use Cpanel::Pkgr            ();
-use Cpanel::Version::Tiny   ();
-use Cpanel::JSON            ();
-use Cpanel::SafeRun::Simple ();
+use Cpanel::OS                         ();
+use Cpanel::Pkgr                       ();
+use Cpanel::Version::Tiny              ();
+use Cpanel::JSON                       ();
+use Cpanel::SafeRun::Simple            ();
+use Cpanel::DB::Map::Collection::Index ();
+use Cpanel::Exception                  ();
 
 use parent qw{Elevate::Blockers::Base};
 
@@ -89,28 +91,16 @@ sub _blocker_acknowledge_postgresql_datadir ($self) {
 
 sub _has_mapped_postgresql_dbs ($self) {
 
-    # Normalize locale:
-    local $ENV{HTTP_COOKIE} = 'session_locale=en';
-
-    # Get a list of cPanel users:
-    my $users_json   = Cpanel::SafeRun::Simple::saferunnoerror(qw(/usr/local/cpanel/bin/whmapi1 --output=json list_users));
-    my $users_parsed = Cpanel::JSON::Load($users_json);
-    die "WHM API1 list_users call returned result 0: $users_parsed->{metadata}->{reason}" unless $users_parsed->{metadata}->{result};
-    my @users = grep { $_ ne "root" } $users_parsed->{data}->{users}->@*;
-
-    # Compile a list of users with PgSQL DBs:
-    my @users_with_dbs;
-    foreach my $user (@users) {
-        my $dbs_json   = Cpanel::SafeRun::Simple::saferunnoerror( "/usr/local/cpanel/bin/uapi", "--user=$user", qw(--output=json Postgresql list_databases) );
-        my $dbs_parsed = Cpanel::JSON::Load($dbs_json);
-        if ( !$dbs_parsed->{result}->{status} ) {
-            return if ( $dbs_parsed->{result}->{errors}->[0] // '' ) eq 'This server does not support this functionality.';    # sanity check
-            die( "UAPI Postgresql::list_databases call returned status 0 for user $user:\n" . join( "\n", $dbs_parsed->{result}->{errors}->@* ) );
-        }
-        push @users_with_dbs, $user if scalar $dbs_parsed->{result}->{data}->@*;
+    my $dbindex = eval { Cpanel::DB::Map::Collection::Index->new( { db => 'PGSQL' } ); };
+    if ( my $exception = $@ ) {
+        ERROR( 'Unable to read the database index file:  ' . Cpanel::Exception::get_string($exception) );
+        $self->has_blocker("Unable to read the database index file; you may need to rebuild it by running: /usr/local/cpanel/bin/dbindex");
+        return ();
     }
 
-    return @users_with_dbs;
+    my %user_hash = map { $dbindex->{dbindex}{$_} => 1 } keys %{ $dbindex->{dbindex} };
+
+    return ( keys %user_hash );
 }
 
 sub _blocker_old_mysql ( $self, $mysql_version = undef ) {


### PR DESCRIPTION
Case RE-188:

Instead of, rather inefficiently, invoking uapi for each user, get the users with postgres databases from the dbindex.db.json file. This will quickly get that list of users regardless of the status of the postgres feature.

Changelog: Improve the check for PostgreSQL users to be more
  efficient and to not throw errors if the feature is disabled
  for any of the users.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

