### PR TITLE
Add blocker for invalid CloudLinux licenses

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -16,6 +16,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Blockers.pm'}                    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/AbsoluteSymlinks.pm'}   = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/BootKernel.pm'}         = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/CloudLinux.pm'}         = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Databases.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/DiskSpace.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Distros.pm'}            = 'script/elevate-cpanel.PL.static';
@@ -165,6 +166,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
         }
 
         my $blocker = cpev::Blocker->new( id => $caller_id, msg => $msg, %others );
+        $self->blockers->add_blocker($blocker);
         die $blocker if $self->blockers->abort_on_first_blocker();
 
         if ( !$others{'quiet'} ) {
@@ -173,8 +175,6 @@ BEGIN {    # Suppress load of all of these at earliest point.
         $msg
         EOS
         }
-
-        $self->blockers->add_blocker($blocker);
 
         return $blocker;
     }
@@ -204,6 +204,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Elevate::Blockers::Base ();
 
     use Elevate::Blockers::AbsoluteSymlinks ();
+    use Elevate::Blockers::CloudLinux       ();
     use Elevate::Blockers::Databases        ();
     use Elevate::Blockers::DiskSpace        ();
     use Elevate::Blockers::Distros          ();
@@ -240,6 +241,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       DiskSpace
       WHM
       Distros
+      CloudLinux
       DNS
 
       Databases
@@ -312,7 +314,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
             my $error = $@;
             if ( ref $error eq 'cpev::Blocker' ) {
                 ERROR( $error->{msg} );
-                return $error->{id} // 401;
+                return 401;
             }
             WARN("Unknown error while checking blockers: $error");
             return 127;    # unknown error
@@ -470,6 +472,51 @@ BEGIN {    # Suppress load of all of these at earliest point.
     1;
 
 }    # --- END lib/Elevate/Blockers/BootKernel.pm
+
+{    # --- BEGIN lib/Elevate/Blockers/CloudLinux.pm
+
+    package Elevate::Blockers::CloudLinux;
+
+    use cPstrict;
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    use Elevate::OS ();
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    use constant CLDETECT  => '/usr/bin/cldetect';
+    use constant RHN_CHECK => '/usr/sbin/rhn_check';
+
+    sub check ($self) {
+        return $self->_check_cloudlinux_license();
+    }
+
+    sub _check_cloudlinux_license ($self) {
+        return 0 unless Elevate::OS::should_check_cloudlinux_license();
+
+        my $out = $self->ssystem_capture_output( CLDETECT, '--check-license' );
+
+        if ( $self->ssystem(RHN_CHECK) != 0 || $out->{status} != 0 || grep { $_ !~ m/^ok/i } @{ $out->{stdout} } ) {
+
+            $self->blockers->abort_on_first_blocker(1);
+
+            return $self->has_blocker( <<~'EOS');
+        The CloudLinux license is reporting that it is not currently valid.  A
+        valid CloudLinux license is required to ELevate from CloudLinux 7 to
+        CloudLinux 8.
+        EOS
+        }
+
+        return 0;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Blockers/CloudLinux.pm
 
 {    # --- BEGIN lib/Elevate/Blockers/Databases.pm
 
@@ -4196,23 +4243,24 @@ EOS
     BEGIN {
 
         %methods = map { $_ => 0 } (
-            'available_upgrade_paths',        # This returns a list of possible upgrade paths for the OS
-            'default_upgrade_to',             # This is the default OS that the current OS should upgrade to (i.e. CL7->CL8, C7->A8)
-            'disable_mysql_yum_repos',        # This is a list of mysql repo files to disable
-            'ea_alias',                       # This is the value for the --target-os flag used when backing up an EA4 profile
-            'elevate_rpm_url',                # This is the URL used to install the leapp RPM/repo
-            'is_experimental',                # This is used to determine if the OS is experimental or not
-            'is_supported',                   # This is used to determine if the OS is supported or not
-            'leapp_can_handle_epel',          # This is used to determine if we can skip removing the EPEL repo pre_leapp or not
-            'leapp_can_handle_imunify',       # This is used to determine if we can skip the Imunify component or not
-            'leapp_can_handle_kernelcare',    # This is used to determine if we can skip the kernelcare component or not
-            'leapp_can_handle_python36',      # This is used to determine if we can skip the python36 blocker or not
-            'leapp_data_pkg',                 # This is used to determine which leapp data package to install
-            'leapp_flag',                     # This is used to determine if we need to pass any flags to the leapp script or not
-            'name',                           # This is the name of the OS we are upgrading from (i.e. CentOS7, or CloudLinux7)
-            'pretty_name',                    # This is the pretty name of the OS we are upgrading from (i.e. 'CentOS 7')
-            'vetted_mysql_yum_repo_ids',      # This is a list of known mysql yum repo ids
-            'vetted_yum_repo',                # This is a list of known yum repos that we do not block on
+            'available_upgrade_paths',            # This returns a list of possible upgrade paths for the OS
+            'default_upgrade_to',                 # This is the default OS that the current OS should upgrade to (i.e. CL7->CL8, C7->A8)
+            'disable_mysql_yum_repos',            # This is a list of mysql repo files to disable
+            'ea_alias',                           # This is the value for the --target-os flag used when backing up an EA4 profile
+            'elevate_rpm_url',                    # This is the URL used to install the leapp RPM/repo
+            'is_experimental',                    # This is used to determine if the OS is experimental or not
+            'is_supported',                       # This is used to determine if the OS is supported or not
+            'leapp_can_handle_epel',              # This is used to determine if we can skip removing the EPEL repo pre_leapp or not
+            'leapp_can_handle_imunify',           # This is used to determine if we can skip the Imunify component or not
+            'leapp_can_handle_kernelcare',        # This is used to determine if we can skip the kernelcare component or not
+            'leapp_can_handle_python36',          # This is used to determine if we can skip the python36 blocker or not
+            'leapp_data_pkg',                     # This is used to determine which leapp data package to install
+            'leapp_flag',                         # This is used to determine if we need to pass any flags to the leapp script or not
+            'name',                               # This is the name of the OS we are upgrading from (i.e. CentOS7, or CloudLinux7)
+            'pretty_name',                        # This is the pretty name of the OS we are upgrading from (i.e. 'CentOS 7')
+            'should_check_cloudlinux_license',    # This is used to determine if we should check the cloudlinux license
+            'vetted_mysql_yum_repo_ids',          # This is a list of known mysql yum repo ids
+            'vetted_yum_repo',                    # This is a list of known yum repos that we do not block on
         );
     }
 
@@ -4301,18 +4349,19 @@ EOS
         'cloudlinux',
     );
 
-    use constant default_upgrade_to          => 'CloudLinux';
-    use constant ea_alias                    => 'CloudLinux_8';
-    use constant elevate_rpm_url             => 'https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.noarch.rpm';
-    use constant is_experimental             => 1;
-    use constant leapp_can_handle_epel       => 1;
-    use constant leapp_can_handle_imunify    => 1;
-    use constant leapp_can_handle_kernelcare => 1;
-    use constant leapp_can_handle_python36   => 1;
-    use constant leapp_data_pkg              => 'leapp-data-cloudlinux';
-    use constant leapp_flag                  => '--nowarn';
-    use constant name                        => 'CloudLinux7';
-    use constant pretty_name                 => 'CloudLinux 7';
+    use constant default_upgrade_to              => 'CloudLinux';
+    use constant ea_alias                        => 'CloudLinux_8';
+    use constant elevate_rpm_url                 => 'https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.noarch.rpm';
+    use constant is_experimental                 => 1;
+    use constant leapp_can_handle_epel           => 1;
+    use constant leapp_can_handle_imunify        => 1;
+    use constant leapp_can_handle_kernelcare     => 1;
+    use constant leapp_can_handle_python36       => 1;
+    use constant leapp_data_pkg                  => 'leapp-data-cloudlinux';
+    use constant leapp_flag                      => '--nowarn';
+    use constant name                            => 'CloudLinux7';
+    use constant pretty_name                     => 'CloudLinux 7';
+    use constant should_check_cloudlinux_license => 1;
 
     sub vetted_yum_repo ($self) {
         my @vetted_cloudlinux_yum_repo = (
@@ -4391,20 +4440,21 @@ EOS
       ),
       vetted_mysql_yum_repo_ids;
 
-    use constant available_upgrade_paths     => undef;
-    use constant default_upgrade_to          => undef;
-    use constant ea_alias                    => undef;
-    use constant elevate_rpm_url             => undef;
-    use constant is_experimental             => 0;
-    use constant is_supported                => 1;
-    use constant leapp_can_handle_epel       => 0;
-    use constant leapp_can_handle_imunify    => 0;
-    use constant leapp_can_handle_kernelcare => 0;
-    use constant leapp_can_handle_python36   => 0;
-    use constant leapp_data_package          => undef;
-    use constant leapp_flag                  => undef;
-    use constant name                        => 'RHEL';
-    use constant pretty_name                 => 'RHEL';
+    use constant available_upgrade_paths         => undef;
+    use constant default_upgrade_to              => undef;
+    use constant ea_alias                        => undef;
+    use constant elevate_rpm_url                 => undef;
+    use constant is_experimental                 => 0;
+    use constant is_supported                    => 1;
+    use constant leapp_can_handle_epel           => 0;
+    use constant leapp_can_handle_imunify        => 0;
+    use constant leapp_can_handle_kernelcare     => 0;
+    use constant leapp_can_handle_python36       => 0;
+    use constant leapp_data_package              => undef;
+    use constant leapp_flag                      => undef;
+    use constant name                            => 'RHEL';
+    use constant pretty_name                     => 'RHEL';
+    use constant should_check_cloudlinux_license => 0;
 
     1;
 
@@ -5834,6 +5884,7 @@ use Elevate::Blockers::Base             ();
 use Elevate::Blockers                   ();
 use Elevate::Blockers::AbsoluteSymlinks ();
 use Elevate::Blockers::BootKernel       ();
+use Elevate::Blockers::CloudLinux       ();
 use Elevate::Blockers::Databases        ();
 use Elevate::Blockers::DiskSpace        ();
 use Elevate::Blockers::Distros          ();

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -19,6 +19,7 @@ use cPstrict;
 use Elevate::Blockers::Base ();
 
 use Elevate::Blockers::AbsoluteSymlinks ();
+use Elevate::Blockers::CloudLinux       ();
 use Elevate::Blockers::Databases        ();
 use Elevate::Blockers::DiskSpace        ();
 use Elevate::Blockers::Distros          ();
@@ -56,6 +57,7 @@ our @BLOCKERS = qw{
   DiskSpace
   WHM
   Distros
+  CloudLinux
   DNS
 
   Databases
@@ -129,7 +131,7 @@ sub _has_blockers ( $self, $check_mode = 0 ) {
         my $error = $@;
         if ( ref $error eq 'cpev::Blocker' ) {
             ERROR( $error->{msg} );
-            return $error->{id} // 401;
+            return 401;
         }
         WARN("Unknown error while checking blockers: $error");
         return 127;    # unknown error

--- a/lib/Elevate/Blockers/Base.pm
+++ b/lib/Elevate/Blockers/Base.pm
@@ -91,6 +91,7 @@ sub has_blocker ( $self, $msg, %others ) {
     }
 
     my $blocker = cpev::Blocker->new( id => $caller_id, msg => $msg, %others );
+    $self->blockers->add_blocker($blocker);
     die $blocker if $self->blockers->abort_on_first_blocker();
 
     if ( !$others{'quiet'} ) {
@@ -99,8 +100,6 @@ sub has_blocker ( $self, $msg, %others ) {
         $msg
         EOS
     }
-
-    $self->blockers->add_blocker($blocker);
 
     return $blocker;
 }

--- a/lib/Elevate/Blockers/CloudLinux.pm
+++ b/lib/Elevate/Blockers/CloudLinux.pm
@@ -1,0 +1,47 @@
+package Elevate::Blockers::CloudLinux;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::CloudLinux
+
+Blocker to check that the CloudLinux licese is valid for CloudLinux upgrades only.
+
+=cut
+
+use cPstrict;
+
+use parent qw{Elevate::Blockers::Base};
+
+use Elevate::OS ();
+
+use Log::Log4perl qw(:easy);
+
+use constant CLDETECT  => '/usr/bin/cldetect';
+use constant RHN_CHECK => '/usr/sbin/rhn_check';
+
+sub check ($self) {
+    return $self->_check_cloudlinux_license();
+}
+
+sub _check_cloudlinux_license ($self) {
+    return 0 unless Elevate::OS::should_check_cloudlinux_license();
+
+    my $out = $self->ssystem_capture_output( CLDETECT, '--check-license' );
+
+    if ( $self->ssystem(RHN_CHECK) != 0 || $out->{status} != 0 || grep { $_ !~ m/^ok/i } @{ $out->{stdout} } ) {
+
+        $self->blockers->abort_on_first_blocker(1);
+
+        return $self->has_blocker( <<~'EOS');
+        The CloudLinux license is reporting that it is not currently valid.  A
+        valid CloudLinux license is required to ELevate from CloudLinux 7 to
+        CloudLinux 8.
+        EOS
+    }
+
+    return 0;
+}
+
+1;

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -69,23 +69,24 @@ BEGIN {
     # The value specifies how many args the method is designed to take.
     %methods = map { $_ => 0 } (
         ### General distro specific methods.
-        'available_upgrade_paths',        # This returns a list of possible upgrade paths for the OS
-        'default_upgrade_to',             # This is the default OS that the current OS should upgrade to (i.e. CL7->CL8, C7->A8)
-        'disable_mysql_yum_repos',        # This is a list of mysql repo files to disable
-        'ea_alias',                       # This is the value for the --target-os flag used when backing up an EA4 profile
-        'elevate_rpm_url',                # This is the URL used to install the leapp RPM/repo
-        'is_experimental',                # This is used to determine if the OS is experimental or not
-        'is_supported',                   # This is used to determine if the OS is supported or not
-        'leapp_can_handle_epel',          # This is used to determine if we can skip removing the EPEL repo pre_leapp or not
-        'leapp_can_handle_imunify',       # This is used to determine if we can skip the Imunify component or not
-        'leapp_can_handle_kernelcare',    # This is used to determine if we can skip the kernelcare component or not
-        'leapp_can_handle_python36',      # This is used to determine if we can skip the python36 blocker or not
-        'leapp_data_pkg',                 # This is used to determine which leapp data package to install
-        'leapp_flag',                     # This is used to determine if we need to pass any flags to the leapp script or not
-        'name',                           # This is the name of the OS we are upgrading from (i.e. CentOS7, or CloudLinux7)
-        'pretty_name',                    # This is the pretty name of the OS we are upgrading from (i.e. 'CentOS 7')
-        'vetted_mysql_yum_repo_ids',      # This is a list of known mysql yum repo ids
-        'vetted_yum_repo',                # This is a list of known yum repos that we do not block on
+        'available_upgrade_paths',            # This returns a list of possible upgrade paths for the OS
+        'default_upgrade_to',                 # This is the default OS that the current OS should upgrade to (i.e. CL7->CL8, C7->A8)
+        'disable_mysql_yum_repos',            # This is a list of mysql repo files to disable
+        'ea_alias',                           # This is the value for the --target-os flag used when backing up an EA4 profile
+        'elevate_rpm_url',                    # This is the URL used to install the leapp RPM/repo
+        'is_experimental',                    # This is used to determine if the OS is experimental or not
+        'is_supported',                       # This is used to determine if the OS is supported or not
+        'leapp_can_handle_epel',              # This is used to determine if we can skip removing the EPEL repo pre_leapp or not
+        'leapp_can_handle_imunify',           # This is used to determine if we can skip the Imunify component or not
+        'leapp_can_handle_kernelcare',        # This is used to determine if we can skip the kernelcare component or not
+        'leapp_can_handle_python36',          # This is used to determine if we can skip the python36 blocker or not
+        'leapp_data_pkg',                     # This is used to determine which leapp data package to install
+        'leapp_flag',                         # This is used to determine if we need to pass any flags to the leapp script or not
+        'name',                               # This is the name of the OS we are upgrading from (i.e. CentOS7, or CloudLinux7)
+        'pretty_name',                        # This is the pretty name of the OS we are upgrading from (i.e. 'CentOS 7')
+        'should_check_cloudlinux_license',    # This is used to determine if we should check the cloudlinux license
+        'vetted_mysql_yum_repo_ids',          # This is a list of known mysql yum repo ids
+        'vetted_yum_repo',                    # This is a list of known yum repos that we do not block on
     );
 }
 

--- a/lib/Elevate/OS/CloudLinux7.pm
+++ b/lib/Elevate/OS/CloudLinux7.pm
@@ -19,18 +19,19 @@ use constant available_upgrade_paths => (
     'cloudlinux',
 );
 
-use constant default_upgrade_to          => 'CloudLinux';
-use constant ea_alias                    => 'CloudLinux_8';
-use constant elevate_rpm_url             => 'https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.noarch.rpm';
-use constant is_experimental             => 1;
-use constant leapp_can_handle_epel       => 1;
-use constant leapp_can_handle_imunify    => 1;
-use constant leapp_can_handle_kernelcare => 1;
-use constant leapp_can_handle_python36   => 1;
-use constant leapp_data_pkg              => 'leapp-data-cloudlinux';
-use constant leapp_flag                  => '--nowarn';
-use constant name                        => 'CloudLinux7';
-use constant pretty_name                 => 'CloudLinux 7';
+use constant default_upgrade_to              => 'CloudLinux';
+use constant ea_alias                        => 'CloudLinux_8';
+use constant elevate_rpm_url                 => 'https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.noarch.rpm';
+use constant is_experimental                 => 1;
+use constant leapp_can_handle_epel           => 1;
+use constant leapp_can_handle_imunify        => 1;
+use constant leapp_can_handle_kernelcare     => 1;
+use constant leapp_can_handle_python36       => 1;
+use constant leapp_data_pkg                  => 'leapp-data-cloudlinux';
+use constant leapp_flag                      => '--nowarn';
+use constant name                            => 'CloudLinux7';
+use constant pretty_name                     => 'CloudLinux 7';
+use constant should_check_cloudlinux_license => 1;
 
 sub vetted_yum_repo ($self) {
     my @vetted_cloudlinux_yum_repo = (

--- a/lib/Elevate/OS/RHEL.pm
+++ b/lib/Elevate/OS/RHEL.pm
@@ -63,19 +63,20 @@ use constant vetted_yum_repo => (
   ),
   vetted_mysql_yum_repo_ids;
 
-use constant available_upgrade_paths     => undef;
-use constant default_upgrade_to          => undef;
-use constant ea_alias                    => undef;
-use constant elevate_rpm_url             => undef;
-use constant is_experimental             => 0;
-use constant is_supported                => 1;
-use constant leapp_can_handle_epel       => 0;
-use constant leapp_can_handle_imunify    => 0;
-use constant leapp_can_handle_kernelcare => 0;
-use constant leapp_can_handle_python36   => 0;
-use constant leapp_data_package          => undef;
-use constant leapp_flag                  => undef;
-use constant name                        => 'RHEL';
-use constant pretty_name                 => 'RHEL';
+use constant available_upgrade_paths         => undef;
+use constant default_upgrade_to              => undef;
+use constant ea_alias                        => undef;
+use constant elevate_rpm_url                 => undef;
+use constant is_experimental                 => 0;
+use constant is_supported                    => 1;
+use constant leapp_can_handle_epel           => 0;
+use constant leapp_can_handle_imunify        => 0;
+use constant leapp_can_handle_kernelcare     => 0;
+use constant leapp_can_handle_python36       => 0;
+use constant leapp_data_package              => undef;
+use constant leapp_flag                      => undef;
+use constant name                            => 'RHEL';
+use constant pretty_name                     => 'RHEL';
+use constant should_check_cloudlinux_license => 0;
 
 1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -261,6 +261,7 @@ use Elevate::Blockers::Base             ();
 use Elevate::Blockers                   ();
 use Elevate::Blockers::AbsoluteSymlinks ();
 use Elevate::Blockers::BootKernel       ();
+use Elevate::Blockers::CloudLinux       ();
 use Elevate::Blockers::Databases        ();
 use Elevate::Blockers::DiskSpace        ();
 use Elevate::Blockers::Distros          ();

--- a/t/blocker-CloudLinux.t
+++ b/t/blocker-CloudLinux.t
@@ -1,0 +1,111 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockFile 0.032;
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $cpev_mock = Test::MockModule->new('cpev');
+my $cl_mock   = Test::MockModule->new('Elevate::Blockers::CloudLinux');
+
+my $cpev = cpev->new;
+my $cl   = $cpev->get_blocker('CloudLinux');
+
+{
+    note 'testing _check_cloudlinux_license';
+
+    my $cpev_mock = Test::MockModule->new('cpev');
+
+    my $system_status         = 0;
+    my $capture_output_status = 0;
+    my @cmds;
+    my @stdout;
+    $cpev_mock->redefine(
+        ssystem => sub ( $, @args ) {
+            push @cmds, [@args];
+            return $system_status;
+        },
+        ssystem_capture_output => sub ( $, @args ) {
+            push @cmds, [@args];
+            return { status => $capture_output_status, stdout => \@stdout, stderr => [] };
+        },
+    );
+
+    set_os_to('cent');
+    is $cl->_check_cloudlinux_license(), 0, 'The blocker check is skipped and returns 0 when the OS is CentOS';
+
+    set_os_to('cloud');
+
+    $system_status = 1;
+
+    my $blocker = dies { $cl->_check_cloudlinux_license() };
+
+    is ref $blocker, 'cpev::Blocker', 'A blocker object is returned when a blocker is found';
+    is(
+        \@cmds,
+        [
+            [
+                '/usr/bin/cldetect',
+                '--check-license',
+            ],
+            [
+                '/usr/sbin/rhn_check',
+            ],
+        ],
+        'The expected system commands are called'
+    );
+
+    check_blocker_content($blocker);
+
+    $system_status         = 0;
+    $capture_output_status = 1;
+
+    $blocker = dies { $cl->_check_cloudlinux_license() };
+
+    check_blocker_content($blocker);
+
+    $capture_output_status = 0;
+    @stdout                = (
+        'CL license is not ok',
+    );
+
+    $blocker = dies { $cl->_check_cloudlinux_license() };
+
+    check_blocker_content($blocker);
+
+    @stdout = (
+        'ok',
+    );
+
+    is $cl->_check_cloudlinux_license(), 0, 'No blockers are found when CL has a valid license';
+
+    no_messages_seen();
+}
+
+sub check_blocker_content ($blocker) {
+
+    like(
+        $blocker,
+        {
+            id  => 'Elevate::Blockers::CloudLinux::_check_cloudlinux_license',
+            msg => qr/^The CloudLinux license is reporting that it is not currently valid/,
+        },
+        'The expected blocker is returned'
+    );
+
+    return;
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-173:  CloudLinux's fork of ELevate verifies that the CloudLinux licese is valid and inhibits the elevation process from starting if it is not.  Due to this, we need to block if the CloudLinux license is not valid in order to avoid leaving the system in a broken state.

Additionally, I fixed a bug where the argument would not be numeric in exit when blockers were set to abort on the first blocker, and a bug where the blocker was not added before dying in this same situation which would result in the elevate-blockers file essentially being null.

Changelog: Add blocker for invalid CloudLinux licenses

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

