### PR TITLE
Do not copy the stage file to the success file until we notify success

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6551,6 +6551,7 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
         if ( $stage == VALID_STAGES ) {
             update_stage_file( { status => q[success] } );
             $self->_notify_success();
+            File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
         }
 
         if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
@@ -7042,8 +7043,6 @@ sub elevation_success_marker ($self) {
             }
         }
     );
-
-    File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
 
     return;
 }

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -784,6 +784,7 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
         if ( $stage == VALID_STAGES ) {
             update_stage_file( { status => q[success] } );
             $self->_notify_success();
+            File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
         }
 
         if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
@@ -1275,8 +1276,6 @@ sub elevation_success_marker ($self) {
             }
         }
     );
-
-    File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
 
     return;
 }


### PR DESCRIPTION
Case RE-228: The success file was reporting that elevate was still running.  This occurred because we were copying the success file into place in stage 5 before elevate had been marked as being succesful. This change makes it so that we do not copy the stage file to the success file until after we have marked in the stage file that we succeeded and notified the customer that the process succeeded.

Changelog: Do not copy the stage file to the success file until we
 notify the user that the process succeeded

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

