### PR TITLE
Have bail_out_on_inappropriate_distro() remove Elevate::OS cache

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -914,6 +914,7 @@ EOS
     }
 
     sub bail_out_on_inappropriate_distro () {
+        Elevate::OS::clear_cache();
         Elevate::OS::is_supported();    # dies
         return;
     }
@@ -4410,6 +4411,12 @@ EOS
     sub upgrade_to () {
         my $default = Elevate::OS::default_upgrade_to();
         return cpev::read_stage_file( 'upgrade_to', $default );
+    }
+
+    sub clear_cache () {
+        undef $OS unless $INC{'Test/Elevate.pm'};
+        cpev::remove_from_stage_file('upgrade_from');
+        return;
     }
 
     1;

--- a/lib/Elevate/Blockers/Distros.pm
+++ b/lib/Elevate/Blockers/Distros.pm
@@ -66,8 +66,15 @@ sub _blocker_is_experimental_os ($self) {
     return 0;
 }
 
-# We are OK if can_be_elevated or if
+=head2
+
+This sub is the primary gateway to determine if a server is eligible for a OS
+upgrade via this script.  Never allow a cache to be used here.
+
+=cut
+
 sub bail_out_on_inappropriate_distro () {
+    Elevate::OS::clear_cache();
     Elevate::OS::is_supported();    # dies
     return;
 }

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -133,4 +133,10 @@ sub upgrade_to () {
     return cpev::read_stage_file( 'upgrade_to', $default );
 }
 
+sub clear_cache () {
+    undef $OS unless $INC{'Test/Elevate.pm'};
+    cpev::remove_from_stage_file('upgrade_from');
+    return;
+}
+
 1;


### PR DESCRIPTION
Case RE-249: Elevate did not detect the correct OS on a server that had been elevated and still had the staging file in place.  This was due to the cached OS value still being present in the staging file.  Due to this, elevate did not bail out as expected on an OS that was not eligible to be elevated.

Changelog: Ensure proper OS detection on servers that have been
 previously elevated

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

