### PR TITLE
Also block on the 'leapp preupgrade' ERRORS

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2173,9 +2173,20 @@ EOS
 
         $self->cpev->leapp->install();
 
-        $self->cpev->leapp->preupgrade();
+        my $out = $self->cpev->leapp->preupgrade();
 
-        my $blockers = $self->cpev->leapp->search_report_file_for_blockers(
+        return if ( $out->{status} == 0 );
+
+        $self->_check_for_inhibitors();
+
+        $self->_check_for_fatal_errors($out);
+
+        return;
+    }
+
+    sub _check_for_inhibitors ($self) {
+
+        my $inhibitors = $self->cpev->leapp->search_report_file_for_inhibitors(
             qw(
               check_installed_devel_kernels
               cl_mysql_repository_setup
@@ -2183,17 +2194,28 @@ EOS
             )
         );
 
-        foreach my $blocker (@$blockers) {
-            my $message = $blocker->{title} . "\n";
-            $message .= $blocker->{summary} . "\n";
-            if ( $blocker->{hint} ) {
-                $message .= "Possible resolution: " . $blocker->{hint} . "\n";
+        foreach my $inhibitor (@$inhibitors) {
+            my $message = $inhibitor->{title} . "\n";
+            $message .= $inhibitor->{summary} . "\n";
+            if ( $inhibitor->{hint} ) {
+                $message .= "Possible resolution: " . $inhibitor->{hint} . "\n";
             }
-            if ( $blocker->{command} ) {
-                $message .= "Consider running:" . "\n" . $blocker->{command} . "\n";
+            if ( $inhibitor->{command} ) {
+                $message .= "Consider running:" . "\n" . $inhibitor->{command} . "\n";
             }
 
             $self->has_blocker($message);
+        }
+
+        return;
+    }
+
+    sub _check_for_fatal_errors ( $self, $out ) {
+
+        my $error_block = $self->cpev->leapp->extract_error_block_from_output( $out->{stdout} );
+
+        if ( length $error_block ) {
+            $self->has_blocker( "Leapp encountered the following error(s):\n" . $error_block );
         }
 
         return;
@@ -4754,11 +4776,11 @@ EOS
 
         INFO("Running leapp preupgrade checks");
 
-        $self->cpev->ssystem_hide_output( '/usr/bin/leapp', 'preupgrade' );
+        my $out = $self->cpev->ssystem_hide_and_capture_output( '/usr/bin/leapp', 'preupgrade' );
 
         INFO("Finished running leapp preupgrade checks");
 
-        return;
+        return $out;
     }
 
     sub upgrade ($self) {
@@ -4790,7 +4812,7 @@ EOS
         return;
     }
 
-    sub search_report_file_for_blockers ( $self, @ignored_blockers ) {
+    sub search_report_file_for_inhibitors ( $self, @ignored_blockers ) {
 
         my @blockers;
         my $leapp_json_report = LEAPP_REPORT_JSON;
@@ -4849,6 +4871,44 @@ EOS
         }
 
         return \@blockers;
+    }
+
+    sub extract_error_block_from_output ( $self, $text_ar ) {
+
+        my $error_block = '';
+
+        my $found_banner_line        = 0;
+        my $found_second_banner_line = 0;
+        my $in_error_block           = 0;
+
+        foreach my $line (@$text_ar) {
+
+            if ( !$found_banner_line ) {
+                $found_banner_line = 1 if $line =~ /^={10}/;
+                next;
+            }
+
+            if ( !$in_error_block ) {
+                if ( $line =~ /^\s+ERRORS/ ) {
+                    $in_error_block = 1;
+                }
+                else {
+                    $found_banner_line = 0;
+                }
+                next;
+            }
+
+            if ( !$found_second_banner_line ) {
+                $found_second_banner_line = 1 if $line =~ /^={10}/;
+                next;
+            }
+
+            last if $line =~ /^={10}/;
+
+            $error_block .= $line . "\n";
+        }
+
+        return $error_block;
     }
 
     sub _report_leapp_failure_and_die ($self) {
@@ -5203,14 +5263,15 @@ EOS
         return _ssystem( \@args, %opts );
     }
 
-    sub ssystem_hide_output ( $, @args ) {
+    sub ssystem_hide_and_capture_output ( $, @args ) {
 
         my %opts;
         if ( ref $args[0] ) {
             my $ropts = shift @args;
             %opts = %$ropts;
         }
-        $opts{should_hide_output} = 1;
+        $opts{should_hide_output}    = 1;
+        $opts{should_capture_output} = 1;
 
         return _ssystem( \@args, %opts );
     }

--- a/lib/Elevate/Roles/Run.pm
+++ b/lib/Elevate/Roles/Run.pm
@@ -39,14 +39,15 @@ sub ssystem_capture_output ( $, @args ) {
     return _ssystem( \@args, %opts );
 }
 
-sub ssystem_hide_output ( $, @args ) {
+sub ssystem_hide_and_capture_output ( $, @args ) {
 
     my %opts;
     if ( ref $args[0] ) {
         my $ropts = shift @args;
         %opts = %$ropts;
     }
-    $opts{should_hide_output} = 1;
+    $opts{should_hide_output}    = 1;
+    $opts{should_capture_output} = 1;
 
     return _ssystem( \@args, %opts );
 }

--- a/t/leapp_upgrade.t
+++ b/t/leapp_upgrade.t
@@ -220,7 +220,7 @@ my $expected_blockers = [
     }
 ];
 
-my $found_blockers = cpev->leapp->search_report_file_for_blockers(
+my $found_blockers = cpev->leapp->search_report_file_for_inhibitors(
     qw(
       check_installed_devel_kernels
       verify_check_results
@@ -241,8 +241,69 @@ $expected_blockers = [
 # This keeps Cpanel::Exception from throwing errors by accessing ummocked locale files
 local $Cpanel::Exception::LOCALIZE_STRINGS = 0;
 
-$found_blockers = cpev->leapp->search_report_file_for_blockers();
+$found_blockers = cpev->leapp->search_report_file_for_inhibitors();
 
 is $found_blockers, $expected_blockers, 'Returned blocker for invalid JSON in report file';
+
+my $test_stdout = <<'EOS';
+====> * used_repository_scanner
+        Scan used enabled repositories
+====> * scan_rollout_repositories
+        Scan for repository files associated with the Gradual Rollout System.
+====> * repositories_blacklist
+        Exclude target repositories provided by Red Hat without support.
+====> * pes_events_scanner
+        Provides data about package events from Package Evolution Service.
+====> * setuptargetrepos
+        Produces list of repositories that should be available to be used by Upgrade process.
+
+============================================================
+                      RANDOM BOGUS BANNER
+============================================================
+
+============================================================
+                           ERRORS
+============================================================
+
+2024-02-23 19:42:32.285162 [ERROR] Actor: system_facts
+Message: Failed parsing of /etc/default/grub
+Summary:
+    Problematic line: unset GRUB_TERMINAL_OUTPUT
+    Error: need more than 1 value to unpack
+
+============================================================
+                       END OF ERRORS
+============================================================
+
+
+Debug output written to /var/log/leapp/leapp-preupgrade.log
+
+============================================================
+                           REPORT
+============================================================
+
+A report has been generated at /var/log/leapp/leapp-report.json
+A report has been generated at /var/log/leapp/leapp-report.txt
+
+============================================================
+                       END OF REPORT
+============================================================
+EOS
+
+my $expected_error_block = <<'EOS';
+
+2024-02-23 19:42:32.285162 [ERROR] Actor: system_facts
+Message: Failed parsing of /etc/default/grub
+Summary:
+    Problematic line: unset GRUB_TERMINAL_OUTPUT
+    Error: need more than 1 value to unpack
+
+EOS
+
+my @test_stdout_lines = split( "\n", $test_stdout );
+
+my $found_error_block = cpev->leapp->extract_error_block_from_output( \@test_stdout_lines );
+
+is $found_error_block, $expected_error_block, 'Properly extracted the error block from leapp stdout';
 
 done_testing;


### PR DESCRIPTION
Case RE-223:

Normally, during a leapp upgrade or preupgrade, leapp reports any issue when inhibits an upgrade in the
leapp-report.json file and flags it as in "inhibitor". Sometimes, however, leapp encounters a fatal error which is not flagged as such in the report file.
Fatal errors will show up in the stdout in a special "ERRORS" block. Also, if leapp encounters either an inhibitor or any other fatal error, the exit code will be non-zero.
So, if we have a non-zero error code, and an error block reported in leapp's stdout, we should report this as a blocker.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

