### PR TITLE
Report potential failures of LEAPP.

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4709,8 +4709,10 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
-    use constant LEAPP_REPORT_JSON => q[/var/log/leapp/leapp-report.json];
-    use constant LEAPP_REPORT_TXT  => q[/var/log/leapp/leapp-report.txt];
+    use constant LEAPP_REPORT_JSON    => q[/var/log/leapp/leapp-report.json];
+    use constant LEAPP_REPORT_TXT     => q[/var/log/leapp/leapp-report.txt];
+    use constant LEAPP_UPGRADE_LOG    => q[/var/log/leapp/leapp-upgrade.log];
+    use constant LEAPP_FAIL_CONT_FILE => q[/var/cpanel/elevate_leap_fail_continue];
 
     use Simple::Accessor qw{
       cpev
@@ -4849,6 +4851,48 @@ EOS
         }
 
         return \@blockers;
+    }
+
+    sub check_upgrade_log_for_failures ($self) {
+        my $upgrade_log = LEAPP_UPGRADE_LOG;
+
+        if ( !-e $upgrade_log ) {
+            ERROR("No LEAPP upgrade log detected at [$upgrade_log]");
+
+            return 1;
+        }
+
+        my $grep_log_error = $self->cpev->ssystem_capture_output( '/usr/bin/grep', '-E', "\\sERROR\\s", $upgrade_log );
+        my $grep_firstboot = $self->cpev->ssystem_capture_output( '/usr/bin/grep', 'Starting stage After of phase FirstBoot', $upgrade_log );
+
+        if ( scalar @{ $grep_log_error->{'stdout'} } ) {
+            if ( -e LEAPP_FAIL_CONT_FILE ) {
+                INFO( "Found LEAPP upgrade errors, but continuing anyway because " . LEAPP_FAIL_CONT_FILE . " exists" );
+
+                return 0;
+            }
+            else {
+                ERROR('There were errors during the LEAPP process.');
+                ERROR( join( '\n', @{ $grep_log_error->{'stdout'} } ) );
+
+                return 1;
+            }
+        }
+
+        if ( !scalar @{ $grep_firstboot->{'stdout'} } ) {
+            if ( -e LEAPP_FAIL_CONT_FILE ) {
+                INFO( "LEAPP does not appear to have completed successfully, but continuing anyway because " . LEAPP_FAIL_CONT_FILE . " exists" );
+
+                return 0;
+            }
+            else {
+                ERROR("No LEAPP upgrade errors detected, but the upgrade process did not complete successfully");
+
+                return 1;
+            }
+        }
+
+        return 0;
     }
 
     sub _report_leapp_failure_and_die ($self) {
@@ -7027,7 +7071,17 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
-    Cpanel::OS::clear_cache_after_cloudlinux_update();    # I didn't pick the "clear cache but don't die" name...
+    Cpanel::OS::clear_cache_after_cloudlinux_update();
+
+    my $upgrade_errors = $self->leapp->check_upgrade_log_for_failures();
+    if ($upgrade_errors) {
+        my $message = sprintf("The LEAPP upgrade process did not succeed\n");
+        $message .= sprintf("Please review the errors, and resolve them.\n");
+        $message .= sprintf("Once resolved, run the following commands to continue the upgrade process:\n");
+        $message .= sprintf("\ttouch /var/cpanel/elevate_leap_fail_continue\n");
+        $message .= sprintf("\t/scripts/elevate-cpanel --continue\n");
+        die($message);
+    }
 
     if ( Cpanel::OS::major() != 8 ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1130,7 +1130,17 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
-    Cpanel::OS::clear_cache_after_cloudlinux_update();    # I didn't pick the "clear cache but don't die" name...
+    Cpanel::OS::clear_cache_after_cloudlinux_update();
+
+    my $upgrade_errors = $self->leapp->check_upgrade_log_for_failures();
+    if ($upgrade_errors) {
+        my $message = sprintf("The LEAPP upgrade process did not succeed\n");
+        $message .= sprintf("Please review the errors, and resolve them.\n");
+        $message .= sprintf("Once resolved, run the following commands to continue the upgrade process:\n");
+        $message .= sprintf("\ttouch /var/cpanel/elevate_leap_fail_continue\n");
+        $message .= sprintf("\t/scripts/elevate-cpanel --continue\n");
+        die($message);
+    }
 
     if ( Cpanel::OS::major() != 8 ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();


### PR DESCRIPTION
Case RE-224: This commit adds in some extra checks to help determine if the LEAPP process failed or not. It also introduces a new potential touch file at /var/cpanel/elevate_leap_fail_continue that can be used to continue even if the new checks detect a possible error.

Changelog: Added in more checks to report potential failures of
 LEAPP.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

