### PR TITLE
Ensure upcp and backups cannot run at the same time as ELevate.

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6838,6 +6838,11 @@ sub run_stage_2 ($self) {
 
     $self->elevation_startup_marker($sum);
 
+    # Remove scripts/upcp and bin/backup to make sure they don't
+    # end up running while ELevate is running.
+    unlink('/usr/local/cpanel/scripts/upcp');
+    unlink('/usr/local/cpanel/bin/backup');
+
     $self->ssystem(qw{/usr/bin/yum clean all});
     $self->ssystem_and_die(qw{/scripts/update-packages});
     $self->ssystem_and_die(qw{/usr/bin/yum -y update});
@@ -6979,7 +6984,7 @@ sub run_stage_4 ($self) {
             {
                 # MySQL server is not upgraded at this point - treat the upcp like a fresh install
                 local $ENV{'CPANEL_BASE_INSTALL'} = 1;
-                $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/upcp --sync});
+                $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/upcp.static --sync});
             }
 
             # cleanup the license: cpsanitycheck.so binary is compiled for a different distro

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1038,6 +1038,11 @@ sub run_stage_2 ($self) {
 
     $self->elevation_startup_marker($sum);
 
+    # Remove scripts/upcp and bin/backup to make sure they don't
+    # end up running while ELevate is running.
+    unlink('/usr/local/cpanel/scripts/upcp');
+    unlink('/usr/local/cpanel/bin/backup');
+
     $self->ssystem(qw{/usr/bin/yum clean all});
     $self->ssystem_and_die(qw{/scripts/update-packages});
     $self->ssystem_and_die(qw{/usr/bin/yum -y update});
@@ -1179,7 +1184,7 @@ sub run_stage_4 ($self) {
             {
                 # MySQL server is not upgraded at this point - treat the upcp like a fresh install
                 local $ENV{'CPANEL_BASE_INSTALL'} = 1;
-                $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/upcp --sync});
+                $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/upcp.static --sync});
             }
 
             # cleanup the license: cpsanitycheck.so binary is compiled for a different distro


### PR DESCRIPTION
Case RE-138: This commit makes it so scripts/upcp and bin/backup are removed early in stage 2 so cron or another entity cannot run them during the ELevate process.

Changelog: Ensure upcp and backups cannot run at the same time
 as ELevate.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

