### PR TITLE
Validate script can execute start option before parsing upgrade_to

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4480,6 +4480,8 @@ EOS
             die "This script is only designed to upgrade the following OSs:\n\n$supported_distros\n";
         }
 
+        Elevate::OS::_set_cache();
+
         return $OS;
     }
 
@@ -4541,6 +4543,11 @@ EOS
     sub clear_cache () {
         undef $OS unless $INC{'Test/Elevate.pm'};
         cpev::remove_from_stage_file('upgrade_from');
+        return;
+    }
+
+    sub _set_cache () {
+        cpev::update_stage_file( { upgrade_from => Elevate::OS::name() } );
         return;
     }
 
@@ -6646,7 +6653,6 @@ sub monitor_upgrade ($self) {
 }
 
 sub start ($self) {
-    $self->_parse_opt_upgrade_to();
     my $stage = get_stage();
     if ( $stage != 0 ) {
         my $header;
@@ -6666,6 +6672,11 @@ sub start ($self) {
         EOS
 
     }
+
+    # Do not do this until after we know that the script is not already in progress
+    # Otherwise, it will clear the Elevate::OS cache which can result in the script
+    # failing once leapp has finished upgrading the server
+    $self->_parse_opt_upgrade_to();
 
     # Check for blockers before starting the migration
     return 1 if ( $self->blockers->check() );
@@ -7085,11 +7096,6 @@ sub run_stage_1 ($self) {
 
     # store 'upgrade_to' early so later stages can access it
     update_stage_file( { upgrade_to => $self->upgrade_to } );
-
-    # store 'upgrade_from' early so that Elevate::OS can access it
-    # Elevate::OS is based on the OS we are upgrading from since the information
-    # that it provides is mostly based on what leapp can do when upgrading from an OS
-    update_stage_file( { upgrade_from => Elevate::OS::name() } );
 
     return $self->service->install();
 }

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -57,6 +57,8 @@ sub instance {
         die "This script is only designed to upgrade the following OSs:\n\n$supported_distros\n";
     }
 
+    Elevate::OS::_set_cache();
+
     return $OS;
 }
 
@@ -136,6 +138,11 @@ sub upgrade_to () {
 sub clear_cache () {
     undef $OS unless $INC{'Test/Elevate.pm'};
     cpev::remove_from_stage_file('upgrade_from');
+    return;
+}
+
+sub _set_cache () {
+    cpev::update_stage_file( { upgrade_from => Elevate::OS::name() } );
     return;
 }
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -578,7 +578,6 @@ sub monitor_upgrade ($self) {
 }
 
 sub start ($self) {
-    $self->_parse_opt_upgrade_to();
     my $stage = get_stage();
     if ( $stage != 0 ) {
         my $header;
@@ -598,6 +597,11 @@ sub start ($self) {
         EOS
 
     }
+
+    # Do not do this until after we know that the script is not already in progress
+    # Otherwise, it will clear the Elevate::OS cache which can result in the script
+    # failing once leapp has finished upgrading the server
+    $self->_parse_opt_upgrade_to();
 
     # Check for blockers before starting the migration
     return 1 if ( $self->blockers->check() );
@@ -1017,11 +1021,6 @@ sub run_stage_1 ($self) {
 
     # store 'upgrade_to' early so later stages can access it
     update_stage_file( { upgrade_to => $self->upgrade_to } );
-
-    # store 'upgrade_from' early so that Elevate::OS can access it
-    # Elevate::OS is based on the OS we are upgrading from since the information
-    # that it provides is mostly based on what leapp can do when upgrading from an OS
-    update_stage_file( { upgrade_from => Elevate::OS::name() } );
 
     return $self->service->install();
 }

--- a/t/Elevate-Database.t
+++ b/t/Elevate-Database.t
@@ -20,6 +20,11 @@ my $cloudlinux_database_installed;
 my $cloudlinux_database_info;
 my $os;
 
+my $mock_elevate_os = Test::MockModule->new('Elevate::OS');
+$mock_elevate_os->redefine(
+    _set_cache => 0,
+);
+
 {
     note 'Test is_database_provided_by_cloudlinux() behavior';
 

--- a/t/blocker-Python.t
+++ b/t/blocker-Python.t
@@ -18,7 +18,9 @@ my %mocks = map { $_ => Test::MockModule->new($_); } qw{
   Cpanel::Pkgr
   Elevate::Blockers
   Elevate::Blockers::Base
+  Elevate::OS
 };
+$mocks{'Elevate::OS'}->redefine( _set_cache => 0 );
 $mocks{'Cpanel::Pkgr'}->redefine( "what_provides" => '', "is_installed" => 1 );
 my $obj = bless {}, 'Elevate::Blockers::Python';
 ok( !$obj->check(), "Returns early on no provider of python36" );

--- a/t/lib/Test/Elevate.pm
+++ b/t/lib/Test/Elevate.pm
@@ -22,7 +22,8 @@ BEGIN {
     require $FindBin::Bin . q[/../elevate-cpanel];
     $INC{'cpev.pm'} = '__TEST__';
     no warnings;
-    *Elevate::Logger::init = sub { };
+    *Elevate::Logger::init   = sub { };
+    *Elevate::OS::_set_cache = sub { };
 }
 
 sub _msg ( $self, $msg, $level = '[void]' ) {


### PR DESCRIPTION
Case RE-265: The start option had an order of operations issue where it would attempt to parse the upgrade_to option before validating that it could start / was not already running.  Since parsing the upgrade_to option validates that the distro is appropriate, it would clear the Elevate::OS cache which could result in the script dying once leapp finished elevating.  This change ensures that the validation that the script can start occurs before parsing the upgrade_to option.

Changelog: Validate script can execute start option before parsing
 upgrade_to option

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

