### PR TITLE
Block if grub not installed or config file missing

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1072,6 +1072,8 @@ EOS
 
     use cPstrict;
 
+    use Cpanel::Pkgr ();
+
     use Elevate::Constants ();
 
     # use Elevate::Blockers::Base();
@@ -1100,6 +1102,8 @@ EOS
         my $ok = 1;
         $ok = 0 unless $self->_blocker_grub2_workaround;
         $ok = 0 unless $self->_blocker_blscfg;
+        $ok = 0 unless $self->_blocker_grub_not_installed;
+        $ok = 0 unless $self->_blocker_grub_config_missing;
         return $ok;
     }
 
@@ -1159,6 +1163,35 @@ EOS
 
     or to change it so that it is set to "true" instead.
     EOS
+
+        return 0;
+    }
+
+    sub _blocker_grub_not_installed ($self) {
+
+        return 0 if Cpanel::Pkgr::is_installed('grub2-pc');
+
+        return $self->has_blocker( <<~EOS );
+    The grub2-pc package is not installed. The GRUB2 boot loader is
+    required to upgrade via leapp.
+
+    You may want to consider reaching out to cPanel Support for assistance:
+    https://docs.cpanel.net/knowledge-base/technical-support-services/how-to-open-a-technical-support-ticket/
+    EOS
+    }
+
+    sub _blocker_grub_config_missing ($self) {
+
+        if (   ( !-f '/boot/grub2/grub.cfg' || !-s '/boot/grub2/grub.cfg' )
+            && ( !-f '/boot/grub/grub.cfg' || !-s '/boot/grub/grub.cfg' ) ) {
+
+            return $self->has_blocker( <<~EOS );
+        The GRUB2 config file is missing.
+
+        You may want to consider reaching out to cPanel Support for assistance:
+        https://docs.cpanel.net/knowledge-base/technical-support-services/how-to-open-a-technical-support-ticket/
+        EOS
+        }
 
         return 0;
     }

--- a/t/blocker-Grub2.t
+++ b/t/blocker-Grub2.t
@@ -29,7 +29,9 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
 {
     note "checking _blocker_blscfg: GRUB_ENABLE_BLSCFG state check";
 
-    $mock_g2->redefine( '_blocker_grub2_workaround' => 0 );
+    $mock_g2->redefine( '_blocker_grub2_workaround'    => 0 );
+    $mock_g2->redefine( '_blocker_grub_not_installed'  => 0 );
+    $mock_g2->redefine( '_blocker_grub_config_missing' => 0 );
 
     $mock_g2->redefine( _parse_shell_variable => sub { die "something happened\n" } );
     is(
@@ -56,6 +58,8 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
     );
 
     $mock_g2->unmock('_blocker_grub2_workaround');
+    $mock_g2->unmock('_blocker_grub_not_installed');
+    $mock_g2->unmock('_blocker_grub_config_missing');
 }
 
 {
@@ -88,6 +92,58 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
 
     is( $grub2->_blocker_grub2_workaround(),                       0, 'Blockers still pass...' );
     is( $stash->{'grub2_workaround'}->{'needs_workaround_update'}, 1, "...but we found the GRUB2 workaround and need to update it" );
+}
+
+{
+    note "grub2 package presence";
+
+    my $grub2_installed = 0;
+    my $mock_pkgr       = Test::MockModule->new('Cpanel::Pkgr');
+    $mock_pkgr->redefine(
+        is_installed => sub { return $grub2_installed; },
+    );
+
+    my $grub2 = $blockers->_get_blocker_for('Grub2');
+
+    like(
+        $grub2->_blocker_grub_not_installed(),
+        {
+            id  => q[Elevate::Blockers::Grub2::_blocker_grub_not_installed],
+            msg => qr/grub2-pc package is not installed/,
+        },
+        'Returns blocker if GRUB2 is not installed'
+    );
+
+    $grub2_installed = 1;
+    is( $grub2->_blocker_grub_not_installed(), 0, 'No blocker if GRUB2 is installed' );
+}
+
+{
+    note "grub2 config file presence";
+
+    my $mock_cfg1 = Test::MockFile->file('/boot/grub/grub.cfg');
+    my $mock_cfg2 = Test::MockFile->file('/boot/grub2/grub.cfg');
+
+    my $grub2 = $blockers->_get_blocker_for('Grub2');
+
+    like(
+        $grub2->_blocker_grub_config_missing(),
+        {
+            id  => q[Elevate::Blockers::Grub2::_blocker_grub_config_missing],
+            msg => qr/config file is missing/,
+        },
+        'Returns blocker if neither config file present'
+    );
+
+    $mock_cfg1->contents('stuff');
+    is( $grub2->_blocker_grub_config_missing(), 0, 'No blocker if only one grub2 config file is present' );
+
+    $mock_cfg1->unlink();
+    $mock_cfg2->contents('other stuff');
+    is( $grub2->_blocker_grub_config_missing(), 0, 'No blocker if only the other grub2 config file is present' );
+
+    $mock_cfg1->contents('stuff');
+    is( $grub2->_blocker_grub_config_missing(), 0, 'No blocker if both grub2 config files are present' );
 }
 
 done_testing();


### PR DESCRIPTION
Case RE-83:

Changelog: Block if the grub2-pc package is not installed
  or if the grub.cfg file is missing.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

