### PR TITLE
Convert systems using Sectigo to use Let's Encrypt

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -33,6 +33,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Blockers/SSH.pm'}                  = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/WHM.pm'}                  = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Leapp.pm'}                = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/AutoSSL.pm'}              = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/Base.pm'}               = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/AbsoluteSymlinks.pm'}   = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/cPanelPlugins.pm'}      = 'script/elevate-cpanel.PL.static';
@@ -54,6 +55,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Components/RmMod.pm'}              = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/WPToolkit.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/SSH.pm'}                = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Components/AutoSSL.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS.pm'}                            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CentOS7.pm'}                    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CloudLinux7.pm'}                = 'script/elevate-cpanel.PL.static';
@@ -274,6 +276,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       OVH
       Python
       AbsoluteSymlinks
+      AutoSSL
     };
 
     push @BLOCKERS, 'Leapp';    # This blocker has to run last!
@@ -2259,6 +2262,46 @@ EOS
     1;
 
 }    # --- END lib/Elevate/Blockers/Leapp.pm
+
+{    # --- BEGIN lib/Elevate/Blockers/AutoSSL.pm
+
+    package Elevate::Blockers::AutoSSL;
+
+    use cPstrict;
+
+    use Cpanel::SSL::Auto ();
+
+    use Elevate::Components::AutoSSL ();
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    sub check ($self) {
+
+        return $self->_check_autossl_provider();
+    }
+
+    sub _check_autossl_provider ($self) {
+
+        if ( Elevate::Components::AutoSSL::is_using_sectigo() ) {
+            WARN( <<~"EOS" );
+        Elevating with Sectigo as the provider for AutoSSL is not supported.
+        If you proceed with this upgrade, we will switch your system
+        to use the Let's Encrypt™ provider.
+
+        EOS
+        }
+
+        return 0;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Blockers/AutoSSL.pm
 
 {    # --- BEGIN lib/Elevate/Components/Base.pm
 
@@ -4430,6 +4473,52 @@ EOS
 
 }    # --- END lib/Elevate/Components/SSH.pm
 
+{    # --- BEGIN lib/Elevate/Components/AutoSSL.pm
+
+    package Elevate::Components::AutoSSL;
+
+    use cPstrict;
+
+    use Cpanel::SSL::Auto ();
+
+    # use Elevate::Components::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Components::Base); }
+
+    sub pre_leapp ($self) {
+
+        if ( is_using_sectigo() ) {
+            $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/autorepair set_autossl_to_lets_encrypt});
+        }
+
+        return;
+    }
+
+    sub post_leapp ($self) {
+
+        return;
+    }
+
+    sub is_using_sectigo {
+
+        my @providers = Cpanel::SSL::Auto::get_all_provider_info();
+
+        foreach my $provider (@providers) {
+            next unless ( ref $provider eq 'HASH' && $provider->{enabled} );
+
+            if ( defined $provider->{display_name}
+                && $provider->{display_name} =~ /sectigo/i ) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Components/AutoSSL.pm
+
 {    # --- BEGIN lib/Elevate/OS.pm
 
     package Elevate::OS;
@@ -6346,6 +6435,7 @@ use Elevate::Blockers::Repositories     ();    # using a constant
 use Elevate::Blockers::SSH              ();
 use Elevate::Blockers::WHM              ();
 use Elevate::Blockers::Leapp            ();
+use Elevate::Blockers::AutoSSL          ();
 
 # - fatpack Components
 use Elevate::Components::Base               ();
@@ -6369,6 +6459,7 @@ use Elevate::Components::RpmDB              ();
 use Elevate::Components::RmMod              ();
 use Elevate::Components::WPToolkit          ();
 use Elevate::Components::SSH                ();
+use Elevate::Components::AutoSSL            ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -7126,6 +7217,7 @@ sub run_stage_2 ($self) {
     Elevate::Motd->setup();
 
     $self->run_component_once( 'SSH'        => 'pre_leapp' );
+    $self->run_component_once( 'AutoSSL'    => 'pre_leapp' );
     $self->run_component_once( 'KernelCare' => 'pre_leapp' );
     $self->run_component_once( 'Grub2'      => 'pre_leapp' );
 

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -70,6 +70,7 @@ our @BLOCKERS = qw{
   OVH
   Python
   AbsoluteSymlinks
+  AutoSSL
 };
 
 push @BLOCKERS, 'Leapp';    # This blocker has to run last!

--- a/lib/Elevate/Blockers/AutoSSL.pm
+++ b/lib/Elevate/Blockers/AutoSSL.pm
@@ -1,0 +1,42 @@
+package Elevate::Blockers::AutoSSL;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::AutoSSL
+
+Blocker to check if Sectigo is the AutoSSL provider.
+
+=cut
+
+use cPstrict;
+
+use Cpanel::SSL::Auto ();
+
+use Elevate::Components::AutoSSL ();
+
+use Log::Log4perl qw(:easy);
+
+use parent qw{Elevate::Blockers::Base};
+
+sub check ($self) {
+
+    return $self->_check_autossl_provider();
+}
+
+sub _check_autossl_provider ($self) {
+
+    if ( Elevate::Components::AutoSSL::is_using_sectigo() ) {
+        WARN( <<~"EOS" );
+        Elevating with Sectigo as the provider for AutoSSL is not supported.
+        If you proceed with this upgrade, we will switch your system
+        to use the Let's Encrypt™ provider.
+
+        EOS
+    }
+
+    return 0;
+}
+
+1;

--- a/lib/Elevate/Components/AutoSSL.pm
+++ b/lib/Elevate/Components/AutoSSL.pm
@@ -1,0 +1,64 @@
+package Elevate::Components::AutoSSL;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Components::AutoSSL
+
+Change AutoSSL provider from Sectigo to Lets Encrypt
+
+=cut
+
+use cPstrict;
+
+use Cpanel::SSL::Auto ();
+
+use parent qw{Elevate::Components::Base};
+
+sub pre_leapp ($self) {
+
+    if ( is_using_sectigo() ) {
+        $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/autorepair set_autossl_to_lets_encrypt});
+    }
+
+    return;
+}
+
+sub post_leapp ($self) {
+
+    # Nothing to do
+    return;
+}
+
+=head2 is_using_sectigo()
+
+Determines whether AutoSSL is using Sectigo as a provider
+
+=head3 ARGUMENTS
+
+None
+
+=head3 RETURNS
+
+true/false if AutoSSL is/isn't using Sectigo
+
+=cut
+
+sub is_using_sectigo {
+
+    my @providers = Cpanel::SSL::Auto::get_all_provider_info();
+
+    foreach my $provider (@providers) {
+        next unless ( ref $provider eq 'HASH' && $provider->{enabled} );
+
+        if ( defined $provider->{display_name}
+            && $provider->{display_name} =~ /sectigo/i ) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -278,6 +278,7 @@ use Elevate::Blockers::Repositories     ();    # using a constant
 use Elevate::Blockers::SSH              ();
 use Elevate::Blockers::WHM              ();
 use Elevate::Blockers::Leapp            ();
+use Elevate::Blockers::AutoSSL          ();
 
 # - fatpack Components
 use Elevate::Components::Base               ();
@@ -301,6 +302,7 @@ use Elevate::Components::RpmDB              ();
 use Elevate::Components::RmMod              ();
 use Elevate::Components::WPToolkit          ();
 use Elevate::Components::SSH                ();
+use Elevate::Components::AutoSSL            ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -1058,6 +1060,7 @@ sub run_stage_2 ($self) {
     Elevate::Motd->setup();
 
     $self->run_component_once( 'SSH'        => 'pre_leapp' );
+    $self->run_component_once( 'AutoSSL'    => 'pre_leapp' );
     $self->run_component_once( 'KernelCare' => 'pre_leapp' );
     $self->run_component_once( 'Grub2'      => 'pre_leapp' );
 

--- a/t/blocker-AutoSSL.t
+++ b/t/blocker-AutoSSL.t
@@ -1,0 +1,62 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $ssl_auto_mock = Test::MockModule->new('Cpanel::SSL::Auto');
+
+my $cpev     = cpev->new;
+my $auto_ssl = $cpev->get_blocker('AutoSSL');
+
+my @test_data = (
+    "asdfasfd",
+    {},
+    {
+        enabled => undef,
+    },
+    {
+        enabled => 1,
+    },
+    {
+        enabled      => 0,
+        display_name => 'Let Us Encrypt',
+    },
+    {
+        enabled      => 0,
+        display_name => 'QAPortal BogoSSL',
+    },
+    {
+        enabled      => 1,
+        display_name => 'Sectigo',
+    },
+);
+
+$ssl_auto_mock->redefine(
+    'get_all_provider_info' => sub { return @test_data; },
+);
+
+{
+    $auto_ssl->_check_autossl_provider();
+    message_seen( 'WARN' => qr/is not supported/ );
+
+    $test_data[-1]->{enabled} = 0;
+    $test_data[-2]->{enabled} = 1;
+
+    $auto_ssl->_check_autossl_provider();
+    no_messages_seen();
+}
+
+done_testing();

--- a/t/components-AutoSSL.t
+++ b/t/components-AutoSSL.t
@@ -1,0 +1,96 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+package test::cpev::components;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $auto_ssl = bless {}, 'Elevate::Components::AutoSSL';
+
+{
+    note "Checking pre_leapp";
+
+    my $is_using_sectigo       = 0;
+    my @ssystem_and_die_params = ();
+
+    my $mock_auto_ssl = Test::MockModule->new('Elevate::Components::AutoSSL');
+    $mock_auto_ssl->redefine(
+        ssystem_and_die => sub {
+            shift;
+            @ssystem_and_die_params = @_;
+            return;
+        },
+        is_using_sectigo => sub { return $is_using_sectigo; },
+    );
+
+    $auto_ssl->pre_leapp();
+    is( \@ssystem_and_die_params, [], 'Autorepair is NOT invoked when NOT using Sectigo' );
+
+    $is_using_sectigo = 1;
+    $auto_ssl->pre_leapp();
+    is(
+        \@ssystem_and_die_params,
+        [qw{/usr/local/cpanel/scripts/autorepair set_autossl_to_lets_encrypt}],
+        'Autorepair is invoked when using Sectigo'
+    );
+}
+
+{
+    note "Checking is_using_sectigo";
+
+    my @test_data = (
+        "asdfasfd",
+        {},
+        {
+            enabled => undef,
+        },
+        {
+            enabled => 1,
+        },
+        {
+            enabled      => 0,
+            display_name => "Let's Encrypt",
+        },
+        {
+            enabled      => 0,
+            display_name => "QAPortal BogoSSL",
+        },
+        {
+            enabled      => 1,
+            display_name => "Sectigo",
+        },
+    );
+
+    my $ssl_auto_mock = Test::MockModule->new('Cpanel::SSL::Auto');
+    $ssl_auto_mock->redefine(
+        'get_all_provider_info' => sub { return @test_data; },
+    );
+
+    is(
+        Elevate::Components::AutoSSL::is_using_sectigo(),
+        1,
+        'is_using_sectigo returns true when Sectigo is enabled'
+    );
+
+    $test_data[-1]->{enabled} = 0;
+    $test_data[-2]->{enabled} = 1;
+
+    is(
+        Elevate::Components::AutoSSL::is_using_sectigo(),
+        0,
+        'is_using_sectigo returns false when Sectigo is NOT enabled'
+    );
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-54:

When CentOS 7 is elevated to AlmaLinux 8, the "nobody" user will retain its uid/gid of 99 where as on AlmaLinux 8 the expected uid/gid for "nobody" is 65534. This will cause issues with the Sectigo AutoSSL provider.
If a system is setup to use Sectigo as the AutoSSL provider, emit a warning that the system will be switched to Lets Encrypt. Run the appropriate autofixer for the conversion during the upgrade

Changelog: Change to Let's Encrypt if Sectigo is the AutoSSL provider.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

