### PR TITLE
Block if sectigo is the provider for autossl domains

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -33,6 +33,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Blockers/SSH.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/WHM.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Leapp.pm'}              = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/AutoSSL.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/Base.pm'}             = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/AbsoluteSymlinks.pm'} = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/cPanelPlugins.pm'}    = 'script/elevate-cpanel.PL.static';
@@ -272,6 +273,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       OVH
       Python
       AbsoluteSymlinks
+      AutoSSL
     };
 
     push @BLOCKERS, 'Leapp';    # This blocker has to run last!
@@ -2184,6 +2186,51 @@ EOS
     1;
 
 }    # --- END lib/Elevate/Blockers/Leapp.pm
+
+{    # --- BEGIN lib/Elevate/Blockers/AutoSSL.pm
+
+    package Elevate::Blockers::AutoSSL;
+
+    use cPstrict;
+
+    use Cpanel::SSL::Auto ();
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    sub check ($self) {
+
+        return $self->_check_autossl_provider();
+    }
+
+    sub _check_autossl_provider ($self) {
+
+        my @providers = Cpanel::SSL::Auto::get_all_provider_info();
+
+        foreach my $provider (@providers) {
+            next unless ( ref $provider eq 'HASH' && $provider->{enabled} );
+
+            if ( defined $provider->{display_name}
+                && $provider->{display_name} =~ /sectigo/i ) {
+                return $self->has_blocker( <<~"EOS");
+            Elevating with the $provider->{display_name} provider in place is no longer supported.
+            To switch to the Let's Encrypt™ provider, review their terms of service here:
+            https://letsencrypt.org/documents/LE-SA-v1.3-September-21-2022.pdf
+            Then, if you accept, execute this command:
+
+            /usr/local/cpanel/bin/whmapi1 set_autossl_provider provider='LetsEncrypt' x_terms_of_service_accepted=https%3A%2F%2Fletsencrypt.org%2Fdocuments%2FLE-SA-v1.3-September-21-2022.pdf
+
+            EOS
+            }
+        }
+
+        return 0;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Blockers/AutoSSL.pm
 
 {    # --- BEGIN lib/Elevate/Components/Base.pm
 
@@ -6078,6 +6125,7 @@ use Elevate::Blockers::Repositories     ();    # using a constant
 use Elevate::Blockers::SSH              ();
 use Elevate::Blockers::WHM              ();
 use Elevate::Blockers::Leapp            ();
+use Elevate::Blockers::AutoSSL          ();
 
 # - fatpack Components
 use Elevate::Components::Base             ();

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -70,6 +70,7 @@ our @BLOCKERS = qw{
   OVH
   Python
   AbsoluteSymlinks
+  AutoSSL
 };
 
 push @BLOCKERS, 'Leapp';    # This blocker has to run last!

--- a/lib/Elevate/Blockers/AutoSSL.pm
+++ b/lib/Elevate/Blockers/AutoSSL.pm
@@ -1,0 +1,48 @@
+package Elevate::Blockers::AutoSSL;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::AutoSSL
+
+Blocker to check if Sectigo is the AutoSSL provider.
+
+=cut
+
+use cPstrict;
+
+use Cpanel::SSL::Auto ();
+
+use parent qw{Elevate::Blockers::Base};
+
+sub check ($self) {
+
+    return $self->_check_autossl_provider();
+}
+
+sub _check_autossl_provider ($self) {
+
+    my @providers = Cpanel::SSL::Auto::get_all_provider_info();
+
+    foreach my $provider (@providers) {
+        next unless ( ref $provider eq 'HASH' && $provider->{enabled} );
+
+        if ( defined $provider->{display_name}
+            && $provider->{display_name} =~ /sectigo/i ) {
+            return $self->has_blocker( <<~"EOS");
+            Elevating with the $provider->{display_name} provider in place is no longer supported.
+            To switch to the Let's Encrypt™ provider, review their terms of service here:
+            https://letsencrypt.org/documents/LE-SA-v1.3-September-21-2022.pdf
+            Then, if you accept, execute this command:
+
+            /usr/local/cpanel/bin/whmapi1 set_autossl_provider provider='LetsEncrypt' x_terms_of_service_accepted=https%3A%2F%2Fletsencrypt.org%2Fdocuments%2FLE-SA-v1.3-September-21-2022.pdf
+
+            EOS
+        }
+    }
+
+    return 0;
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -278,6 +278,7 @@ use Elevate::Blockers::Repositories     ();    # using a constant
 use Elevate::Blockers::SSH              ();
 use Elevate::Blockers::WHM              ();
 use Elevate::Blockers::Leapp            ();
+use Elevate::Blockers::AutoSSL          ();
 
 # - fatpack Components
 use Elevate::Components::Base             ();

--- a/t/blocker-AutoSSL.t
+++ b/t/blocker-AutoSSL.t
@@ -1,0 +1,67 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $ssl_auto_mock = Test::MockModule->new('Cpanel::SSL::Auto');
+
+my $cpev     = cpev->new;
+my $auto_ssl = $cpev->get_blocker('AutoSSL');
+
+my @test_data = (
+    "asdfasfd",
+    {},
+    {
+        enabled => undef,
+    },
+    {
+        enabled => 1,
+    },
+    {
+        enabled      => 0,
+        display_name => 'Let Us Encrypt',
+    },
+    {
+        enabled      => 0,
+        display_name => 'QAPortal BogoSSL',
+    },
+    {
+        enabled      => 1,
+        display_name => 'Sectigo',
+    },
+);
+
+$ssl_auto_mock->redefine(
+    'get_all_provider_info' => sub { return @test_data; },
+);
+
+{
+    like(
+        $auto_ssl->_check_autossl_provider(),
+        {
+            id  => q[Elevate::Blockers::AutoSSL::_check_autossl_provider],
+            msg => qr/Elevating with the Sectigo provider in place is no longer supported/,
+        },
+        'Sectigo enabled is a blocker.'
+    );
+
+    $test_data[-1]->{enabled} = 0;
+    $test_data[-2]->{enabled} = 1;
+
+    is( $auto_ssl->_check_autossl_provider(), 0, 'A different provider is not a blocker' );
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-54:

When CentOS 7 is elevated to AlmaLinux 8, the "nobody" user will retain its uid/gid of 99 where as on AlmaLinux 8 the expected uid/gid for "nobody" is 65534. This will cause issues with the Sectigo AutoSSL provider.

Changelog: Block if Sectigo is the AutoSSL provider.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

