### PR TITLE
Modularize stage logic

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -64,12 +64,15 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Fetch.pm'}                         = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Leapp.pm'}                         = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Logger.pm'}                        = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Marker.pm'}                        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Motd.pm'}                          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Notify.pm'}                        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Roles/Run.pm'}                     = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/RPM.pm'}                           = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Script.pm'}                        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Service.pm'}                       = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/StageFile.pm'}                     = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Stages.pm'}                        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/SystemctlService.pm'}              = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Usage.pm'}                         = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/DNF.pm'}                           = 'script/elevate-cpanel.PL.static';
@@ -134,7 +137,6 @@ BEGIN {    # Suppress load of all of these at earliest point.
     BEGIN {
         my @_DELEGATE_TO_CPEV = qw{
           getopt
-          update_stage_file
           upgrade_to_rocky
           upgrade_to_pretty_name
           should_run_leapp
@@ -552,7 +554,8 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     use cPstrict;
 
-    use Elevate::Database ();
+    use Elevate::Database  ();
+    use Elevate::StageFile ();
 
     use Cpanel::OS                         ();
     use Cpanel::Pkgr                       ();
@@ -735,7 +738,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
             EOS
         }
 
-        cpev::update_stage_file( { 'mysql-version' => $mysql_version } );
+        Elevate::StageFile::update_stage_file( { 'mysql-version' => $mysql_version } );
 
         return 0;
     }
@@ -752,7 +755,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
         require Cpanel::Services::Enabled;
         my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
 
-        cpev::update_stage_file( { 'mysql-enabled' => $enabled } );
+        Elevate::StageFile::update_stage_file( { 'mysql-enabled' => $enabled } );
         WARN( "MySQL is disabled. This must be enabled for MySQL upgrade to succeed.\n" . "We temporarily will enable it when it is needed to be enabled,\n" . "but we reccomend starting the process with MySQL enabled." ) if !$enabled;
         return 0;
     }
@@ -973,6 +976,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -997,7 +1001,7 @@ EOS
         INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 
         $self->cpev->component('EA4')->backup;                        # _backup_ea4_profile();
-        my $stash        = cpev::read_stage_file();                   # FIXME - move it to a function
+        my $stash        = Elevate::StageFile::read_stage_file();     # FIXME - move it to a function
         my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
         return unless scalar keys $dropped_pkgs->%*;
 
@@ -1097,6 +1101,7 @@ EOS
     use Cpanel::Pkgr ();
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -1143,7 +1148,7 @@ EOS
         current $deb directory, re-create $deb as a symlink to $rhel,
         and then copy as much of the old $deb into $rhel as possible.
         EOS
-            cpev::update_stage_file( { 'grub2_workaround' => { 'needs_workaround_update' => 1 } } ) if !$self->is_check_mode();    # don't update stage file if this is just a check
+            Elevate::StageFile::update_stage_file( { 'grub2_workaround' => { 'needs_workaround_update' => 1 } } ) if !$self->is_check_mode();    # don't update stage file if this is just a check
         }
         elsif ( $state == GRUB2_WORKAROUND_UNCERTAIN ) {
 
@@ -2323,7 +2328,6 @@ EOS
     BEGIN {
         my @_DELEGATE_TO_CPEV = qw{
           getopt
-          update_stage_file
           upgrade_to_rocky
           upgrade_to_pretty_name
           tmp_dir
@@ -2443,6 +2447,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     use Cwd ();
 
@@ -2465,14 +2470,14 @@ EOS
 
         return unless @installed_arch_cpanel_plugins;
 
-        cpev::update_stage_file( { restore => { yum => \@installed_arch_cpanel_plugins } } );
+        Elevate::StageFile::update_stage_file( { restore => { yum => \@installed_arch_cpanel_plugins } } );
 
         return;
     }
 
     sub post_leapp ($self) {
 
-        my $stash            = cpev::read_stage_file();
+        my $stash            = Elevate::StageFile::read_stage_file();
         my $yum_arch_plugins = $stash->{'restore'}->{'yum'} // [];
         return unless scalar @$yum_arch_plugins;
 
@@ -2495,6 +2500,7 @@ EOS
     use Elevate::Constants ();
     use Elevate::OS        ();
     use Elevate::RPM       ();
+    use Elevate::StageFile ();
     use Elevate::YUM       ();
 
     use Cwd ();
@@ -2549,7 +2555,7 @@ EOS
 
     sub _restore_ea_addons ($self) {
 
-        return unless cpev::read_stage_file('ea4')->{'nginx'};
+        return unless Elevate::StageFile::read_stage_file('ea4')->{'nginx'};
 
         INFO("Restoring ea-nginx");
 
@@ -2562,10 +2568,10 @@ EOS
     sub _backup_ea_addons ($self) {
 
         if ( Cpanel::Pkgr::is_installed('ea-nginx') ) {
-            cpev::update_stage_file( { ea4 => { nginx => 1 } } );
+            Elevate::StageFile::update_stage_file( { ea4 => { nginx => 1 } } );
         }
         else {
-            cpev::update_stage_file( { ea4 => { nginx => 0 } } );
+            Elevate::StageFile::update_stage_file( { ea4 => { nginx => 0 } } );
         }
 
         return;
@@ -2575,8 +2581,8 @@ EOS
 
         my $use_ea4 = Cpanel::Config::Httpd::is_ea4() ? 1 : 0;
 
-        cpev::remove_from_stage_file('ea4');
-        cpev::update_stage_file( { ea4 => { enable => $use_ea4 } } );
+        Elevate::StageFile::remove_from_stage_file('ea4');
+        Elevate::StageFile::update_stage_file( { ea4 => { enable => $use_ea4 } } );
 
         unless ($use_ea4) {
 
@@ -2594,7 +2600,7 @@ EOS
             $data->{dropped_pkgs} = $profile->{os_upgrade}->{dropped_pkgs};
         }
 
-        cpev::update_stage_file( { ea4 => $data } );    # FIXME
+        Elevate::StageFile::update_stage_file( { ea4 => $data } );    # FIXME
 
         return 1;
     }
@@ -2645,7 +2651,7 @@ EOS
 
     sub _restore_ea4_profile ($self) {
 
-        my $stash      = cpev::read_stage_file();
+        my $stash      = Elevate::StageFile::read_stage_file();
         my $is_enabled = $stash->{'ea4'} && $stash->{'ea4'}->{'enable'};
 
         unless ($is_enabled) {
@@ -2679,12 +2685,12 @@ EOS
 
     sub _backup_config_files ($self) {
 
-        cpev::remove_from_stage_file('ea4_config_files');
+        Elevate::StageFile::remove_from_stage_file('ea4_config_files');
 
         my $ea4_regex        = qr/^EA4(:?-c7)?/a;
         my $ea4_config_files = $self->rpm->get_config_files_for_repo($ea4_regex);
 
-        cpev::update_stage_file( { ea4_config_files => $ea4_config_files } );
+        Elevate::StageFile::update_stage_file( { ea4_config_files => $ea4_config_files } );
 
         return;
     }
@@ -2701,7 +2707,7 @@ EOS
 
     sub _restore_config_files ($self) {
 
-        my $config_files = cpev::read_stage_file('ea4_config_files');
+        my $config_files = Elevate::StageFile::read_stage_file('ea4_config_files');
 
         foreach my $key ( sort keys %$config_files ) {
             INFO("Restoring config files for package: '$key'");
@@ -2728,6 +2734,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     use Cwd ();
 
@@ -2760,7 +2767,7 @@ EOS
 
     sub _update_grub2_workaround_if_needed ($self) {
 
-        my $grub2_info = cpev::read_stage_file('grub2_workaround');
+        my $grub2_info = Elevate::StageFile::read_stage_file('grub2_workaround');
         return unless $grub2_info->{'needs_workaround_update'};
 
         my $grub_dir  = GRUB2_PREFIX_DEBIAN;
@@ -2772,7 +2779,7 @@ EOS
         }
         else {
             $grub_bak = $grub2_info->{'backup_dir'} = $grub_dir . '-' . time;
-            cpev::update_stage_file( { 'grub2_workaround' => $grub2_info } );
+            Elevate::StageFile::update_stage_file( { 'grub2_workaround' => $grub2_info } );
         }
 
         rename $grub_dir, $grub_bak or LOGDIE("Unable to rename $grub_dir to $grub_bak: $!");    # failure on cross-device move is a feature
@@ -2786,7 +2793,7 @@ EOS
 
     sub _merge_grub_directories_if_needed ($self) {
 
-        my $grub2_info = cpev::read_stage_file('grub2_workaround');
+        my $grub2_info = Elevate::StageFile::read_stage_file('grub2_workaround');
         return unless $grub2_info->{'needs_workaround_update'};
 
         my $grub_dir  = GRUB2_PREFIX_DEBIAN;
@@ -2892,6 +2899,7 @@ EOS
     use Elevate::Fetch     ();
     use Elevate::Notify    ();
     use Elevate::OS        ();
+    use Elevate::StageFile ();
 
     use Cwd ();
 
@@ -2942,14 +2950,14 @@ EOS
 
         return unless scalar @packages;
 
-        cpev::update_stage_file( { 'reinstall' => { 'imunify_packages' => \@packages } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify_packages' => \@packages } } );
 
         return;
     }
 
     sub _restore_imunify_packages ($self) {
 
-        return unless my $packages = cpev::read_stage_file('reinstall')->{'imunify_packages'};
+        return unless my $packages = Elevate::StageFile::read_stage_file('reinstall')->{'imunify_packages'};
 
         foreach my $pkg (@$packages) {
             next unless Cpanel::Pkgr::is_installed($pkg);
@@ -2970,14 +2978,14 @@ EOS
             File::Copy::move( IMUNIFY_LICENSE_FILE, IMUNIFY_LICENSE_BACKUP );
         }
 
-        cpev::update_stage_file( { 'reinstall' => { 'imunify_features' => \@features } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify_features' => \@features } } );
 
         return;
     }
 
     sub _restore_imunify_features {
 
-        return unless my $features = cpev::read_stage_file('reinstall')->{'imunify_features'};
+        return unless my $features = Elevate::StageFile::read_stage_file('reinstall')->{'imunify_features'};
 
         File::Copy::move( IMUNIFY_LICENSE_BACKUP, IMUNIFY_LICENSE_FILE ) if -f IMUNIFY_LICENSE_BACKUP;
 
@@ -3099,7 +3107,7 @@ EOS
         }
         unlink $installer_script;
 
-        cpev::update_stage_file( { 'reinstall' => { 'imunify360' => $product_type } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify360' => $product_type } } );
 
         $self->remove_rpms_from_repos('imunify');
 
@@ -3107,7 +3115,7 @@ EOS
     }
 
     sub _reinstall_imunify_360 ($self) {
-        my $product_type = cpev::read_stage_file('reinstall')->{'imunify360'} or return;
+        my $product_type = Elevate::StageFile::read_stage_file('reinstall')->{'imunify360'} or return;
 
         INFO("Reinstalling $product_type");
 
@@ -3162,6 +3170,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     use Cpanel::Pkgr ();
     use Cwd          ();
@@ -3175,19 +3184,19 @@ EOS
 
     sub pre_leapp ($self) {
 
-        cpev::remove_from_stage_file('reinstall.influxdb');
+        Elevate::StageFile::remove_from_stage_file('reinstall.influxdb');
 
         return unless Cpanel::Pkgr::is_installed('telegraf');
 
         INFO("Not removing influxdb. Will re-install it after elevate.");
-        cpev::update_stage_file( { 'reinstall' => { 'influxdb' => 1 } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'influxdb' => 1 } } );
 
         return;
     }
 
     sub post_leapp ($self) {
 
-        return unless cpev::read_stage_file('reinstall')->{'influxdb'};
+        return unless Elevate::StageFile::read_stage_file('reinstall')->{'influxdb'};
 
         INFO("Re-installing telegraf for influxdb");
         $self->ssystem_and_die(qw{/usr/bin/yum -y reinstall telegraf});
@@ -3207,6 +3216,7 @@ EOS
 
     use Cpanel::Pkgr       ();
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     use Cwd ();
 
@@ -3219,7 +3229,7 @@ EOS
 
     sub pre_leapp ($self) {
 
-        cpev::remove_from_stage_file('reinstall.jetbackup');
+        Elevate::StageFile::remove_from_stage_file('reinstall.jetbackup');
 
         return unless Cpanel::Pkgr::is_installed('jetbackup5-cpanel');
 
@@ -3238,7 +3248,7 @@ EOS
             packages => \@reinstall,
         };
 
-        cpev::update_stage_file( { 'reinstall' => { 'jetbackup' => $data } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'jetbackup' => $data } } );
 
         $self->ssystem(qw{/usr/bin/rpm -e --nodeps jetphp81-zip});
 
@@ -3247,7 +3257,7 @@ EOS
 
     sub post_leapp ($self) {
 
-        my $data = cpev::read_stage_file('reinstall')->{'jetbackup'};
+        my $data = Elevate::StageFile::read_stage_file('reinstall')->{'jetbackup'};
         return unless ref $data && ref $data->{packages};
 
         INFO("Re-installing jetbackup.");
@@ -3272,6 +3282,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     use Cwd ();
 
@@ -3284,7 +3295,7 @@ EOS
 
     sub pre_leapp ($self) {
 
-        cpev::remove_from_stage_file('reinstall.litespeed');
+        Elevate::StageFile::remove_from_stage_file('reinstall.litespeed');
 
         my $ls_cfg_dir = q[/usr/local/lsws/conf];
         return unless -d $ls_cfg_dir;
@@ -3298,14 +3309,14 @@ EOS
             has_valid_license => $has_valid_license,
         };
 
-        cpev::update_stage_file( { 'reinstall' => { 'litespeed' => $data } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'litespeed' => $data } } );
 
         return;
     }
 
     sub post_leapp ($self) {
 
-        my $data = cpev::read_stage_file('reinstall')->{'litespeed'};
+        my $data = Elevate::StageFile::read_stage_file('reinstall')->{'litespeed'};
         return unless ref $data;
 
         INFO("Checking LiteSpeed");
@@ -3332,6 +3343,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::OS        ();
+    use Elevate::StageFile ();
 
     use Cwd        ();
     use File::Copy ();
@@ -3369,13 +3381,13 @@ EOS
         local $ENV{KCARE_KEEP_REGISTRATION} = '1';
         $self->remove_rpms_from_repos('kernelcare');
 
-        cpev::update_stage_file( { 'reinstall' => { 'kernelcare' => 1 } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'kernelcare' => 1 } } );
 
         return 1;
     }
 
     sub _restore_kernelcare ($self) {
-        return unless cpev::read_stage_file('reinstall')->{'kernelcare'};
+        return unless Elevate::StageFile::read_stage_file('reinstall')->{'kernelcare'};
 
         INFO("Restoring kernelcare");
 
@@ -3470,8 +3482,9 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
-    use Elevate::Database ();
-    use Elevate::Notify   ();
+    use Elevate::Database  ();
+    use Elevate::Notify    ();
+    use Elevate::StageFile ();
 
     # use Elevate::Components::Base();
     our @ISA;
@@ -3498,12 +3511,12 @@ EOS
 
     sub _cleanup_mysql_packages ($self) {
 
-        my $mysql_version = cpev::read_stage_file( 'mysql-version', '' );
+        my $mysql_version = Elevate::StageFile::read_stage_file( 'mysql-version', '' );
         return unless length $mysql_version;
 
         INFO("# Cleanup MySQL packages ; using version $mysql_version");
 
-        cpev::update_stage_file( { 'mysql-version' => $mysql_version } );
+        Elevate::StageFile::update_stage_file( { 'mysql-version' => $mysql_version } );
 
         File::Copy::copy( $cnf_file, "$cnf_file.rpmsave_pre_elevate" ) or WARN("Couldn't backup $cnf_file to $cnf_file.rpmsave_pre_elevate: $!");
 
@@ -3525,8 +3538,8 @@ EOS
 
     sub _reinstall_mysql_packages {
 
-        my $mysql_version = cpev::read_stage_file( 'mysql-version', '' ) or return;
-        my $enabled       = cpev::read_stage_file( 'mysql-enabled', '' ) or return;
+        my $mysql_version = Elevate::StageFile::read_stage_file( 'mysql-version', '' ) or return;
+        my $enabled       = Elevate::StageFile::read_stage_file( 'mysql-enabled', '' ) or return;
 
         INFO("Restoring MySQL $mysql_version");
 
@@ -3674,6 +3687,7 @@ EOS
     use Elevate::SystemctlService ();
     use Elevate::Fetch            ();
     use Elevate::Notify           ();
+    use Elevate::StageFile        ();
 
     use Cwd ();
 
@@ -3755,13 +3769,13 @@ EOS
             to_restore      => $to_restore,
         };
 
-        cpev::update_stage_file( { 'reinstall' => { 'nixstats' => $data } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'nixstats' => $data } } );
 
         return;
     }
 
     sub _restore_nixstats ($self) {
-        my $data = cpev::read_stage_file('reinstall')->{'nixstats'};
+        my $data = Elevate::StageFile::read_stage_file('reinstall')->{'nixstats'};
         return unless ref $data;
 
         INFO("Restoring nixstats");
@@ -3819,6 +3833,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::StageFile ();
 
     use Cwd ();
 
@@ -3857,7 +3872,7 @@ EOS
 
     sub _check_pecl_packages ($self) {
 
-        my $pecl = cpev::read_stage_file('pecl');
+        my $pecl = Elevate::StageFile::read_stage_file('pecl');
 
         return unless ref $pecl && scalar keys $pecl->%*;
 
@@ -3914,11 +3929,11 @@ EOS
     sub _store_pecl_for ( $bin, $name ) {
         my $list = _get_pecl_installed_for($bin);
 
-        cpev::remove_from_stage_file("pecl.$name");
+        Elevate::StageFile::remove_from_stage_file("pecl.$name");
 
         return unless ref $list && scalar keys $list->%*;
 
-        cpev::update_stage_file( { pecl => { $name => $list } } );
+        Elevate::StageFile::update_stage_file( { pecl => { $name => $list } } );
 
         return;
     }
@@ -3957,6 +3972,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::Notify    ();
+    use Elevate::StageFile ();
 
     use Config;
     use Cwd ();
@@ -4050,13 +4066,13 @@ EOS
             }
         }
 
-        cpev::update_stage_file($stash);
+        Elevate::StageFile::update_stage_file($stash);
 
         return;
     }
 
     sub restore_perl_xs ( $self, $path ) {
-        my $stash = cpev::read_stage_file();
+        my $stash = Elevate::StageFile::read_stage_file();
 
         if ( $path eq DISTRO_PERL_XS_PATH ) {
             my $rpms = $stash->{'restore'}->{ DISTRO_PERL_XS_PATH() }->{'rpm'};
@@ -4360,6 +4376,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::Fetch     ();
+    use Elevate::StageFile ();
 
     use Cpanel::SafeRun::Errors ();
     use Cwd                     ();
@@ -4401,13 +4418,13 @@ EOS
         cpev::yum_list(1);    # Invalidate the cache since we just ran an rpm -e by hand.
         $self->remove_rpms_from_repos(qw/wp-toolkit-cpanel wp-toolkit-thirdparties/);
 
-        cpev::update_stage_file( { 'reinstall' => { 'wordpress_toolkit' => 1 } } );
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'wordpress_toolkit' => 1 } } );
 
         return;
     }
 
     sub _reinstall_wordpress_toolkit ($self) {
-        return unless cpev::read_stage_file('reinstall')->{'wordpress_toolkit'};
+        return unless Elevate::StageFile::read_stage_file('reinstall')->{'wordpress_toolkit'};
 
         INFO("Restoring Wordpress Toolkit");
         my $installer_script = Elevate::Fetch::script( 'https://wp-toolkit.plesk.com/cPanel/installer.sh', 'wptk_installer' );
@@ -4527,6 +4544,8 @@ EOS
 
     use Carp ();
 
+    use Elevate::StageFile ();
+
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
@@ -4538,7 +4557,7 @@ EOS
     our $OS;
 
     sub factory {
-        my $distro_with_version = cpev::read_stage_file( 'upgrade_from', '' );
+        my $distro_with_version = Elevate::StageFile::read_stage_file( 'upgrade_from', '' );
 
         my $distro;
         my $major;
@@ -4611,10 +4630,10 @@ EOS
         my $sub = $AUTOLOAD;
         $sub =~ s/.*:://;
 
-        exists $methods{$sub} or Carp::Croak("$sub is not a supported data variable for Elevate::OS");
+        exists $methods{$sub} or Carp::croak("$sub is not a supported data variable for Elevate::OS");
 
         my $i   = instance();
-        my $can = $i->can($sub) or Carp::Croak( ref($i) . " does not implement $sub" );
+        my $can = $i->can($sub) or Carp::croak( ref($i) . " does not implement $sub" );
         return $can->( $i, @_ );
     }
 
@@ -4626,17 +4645,17 @@ EOS
 
     sub upgrade_to () {
         my $default = Elevate::OS::default_upgrade_to();
-        return cpev::read_stage_file( 'upgrade_to', $default );
+        return Elevate::StageFile::read_stage_file( 'upgrade_to', $default );
     }
 
     sub clear_cache () {
         undef $OS unless $INC{'Test/Elevate.pm'};
-        cpev::remove_from_stage_file('upgrade_from');
+        Elevate::StageFile::remove_from_stage_file('upgrade_from');
         return;
     }
 
     sub _set_cache () {
-        cpev::update_stage_file( { upgrade_from => Elevate::OS::name() } );
+        Elevate::StageFile::update_stage_file( { upgrade_from => Elevate::OS::name() } );
         return;
     }
 
@@ -4817,7 +4836,8 @@ EOS
 
     use cPstrict;
 
-    use Elevate::OS ();
+    use Elevate::OS        ();
+    use Elevate::StageFile ();
 
     use Cpanel::Pkgr ();
 
@@ -4826,13 +4846,13 @@ EOS
     sub is_database_provided_by_cloudlinux ( $use_cache = 1 ) {
 
         if ($use_cache) {
-            my $cloudlinux_database_installed = cpev::read_stage_file( 'cloudlinux_database_installed', '' );
+            my $cloudlinux_database_installed = Elevate::StageFile::read_stage_file( 'cloudlinux_database_installed', '' );
 
             return $cloudlinux_database_installed if length $cloudlinux_database_installed;
         }
 
         if ( !Elevate::OS::provides_mysql_governor() ) {
-            cpev::update_stage_file( { cloudlinux_database_installed => 0 } );
+            Elevate::StageFile::update_stage_file( { cloudlinux_database_installed => 0 } );
             return 0;
         }
 
@@ -4845,7 +4865,7 @@ EOS
     sub get_db_info_if_provided_by_cloudlinux ( $use_cache = 1 ) {
 
         if ($use_cache) {
-            my $cloudlinux_database_info = cpev::read_stage_file( 'cloudlinux_database_info', '' );
+            my $cloudlinux_database_info = Elevate::StageFile::read_stage_file( 'cloudlinux_database_info', '' );
             return ( $cloudlinux_database_info->{db_type}, $cloudlinux_database_info->{db_version} )
               if length $cloudlinux_database_info;
         }
@@ -4855,10 +4875,10 @@ EOS
         my ( $db_type, $db_version ) = $pkg =~ m/^cl-(mysql|mariadb|percona)([0-9]+)-server$/i;
 
         my $cloudlinux_database_installed = ( $db_type && $db_version ) ? 1 : 0;
-        cpev::update_stage_file( { cloudlinux_database_installed => $cloudlinux_database_installed } );
+        Elevate::StageFile::update_stage_file( { cloudlinux_database_installed => $cloudlinux_database_installed } );
 
         if ($cloudlinux_database_installed) {
-            cpev::update_stage_file(
+            Elevate::StageFile::update_stage_file(
                 {
                     cloudlinux_database_info => {
                         db_type    => lc $db_type,
@@ -4929,8 +4949,9 @@ EOS
     use Cpanel::JSON ();
     use Cpanel::Pkgr ();
 
-    use Elevate::OS  ();
-    use Elevate::YUM ();
+    use Elevate::OS        ();
+    use Elevate::StageFile ();
+    use Elevate::YUM       ();
 
     use Config::Tiny ();
 
@@ -5007,7 +5028,7 @@ EOS
         INFO("Running leapp upgrade");
 
         my $ok = eval {
-            local $ENV{LEAPP_OVL_SIZE} = cpev::read_stage_file('env')->{'LEAPP_OVL_SIZE'} || 3000;
+            local $ENV{LEAPP_OVL_SIZE} = Elevate::StageFile::read_stage_file('env')->{'LEAPP_OVL_SIZE'} || 3000;
             $self->cpev->ssystem_and_die( { keep_env => 1 }, $leapp_bin, @leapp_args );
             1;
         };
@@ -5298,6 +5319,78 @@ EOS
 
 }    # --- END lib/Elevate/Logger.pm
 
+{    # --- BEGIN lib/Elevate/Marker.pm
+
+    package Elevate::Marker;
+
+    use cPstrict;
+
+    use POSIX ();
+
+    use Cpanel::LoadFile      ();
+    use Cpanel::MD5           ();
+    use Cpanel::Version::Tiny ();
+
+    use Elevate::StageFile ();
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    sub startup ( $sum = undef ) {
+
+        $sum //= Cpanel::MD5::getmd5sum($0);
+        chomp($sum);
+        _write_debug_line($sum);
+
+        Elevate::StageFile::update_stage_file(
+            {
+                '_elevate_process' => {
+                    script_md5            => $sum,
+                    cpanel_build          => $Cpanel::Version::Tiny::VERSION_BUILD,
+                    started_at            => _bq_now(),
+                    redhat_release_pre    => _read_redhat_release(),
+                    elevate_version_start => cpev::VERSION(),
+                }
+            }
+        );
+
+        return;
+    }
+
+    sub success () {
+
+        Elevate::StageFile::update_stage_file(
+            {
+                '_elevate_process' => {
+                    finished_at            => _bq_now(),
+                    redhat_release_post    => _read_redhat_release(),
+                    elevate_version_finish => cpev::VERSION(),
+                }
+            }
+        );
+
+        return;
+    }
+
+    sub _bq_now () {
+        return POSIX::strftime( '%FT%T', gmtime );
+    }
+
+    sub _read_redhat_release() {
+        my ($first_line) = split( "\n", Cpanel::LoadFile::loadfile('/etc/redhat-release') // '' );
+
+        return $first_line;
+    }
+
+    sub _write_debug_line ($sum) {
+        DEBUG( sprintf( "Running $0 (%s/%s)", -s $0, $sum ) );
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Marker.pm
+
 {    # --- BEGIN lib/Elevate/Motd.pm
 
     package Elevate::Motd;
@@ -5383,6 +5476,8 @@ EOS
 
     use cPstrict;
 
+    use Elevate::StageFile ();
+
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
@@ -5392,11 +5487,11 @@ EOS
     }
 
     sub add_final_notification ( $msg, $warn_now = 0 ) {
-        my $stage_info = cpev::read_stage_file();
+        my $stage_info = Elevate::StageFile::read_stage_file();
 
         return unless defined $msg && length $msg;
 
-        cpev::update_stage_file( { final_notifications => [$msg] } );    # stacked to the previously stored
+        Elevate::StageFile::update_stage_file( { final_notifications => [$msg] } );    # stacked to the previously stored
 
         if ($warn_now) {
             foreach my $l ( split( "\n", $msg ) ) {
@@ -5734,6 +5829,7 @@ EOS
     INIT { Log::Log4perl->import(qw{:easy}); }
 
     use Elevate::Roles::Run ();    # for fatpck
+    use Elevate::Stages     ();
 
     use Simple::Accessor qw{
       name
@@ -5801,7 +5897,7 @@ EOS
         $self->ssystem_and_die( '/usr/bin/systemctl', 'daemon-reload' );
         $self->ssystem_and_die( '/usr/bin/systemctl', 'enable', $name );
 
-        $self->cpev->bump_stage();
+        Elevate::Stages::bump_stage();
 
         my $pid = fork();
         die qq[Failed to fork: $!] unless defined $pid;
@@ -5827,6 +5923,121 @@ EOS
     1;
 
 }    # --- END lib/Elevate/Service.pm
+
+{    # --- BEGIN lib/Elevate/StageFile.pm
+
+    package Elevate::StageFile;
+
+    use cPstrict;
+
+    use Cpanel::JSON ();
+
+    use File::Copy  ();
+    use Hash::Merge ();
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    use constant ELEVATE_STAGE_FILE   => '/var/cpanel/elevate';
+    use constant ELEVATE_SUCCESS_FILE => '/var/cpanel/version/elevate';
+
+    sub create_success_file () {
+        File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
+        return;
+    }
+
+    sub read_stage_file ( $k = undef, $default = {} ) {
+        my $stage_info = Elevate::StageFile::_read_stage_file() // {};
+
+        return $stage_info->{$k} // $default if defined $k;
+        return $stage_info;
+    }
+
+    sub remove_from_stage_file ($key) {
+        return unless length $key;
+
+        my $stage = Elevate::StageFile::read_stage_file();
+
+        my @list = split( qr/\./, $key );
+        return unless scalar @list;
+
+        my $to_delete = pop @list;
+
+        my $h = $stage;
+        while ( my $k = shift @list ) {
+            $h = $h->{$k};
+            last unless ref $h;
+        }
+
+        return if scalar @list;
+        return unless exists $h->{$to_delete};
+
+        delete $h->{$to_delete};
+
+        return Elevate::StageFile::_save_stage_file($stage);
+    }
+
+    sub remove_stage_file () {
+        unlink ELEVATE_STAGE_FILE;
+        return;
+    }
+
+    sub update_stage_file ($data) {
+
+        die q[Need a hash] unless ref $data eq 'HASH';
+
+        my $current = Elevate::StageFile::read_stage_file();
+        my $merged  = Hash::Merge::merge( $data, $current );
+
+        return Elevate::StageFile::_save_stage_file($merged);
+    }
+
+    sub _read_stage_file () {
+        return eval { Cpanel::JSON::LoadFile(ELEVATE_STAGE_FILE) };
+    }
+
+    sub _save_stage_file ($stash) {
+        open( my $fh, '>', ELEVATE_STAGE_FILE ) or LOGDIE( "Failed to open " . ELEVATE_STAGE_FILE . ": $!" );
+        print {$fh} Cpanel::JSON::pretty_canonical_dump($stash);
+        close $fh;
+
+        return 1;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/StageFile.pm
+
+{    # --- BEGIN lib/Elevate/Stages.pm
+
+    package Elevate::Stages;
+
+    use cPstrict;
+
+    sub bump_stage ( $by = 1 ) {
+
+        return Elevate::Stages::update_stage_number( Elevate::Stages::get_stage() + $by );
+    }
+
+    sub get_stage {
+        return Elevate::StageFile::read_stage_file( 'stage_number', 0 );
+    }
+
+    sub update_stage_number ($stage_id) {
+
+        if ( $stage_id > 10 ) {    # protection for stage
+            require Carp;
+            Carp::confess("Invalid stage number $stage_id");
+        }
+
+        Elevate::StageFile::update_stage_file( { stage_number => $stage_id } );
+
+        return $stage_id;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Stages.pm
 
 {    # --- BEGIN lib/Elevate/SystemctlService.pm
 
@@ -6478,12 +6689,15 @@ use Elevate::Database         ();
 use Elevate::Fetch            ();
 use Elevate::Leapp            ();
 use Elevate::Logger           ();
+use Elevate::Marker           ();
 use Elevate::Motd             ();
 use Elevate::Notify           ();
 use Elevate::Roles::Run       ();    # used as parent, but ensure fatpack
 use Elevate::RPM              ();
 use Elevate::Script           ();
 use Elevate::Service          ();
+use Elevate::StageFile        ();
+use Elevate::Stages           ();
 use Elevate::SystemctlService ();
 use Elevate::Usage            ();
 use Elevate::DNF              ();
@@ -6494,8 +6708,6 @@ use constant VERSION => 31;
 #>>V *** DO NOT EDIT THESE LINES MANUALLY ***
 
 use constant CHKSRVD_SUSPEND_FILE => q[/var/run/chkservd.suspend];
-use constant ELEVATE_STAGE_FILE   => '/var/cpanel/elevate';
-use constant ELEVATE_SUCCESS_FILE => '/var/cpanel/version/elevate';
 
 use constant VALID_STAGES => 5;
 
@@ -6589,7 +6801,7 @@ sub run ( $pkg, @args ) {
     return $self->do_cleanup()      if $self->getopt('clean');
     return $self->blockers->check() if defined $self->getopt('check');
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( $stage == 0 ) {
         print_box_no_log( <<~EOS );
@@ -6721,7 +6933,7 @@ sub upgrade_to_pretty_name ($self) {    # used by output messages
 }
 
 sub monitor_upgrade ($self) {
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     my $tail_msg = q[Running: tail -f ] . Elevate::Constants::LOG_FILE;
 
@@ -6744,7 +6956,7 @@ sub monitor_upgrade ($self) {
 }
 
 sub start ($self) {
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
     if ( $stage != 0 ) {
         my $header;
         if ( $stage > VALID_STAGES ) {
@@ -6776,12 +6988,12 @@ sub start ($self) {
 
     system touch => Elevate::Constants::LOG_FILE;
 
-    $self->bump_stage();    # init stage number to 1
+    Elevate::Stages::bump_stage();    # init stage number to 1
 
     # store the manual reboots flag
     if ( $self->getopt('manual-reboots') ) {
         WARN('Manual Reboot would be required between each stages');
-        update_stage_file( { manual_reboots => 1 } );
+        Elevate::StageFile::update_stage_file( { manual_reboots => 1 } );
     }
 
     $self->_capture_env_variables();    # capture at startup
@@ -6796,7 +7008,7 @@ sub start ($self) {
         Once the system has been successfully upgraded from 7 to 8 you can then remove that file
         to let the elevation process continue and update cPanel for the updated distribution.
         EOS
-        update_stage_file( { no_leapp => 1 } );
+        Elevate::StageFile::update_stage_file( { no_leapp => 1 } );
     }
 
     # prefer over running step1: so status and notifications are enabled
@@ -6806,7 +7018,7 @@ sub start ($self) {
 sub _capture_env_variables ($self) {
 
     if ( my $ovl_size = $ENV{LEAPP_OVL_SIZE} ) {
-        update_stage_file( { env => { LEAPP_OVL_SIZE => $ovl_size } } );
+        Elevate::StageFile::update_stage_file( { env => { LEAPP_OVL_SIZE => $ovl_size } } );
     }
 
     return;
@@ -6888,7 +7100,7 @@ sub continue_elevation ($self) {
     # check that no process is running and remove the pidfile for the other
     $self->check_and_create_pidfile()->remove_pid_file;
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
     if ( $stage == 0 ) {
         Elevate::Logger::ERROR_nolog("Looks like no elevate process was started. Please consider running: /scripts/elevate-cpanel --start");
         return;
@@ -6920,7 +7132,7 @@ sub do_cleanup ($self) {
     $self->service->remove;
 
     $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
-    unlink ELEVATE_STAGE_FILE;
+    Elevate::StageFile::remove_stage_file();
     unlink Elevate::Constants::PID_FILE;
 
     unlink Elevate::Blockers::OVH::OVH_MONITORING_TOUCH_FILE;
@@ -6935,11 +7147,11 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
     # check it outside the eval block to avoid notification from the command line
     $self->check_and_create_pidfile();
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( $stage >= 2 ) {
         my $status = $self->get_current_status();
-        update_stage_file( { status => q[running] } ) if $status ne 'paused';
+        Elevate::StageFile::update_stage_file( { status => q[running] } ) if $status ne 'paused';
     }
 
     my $action_todo;
@@ -6954,13 +7166,13 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
 
         # only notify a success when reaching the last stage
         if ( $stage == VALID_STAGES ) {
-            update_stage_file( { status => q[success] } );
+            Elevate::StageFile::update_stage_file( { status => q[success] } );
             $self->_notify_success();
-            File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
+            Elevate::StageFile::create_success_file();
         }
 
         if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
-            update_stage_file( { status => q[paused] } );
+            Elevate::StageFile::update_stage_file( { status => q[paused] } );
         }
         elsif ( $action_todo == ACTION_REBOOT_NEEDED ) {
             $self->reboot();
@@ -6969,7 +7181,7 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
     else {
         my $error = $@ // q[Unknown error];
 
-        update_stage_file( { status => q[failed] } );
+        Elevate::StageFile::update_stage_file( { status => q[failed] } );
         $self->_notify_error($error);
 
         LOGDIE($error);
@@ -6989,7 +7201,7 @@ sub check_and_create_pidfile ($self) {
 }
 
 sub check_status ($self) {
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( !$stage ) {
         Elevate::Logger::ERROR_nolog('Elevation process has not started yet.');
@@ -7030,7 +7242,7 @@ sub _notify_success ($self) {
 The cPanel & WHM server has completed the elevation process from $upgrade_from_name to $pretty_distro_name.
 EOS
 
-    if ( my $warnings = read_stage_file( 'final_notifications', [] ) ) {
+    if ( my $warnings = Elevate::StageFile::read_stage_file( 'final_notifications', [] ) ) {
         if ( scalar @$warnings ) {
             $msg .= "\nThe update to $pretty_distro_name was successful but please note that one ore more notifications require your attention:\n";
 
@@ -7047,7 +7259,7 @@ EOS
 
 sub _notify_error ( $self, $error = '' ) {
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     my $msg = <<"EOS";
 The elevation process failed during stage $stage.
@@ -7074,7 +7286,7 @@ EOS
 
 sub _run_service ($self) {
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     print_box( "Starting stage $stage of " . VALID_STAGES ) if $stage > 1;
 
@@ -7084,7 +7296,7 @@ sub _run_service ($self) {
     if ( Cpanel::OS::major() == 8 && 2 <= $stage && $stage <= 3 ) {
         WARN( "Detected " . Cpanel::OS::pretty_distro() . " while running stage $stage: swtiching to stage 4" );
         $stage = 4;
-        _update_stage_number($stage);
+        Elevate::Stages::update_stage_number($stage);
     }
 
     return $stage == 1
@@ -7102,7 +7314,7 @@ sub _wait_on_pause ($self) {
     my $pause_file = PAUSE_ELEVATE_TOUCHFILE;
     return unless -e $pause_file;
 
-    update_stage_file( { status => q[paused] } );
+    Elevate::StageFile::update_stage_file( { status => q[paused] } );
 
     WARN( <<~"EOS" );
     The elevation process is currently paused by $pause_file
@@ -7113,9 +7325,9 @@ sub _wait_on_pause ($self) {
         sleep 5;
     }
 
-    update_stage_file( { status => q[running] } );
+    Elevate::StageFile::update_stage_file( { status => q[running] } );
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
     INFO("The pause file was removed. Continuing elevate process to stage $stage.");
 
     return 1;
@@ -7186,7 +7398,7 @@ sub run_stage_1 ($self) {
     print_box( "Starting stage 1 of " . VALID_STAGES . ": Installing " . $self->service->name . " service" );
 
     # store 'upgrade_to' early so later stages can access it
-    update_stage_file( { upgrade_to => $self->upgrade_to } );
+    Elevate::StageFile::update_stage_file( { upgrade_to => $self->upgrade_to } );
 
     return $self->service->install();
 }
@@ -7199,11 +7411,7 @@ Update the current distro packages then reboot.
 
 sub run_stage_2 ($self) {
 
-    my $sum = `/usr/bin/md5sum $0`;
-    chomp $sum;
-    DEBUG( sprintf( "Running $0 (%s/%s)", -s $0, $sum ) );
-
-    $self->elevation_startup_marker($sum);
+    Elevate::Marker::startup();
 
     # Remove scripts/upcp and bin/backup to make sure they don't
     # end up running while ELevate is running.
@@ -7310,7 +7518,7 @@ sub run_stage_4 ($self) {
 
         if ( Cpanel::OS::major() == 7 ) {
             WARN("Detected $current_distro from stage 4, reverting back to stage 3.");
-            _update_stage_number(3);
+            Elevate::Stages::update_stage_number(3);
         }
 
         die( <<~"END");
@@ -7328,7 +7536,7 @@ sub run_stage_4 ($self) {
         END
     }
 
-    my $stash = read_stage_file();
+    my $stash = Elevate::StageFile::read_stage_file();
 
     $stash->{stage4} //= {};    # run once each blocks
 
@@ -7396,7 +7604,8 @@ sub run_stage_5 ($self) {
 
     $self->run_component_once( 'Grub2' => 'post_leapp' );
 
-    $self->elevation_success_marker();
+    Elevate::Marker::success();
+
     $self->restore_outdated_services();
 
     INFO("Updating all packages before final reboot");
@@ -7407,44 +7616,6 @@ sub run_stage_5 ($self) {
     print_box("Great SUCCESS! Your upgrade to $pretty_distro_name is complete.");
 
     return ACTION_REBOOT_NEEDED;
-}
-
-sub _bq_now () {
-    require POSIX;
-    return POSIX::strftime( '%FT%T', gmtime );
-}
-
-sub elevation_startup_marker ( $self, $sum = 'unknown' ) {
-
-    # store some generic informations about the update process
-    update_stage_file(
-        {
-            '_elevate_process' => {
-                script_md5            => $sum,
-                cpanel_build          => $Cpanel::Version::Tiny::VERSION_BUILD,
-                started_at            => _bq_now(),
-                redhat_release_pre    => read_redhat_release(),
-                elevate_version_start => VERSION,
-            }
-        }
-    );
-
-    return;
-}
-
-sub elevation_success_marker ($self) {
-
-    update_stage_file(
-        {
-            '_elevate_process' => {
-                finished_at            => _bq_now(),
-                redhat_release_post    => read_redhat_release(),
-                elevate_version_finish => VERSION,
-            }
-        }
-    );
-
-    return;
 }
 
 sub run_component_once ( $self, $name, $function ) {
@@ -7470,10 +7641,10 @@ sub run_once ( $self, $label, $code = undef ) {
 
     die unless ref $code eq 'CODE';
 
-    my $current_stage = get_stage() // 0;
+    my $current_stage = Elevate::Stages::get_stage() // 0;
     my $stage_name    = 'stage' . $current_stage;
 
-    my $stash = read_stage_file();
+    my $stash = Elevate::StageFile::read_stage_file();
     $stash->{'_run_once'} //= {};
 
     my $full_label = $stage_name . '_' . $label;
@@ -7487,7 +7658,7 @@ sub run_once ( $self, $label, $code = undef ) {
     $code->($self);
 
     # successfully run that block
-    update_stage_file( { _run_once => { $full_label => 1 } } );
+    Elevate::StageFile::update_stage_file( { _run_once => { $full_label => 1 } } );
 
     return;
 }
@@ -7579,7 +7750,7 @@ sub restore_outdated_services ($self) {
 }
 
 sub enable_all_cpanel_services ($self) {
-    my $services = read_stage_file( 'disabled_cpanel_services', [] );
+    my $services = Elevate::StageFile::read_stage_file( 'disabled_cpanel_services', [] );
     unless (@$services) {
         WARN('No cPanel services were disabled!');
     }
@@ -7623,7 +7794,7 @@ sub disable_all_cpanel_services ($self) {
 
         push @disabled_services, $name;
     }
-    update_stage_file( { 'disabled_cpanel_services' => [ sort @disabled_services ] } );
+    Elevate::StageFile::update_stage_file( { 'disabled_cpanel_services' => [ sort @disabled_services ] } );
 
     return;
 }
@@ -7803,93 +7974,19 @@ sub should_run_leapp ($self) {
     # we store the no_leapp option, but prefer using a positive check instead
     # we need to check to see if the no-leapp option is passed via CLI here too in order
     # to allow users to run this script with the '--check --no-leapp' options
-    my $no_leapp = read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
+    my $no_leapp = Elevate::StageFile::read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
     return !$no_leapp;
 }
 
 sub get_current_status ($self) {
-    return read_stage_file( 'status', 'unknown' );
-}
-
-sub read_stage_file ( $k = undef, $default = {} ) {
-    my $stage_info = _read_stage_file() // {};
-
-    return $stage_info->{$k} // $default if defined $k;
-    return $stage_info;
-}
-
-sub _read_stage_file {    # can be mocked during unit tests
-    return eval { Cpanel::JSON::LoadFile(ELEVATE_STAGE_FILE) };
-}
-
-sub save_stage_file ($stash) {
-    open( my $fh, '>', ELEVATE_STAGE_FILE ) or LOGDIE( "Failed to open " . ELEVATE_STAGE_FILE . ": $!" );
-    print {$fh} Cpanel::JSON::pretty_canonical_dump($stash);
-    close $fh;
-
-    return 1;
-}
-
-sub update_stage_file ($data) {
-
-    die q[Need a hash] unless ref $data eq 'HASH';
-
-    my $current = read_stage_file();
-    my $merged  = Hash::Merge::merge( $data, $current );
-
-    return save_stage_file($merged);
-}
-
-sub remove_from_stage_file ($key) {
-    return unless length $key;
-
-    my $stage = read_stage_file();
-
-    my @list = split( qr/\./, $key );
-    return unless scalar @list;
-
-    my $to_delete = pop @list;
-
-    my $h = $stage;
-    while ( my $k = shift @list ) {
-        $h = $h->{$k};
-        last unless ref $h;
-    }
-
-    return if scalar @list;
-    return unless exists $h->{$to_delete};
-
-    delete $h->{$to_delete};
-
-    return save_stage_file($stage);
-}
-
-sub get_stage {
-    return read_stage_file( 'stage_number', 0 );
-}
-
-sub bump_stage ( $self, $by = 1 ) {
-
-    return _update_stage_number( get_stage() + $by );
-}
-
-sub _update_stage_number ($stage_id) {
-
-    if ( $stage_id > 10 ) {    # protection for stage
-        require Carp;
-        Carp::confess("Invalid stage number $stage_id");
-    }
-
-    update_stage_file( { stage_number => $stage_id } );
-
-    return $stage_id;
+    return Elevate::StageFile::read_stage_file( 'status', 'unknown' );
 }
 
 sub reboot ($self) {
-    $self->bump_stage();
+    Elevate::Stages::bump_stage();
 
     # protection
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( $stage > VALID_STAGES + 1 ) {
         LOGDIE(qq[Cannot reboot reaching stage $stage]);
@@ -7913,13 +8010,7 @@ sub reboot ($self) {
 }
 
 sub request_manual_reboots() {
-    return !!read_stage_file( 'manual_reboots', 0 );
-}
-
-sub read_redhat_release() {
-    my ($first_line) = split( "\n", Cpanel::LoadFile::loadfile('/etc/redhat-release') // '' );
-
-    return $first_line;
+    return !!Elevate::StageFile::read_stage_file( 'manual_reboots', 0 );
 }
 
 1;

--- a/lib/Elevate/Blockers/Base.pm
+++ b/lib/Elevate/Blockers/Base.pm
@@ -41,7 +41,6 @@ sub cpev ($self) {
 BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
-      update_stage_file
       upgrade_to_rocky
       upgrade_to_pretty_name
       should_run_leapp

--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -12,7 +12,8 @@ Blockers for datbase: MySQL, PostgreSQL...
 
 use cPstrict;
 
-use Elevate::Database ();
+use Elevate::Database  ();
+use Elevate::StageFile ();
 
 use Cpanel::OS                         ();
 use Cpanel::Pkgr                       ();
@@ -200,7 +201,7 @@ sub _blocker_old_cpanel_mysql ( $self, $mysql_version = undef ) {
     }
 
     # store the MySQL version we started from
-    cpev::update_stage_file( { 'mysql-version' => $mysql_version } );
+    Elevate::StageFile::update_stage_file( { 'mysql-version' => $mysql_version } );
 
     return 0;
 }
@@ -217,7 +218,7 @@ sub _warning_mysql_not_enabled ($self) {
     require Cpanel::Services::Enabled;
     my $enabled = Cpanel::Services::Enabled::is_enabled('mysql');
 
-    cpev::update_stage_file( { 'mysql-enabled' => $enabled } );
+    Elevate::StageFile::update_stage_file( { 'mysql-enabled' => $enabled } );
     WARN( "MySQL is disabled. This must be enabled for MySQL upgrade to succeed.\n" . "We temporarily will enable it when it is needed to be enabled,\n" . "but we reccomend starting the process with MySQL enabled." ) if !$enabled;
     return 0;
 }

--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -13,6 +13,7 @@ Blocker to check EasyApache profile compatibility.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use parent qw{Elevate::Blockers::Base};
 
@@ -39,7 +40,7 @@ sub _blocker_ea4_profile ($self) {
     INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 
     $self->cpev->component('EA4')->backup;                        # _backup_ea4_profile();
-    my $stash        = cpev::read_stage_file();                   # FIXME - move it to a function
+    my $stash        = Elevate::StageFile::read_stage_file();     # FIXME - move it to a function
     my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
     return unless scalar keys $dropped_pkgs->%*;
 

--- a/lib/Elevate/Blockers/Grub2.pm
+++ b/lib/Elevate/Blockers/Grub2.pm
@@ -15,6 +15,7 @@ use cPstrict;
 use Cpanel::Pkgr ();
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use parent qw{Elevate::Blockers::Base};
 
@@ -57,7 +58,7 @@ sub _blocker_grub2_workaround ($self) {
         current $deb directory, re-create $deb as a symlink to $rhel,
         and then copy as much of the old $deb into $rhel as possible.
         EOS
-        cpev::update_stage_file( { 'grub2_workaround' => { 'needs_workaround_update' => 1 } } ) if !$self->is_check_mode();    # don't update stage file if this is just a check
+        Elevate::StageFile::update_stage_file( { 'grub2_workaround' => { 'needs_workaround_update' => 1 } } ) if !$self->is_check_mode();    # don't update stage file if this is just a check
     }
     elsif ( $state == GRUB2_WORKAROUND_UNCERTAIN ) {
 

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -29,7 +29,6 @@ use Log::Log4perl qw(:easy);
 BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
-      update_stage_file
       upgrade_to_rocky
       upgrade_to_pretty_name
       tmp_dir

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -15,6 +15,7 @@ use cPstrict;
 use Elevate::Constants ();
 use Elevate::OS        ();
 use Elevate::RPM       ();
+use Elevate::StageFile ();
 use Elevate::YUM       ();
 
 use Cwd           ();
@@ -82,7 +83,7 @@ sub _cleanup_rpm_db ($self) {
 
 sub _restore_ea_addons ($self) {
 
-    return unless cpev::read_stage_file('ea4')->{'nginx'};
+    return unless Elevate::StageFile::read_stage_file('ea4')->{'nginx'};
 
     INFO("Restoring ea-nginx");
 
@@ -96,10 +97,10 @@ sub _restore_ea_addons ($self) {
 sub _backup_ea_addons ($self) {
 
     if ( Cpanel::Pkgr::is_installed('ea-nginx') ) {
-        cpev::update_stage_file( { ea4 => { nginx => 1 } } );
+        Elevate::StageFile::update_stage_file( { ea4 => { nginx => 1 } } );
     }
     else {
-        cpev::update_stage_file( { ea4 => { nginx => 0 } } );
+        Elevate::StageFile::update_stage_file( { ea4 => { nginx => 0 } } );
     }
 
     return;
@@ -109,8 +110,8 @@ sub _backup_ea4_profile ($self) {    ## _backup_ea4_profile
 
     my $use_ea4 = Cpanel::Config::Httpd::is_ea4() ? 1 : 0;
 
-    cpev::remove_from_stage_file('ea4');
-    cpev::update_stage_file( { ea4 => { enable => $use_ea4 } } );
+    Elevate::StageFile::remove_from_stage_file('ea4');
+    Elevate::StageFile::update_stage_file( { ea4 => { enable => $use_ea4 } } );
 
     unless ($use_ea4) {
 
@@ -129,7 +130,7 @@ sub _backup_ea4_profile ($self) {    ## _backup_ea4_profile
         $data->{dropped_pkgs} = $profile->{os_upgrade}->{dropped_pkgs};
     }
 
-    cpev::update_stage_file( { ea4 => $data } );    # FIXME
+    Elevate::StageFile::update_stage_file( { ea4 => $data } );    # FIXME
 
     return 1;
 }
@@ -183,7 +184,7 @@ sub _get_ea4_profile ($self) {
 
 sub _restore_ea4_profile ($self) {
 
-    my $stash      = cpev::read_stage_file();
+    my $stash      = Elevate::StageFile::read_stage_file();
     my $is_enabled = $stash->{'ea4'} && $stash->{'ea4'}->{'enable'};
 
     unless ($is_enabled) {
@@ -217,12 +218,12 @@ sub _restore_ea4_profile ($self) {
 
 sub _backup_config_files ($self) {
 
-    cpev::remove_from_stage_file('ea4_config_files');
+    Elevate::StageFile::remove_from_stage_file('ea4_config_files');
 
     my $ea4_regex        = qr/^EA4(:?-c7)?/a;
     my $ea4_config_files = $self->rpm->get_config_files_for_repo($ea4_regex);
 
-    cpev::update_stage_file( { ea4_config_files => $ea4_config_files } );
+    Elevate::StageFile::update_stage_file( { ea4_config_files => $ea4_config_files } );
 
     return;
 }
@@ -239,7 +240,7 @@ our %config_files_to_ignore = (
 
 sub _restore_config_files ($self) {
 
-    my $config_files = cpev::read_stage_file('ea4_config_files');
+    my $config_files = Elevate::StageFile::read_stage_file('ea4_config_files');
 
     foreach my $key ( sort keys %$config_files ) {
         INFO("Restoring config files for package: '$key'");

--- a/lib/Elevate/Components/Grub2.pm
+++ b/lib/Elevate/Components/Grub2.pm
@@ -13,6 +13,7 @@ Logic to update and fix grub2 configuration.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -41,7 +42,7 @@ sub GRUB2_PREFIX_RHEL   { return '/boot/grub2' }    # FIXME deduplicate & move t
 
 sub _update_grub2_workaround_if_needed ($self) {
 
-    my $grub2_info = cpev::read_stage_file('grub2_workaround');
+    my $grub2_info = Elevate::StageFile::read_stage_file('grub2_workaround');
     return unless $grub2_info->{'needs_workaround_update'};
 
     my $grub_dir  = GRUB2_PREFIX_DEBIAN;
@@ -53,7 +54,7 @@ sub _update_grub2_workaround_if_needed ($self) {
     }
     else {
         $grub_bak = $grub2_info->{'backup_dir'} = $grub_dir . '-' . time;
-        cpev::update_stage_file( { 'grub2_workaround' => $grub2_info } );
+        Elevate::StageFile::update_stage_file( { 'grub2_workaround' => $grub2_info } );
     }
 
     rename $grub_dir, $grub_bak or LOGDIE("Unable to rename $grub_dir to $grub_bak: $!");    # failure on cross-device move is a feature
@@ -67,7 +68,7 @@ sub _update_grub2_workaround_if_needed ($self) {
 
 sub _merge_grub_directories_if_needed ($self) {
 
-    my $grub2_info = cpev::read_stage_file('grub2_workaround');
+    my $grub2_info = Elevate::StageFile::read_stage_file('grub2_workaround');
     return unless $grub2_info->{'needs_workaround_update'};
 
     my $grub_dir  = GRUB2_PREFIX_DEBIAN;

--- a/lib/Elevate/Components/Imunify.pm
+++ b/lib/Elevate/Components/Imunify.pm
@@ -16,6 +16,7 @@ use Elevate::Constants ();
 use Elevate::Fetch     ();
 use Elevate::Notify    ();
 use Elevate::OS        ();
+use Elevate::StageFile ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -64,7 +65,7 @@ sub _capture_imunify_packages ($self) {
 
     return unless scalar @packages;
 
-    cpev::update_stage_file( { 'reinstall' => { 'imunify_packages' => \@packages } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify_packages' => \@packages } } );
 
     return;
 }
@@ -73,7 +74,7 @@ sub _restore_imunify_packages ($self) {
 
     # try to reinstall missing Imunify packages which were previously installed
 
-    return unless my $packages = cpev::read_stage_file('reinstall')->{'imunify_packages'};
+    return unless my $packages = Elevate::StageFile::read_stage_file('reinstall')->{'imunify_packages'};
 
     foreach my $pkg (@$packages) {
         next unless Cpanel::Pkgr::is_installed($pkg);
@@ -94,14 +95,14 @@ sub _capture_imunify_features {
         File::Copy::move( IMUNIFY_LICENSE_FILE, IMUNIFY_LICENSE_BACKUP );
     }
 
-    cpev::update_stage_file( { 'reinstall' => { 'imunify_features' => \@features } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify_features' => \@features } } );
 
     return;
 }
 
 sub _restore_imunify_features {
 
-    return unless my $features = cpev::read_stage_file('reinstall')->{'imunify_features'};
+    return unless my $features = Elevate::StageFile::read_stage_file('reinstall')->{'imunify_features'};
 
     File::Copy::move( IMUNIFY_LICENSE_BACKUP, IMUNIFY_LICENSE_FILE ) if -f IMUNIFY_LICENSE_BACKUP;
 
@@ -228,7 +229,7 @@ sub _remove_imunify_360 ($self) {
     }
     unlink $installer_script;
 
-    cpev::update_stage_file( { 'reinstall' => { 'imunify360' => $product_type } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify360' => $product_type } } );
 
     # Cleanup any lingering packages.
     $self->remove_rpms_from_repos('imunify');
@@ -237,7 +238,7 @@ sub _remove_imunify_360 ($self) {
 }
 
 sub _reinstall_imunify_360 ($self) {
-    my $product_type = cpev::read_stage_file('reinstall')->{'imunify360'} or return;
+    my $product_type = Elevate::StageFile::read_stage_file('reinstall')->{'imunify360'} or return;
 
     INFO("Reinstalling $product_type");
 

--- a/lib/Elevate/Components/InfluxDB.pm
+++ b/lib/Elevate/Components/InfluxDB.pm
@@ -13,6 +13,7 @@ Capture and reinstall InfluxDB packages.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use Cpanel::Pkgr  ();
 use Cwd           ();
@@ -22,19 +23,19 @@ use parent qw{Elevate::Components::Base};
 
 sub pre_leapp ($self) {
 
-    cpev::remove_from_stage_file('reinstall.influxdb');
+    Elevate::StageFile::remove_from_stage_file('reinstall.influxdb');
 
     return unless Cpanel::Pkgr::is_installed('telegraf');
 
     INFO("Not removing influxdb. Will re-install it after elevate.");
-    cpev::update_stage_file( { 'reinstall' => { 'influxdb' => 1 } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'influxdb' => 1 } } );
 
     return;
 }
 
 sub post_leapp ($self) {
 
-    return unless cpev::read_stage_file('reinstall')->{'influxdb'};
+    return unless Elevate::StageFile::read_stage_file('reinstall')->{'influxdb'};
 
     INFO("Re-installing telegraf for influxdb");
     $self->ssystem_and_die(qw{/usr/bin/yum -y reinstall telegraf});

--- a/lib/Elevate/Components/JetBackup.pm
+++ b/lib/Elevate/Components/JetBackup.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Cpanel::Pkgr       ();
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -22,7 +23,7 @@ use parent qw{Elevate::Components::Base};
 
 sub pre_leapp ($self) {
 
-    cpev::remove_from_stage_file('reinstall.jetbackup');
+    Elevate::StageFile::remove_from_stage_file('reinstall.jetbackup');
 
     return unless Cpanel::Pkgr::is_installed('jetbackup5-cpanel');
 
@@ -41,7 +42,7 @@ sub pre_leapp ($self) {
         packages => \@reinstall,
     };
 
-    cpev::update_stage_file( { 'reinstall' => { 'jetbackup' => $data } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'jetbackup' => $data } } );
 
     # Remove this package because leapp will remove it as it depends on libzip.so.2 which isn't available in 8.
     $self->ssystem(qw{/usr/bin/rpm -e --nodeps jetphp81-zip});
@@ -51,7 +52,7 @@ sub pre_leapp ($self) {
 
 sub post_leapp ($self) {
 
-    my $data = cpev::read_stage_file('reinstall')->{'jetbackup'};
+    my $data = Elevate::StageFile::read_stage_file('reinstall')->{'jetbackup'};
     return unless ref $data && ref $data->{packages};
 
     INFO("Re-installing jetbackup.");

--- a/lib/Elevate/Components/KernelCare.pm
+++ b/lib/Elevate/Components/KernelCare.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::OS        ();
+use Elevate::StageFile ();
 
 use Cwd            ();
 use File::Copy     ();
@@ -48,13 +49,13 @@ sub _remove_kernelcare_if_needed ($self) {
     local $ENV{KCARE_KEEP_REGISTRATION} = '1';
     $self->remove_rpms_from_repos('kernelcare');
 
-    cpev::update_stage_file( { 'reinstall' => { 'kernelcare' => 1 } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'kernelcare' => 1 } } );
 
     return 1;
 }
 
 sub _restore_kernelcare ($self) {
-    return unless cpev::read_stage_file('reinstall')->{'kernelcare'};
+    return unless Elevate::StageFile::read_stage_file('reinstall')->{'kernelcare'};
 
     INFO("Restoring kernelcare");
 

--- a/lib/Elevate/Components/LiteSpeed.pm
+++ b/lib/Elevate/Components/LiteSpeed.pm
@@ -13,6 +13,7 @@ Capture and reinstall LiteSpeed packages.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -21,7 +22,7 @@ use parent qw{Elevate::Components::Base};
 
 sub pre_leapp ($self) {
 
-    cpev::remove_from_stage_file('reinstall.litespeed');
+    Elevate::StageFile::remove_from_stage_file('reinstall.litespeed');
 
     my $ls_cfg_dir = q[/usr/local/lsws/conf];
     return unless -d $ls_cfg_dir;
@@ -36,14 +37,14 @@ sub pre_leapp ($self) {
         has_valid_license => $has_valid_license,
     };
 
-    cpev::update_stage_file( { 'reinstall' => { 'litespeed' => $data } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'litespeed' => $data } } );
 
     return;
 }
 
 sub post_leapp ($self) {
 
-    my $data = cpev::read_stage_file('reinstall')->{'litespeed'};
+    my $data = Elevate::StageFile::read_stage_file('reinstall')->{'litespeed'};
     return unless ref $data;
 
     INFO("Checking LiteSpeed");

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -15,8 +15,9 @@ use cPstrict;
 use File::Copy    ();
 use Log::Log4perl qw(:easy);
 
-use Elevate::Database ();
-use Elevate::Notify   ();
+use Elevate::Database  ();
+use Elevate::Notify    ();
+use Elevate::StageFile ();
 
 use parent qw{Elevate::Components::Base};
 
@@ -41,12 +42,12 @@ sub post_leapp ($self) {
 
 sub _cleanup_mysql_packages ($self) {
 
-    my $mysql_version = cpev::read_stage_file( 'mysql-version', '' );
+    my $mysql_version = Elevate::StageFile::read_stage_file( 'mysql-version', '' );
     return unless length $mysql_version;
 
     INFO("# Cleanup MySQL packages ; using version $mysql_version");
 
-    cpev::update_stage_file( { 'mysql-version' => $mysql_version } );
+    Elevate::StageFile::update_stage_file( { 'mysql-version' => $mysql_version } );
 
     # Stash current config so we can restore it later.
     File::Copy::copy( $cnf_file, "$cnf_file.rpmsave_pre_elevate" ) or WARN("Couldn't backup $cnf_file to $cnf_file.rpmsave_pre_elevate: $!");
@@ -84,8 +85,8 @@ sub _remove_cpanel_mysql_packages ($self) {
 
 sub _reinstall_mysql_packages {
 
-    my $mysql_version = cpev::read_stage_file( 'mysql-version', '' ) or return;
-    my $enabled       = cpev::read_stage_file( 'mysql-enabled', '' ) or return;
+    my $mysql_version = Elevate::StageFile::read_stage_file( 'mysql-version', '' ) or return;
+    my $enabled       = Elevate::StageFile::read_stage_file( 'mysql-enabled', '' ) or return;
 
     INFO("Restoring MySQL $mysql_version");
 

--- a/lib/Elevate/Components/NixStats.pm
+++ b/lib/Elevate/Components/NixStats.pm
@@ -16,6 +16,7 @@ use Elevate::Constants        ();
 use Elevate::SystemctlService ();
 use Elevate::Fetch            ();
 use Elevate::Notify           ();
+use Elevate::StageFile        ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -94,13 +95,13 @@ sub _remove_nixstats ($self) {
         to_restore      => $to_restore,
     };
 
-    cpev::update_stage_file( { 'reinstall' => { 'nixstats' => $data } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'nixstats' => $data } } );
 
     return;
 }
 
 sub _restore_nixstats ($self) {
-    my $data = cpev::read_stage_file('reinstall')->{'nixstats'};
+    my $data = Elevate::StageFile::read_stage_file('reinstall')->{'nixstats'};
     return unless ref $data;
 
     INFO("Restoring nixstats");

--- a/lib/Elevate/Components/PECL.pm
+++ b/lib/Elevate/Components/PECL.pm
@@ -13,6 +13,7 @@ Capture and reinstall PECL packages.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -47,7 +48,7 @@ sub _backup_pecl_packages ($self) {
 
 sub _check_pecl_packages ($self) {
 
-    my $pecl = cpev::read_stage_file('pecl');
+    my $pecl = Elevate::StageFile::read_stage_file('pecl');
 
     return unless ref $pecl && scalar keys $pecl->%*;
 
@@ -106,11 +107,11 @@ sub _check_pecl_packages ($self) {
 sub _store_pecl_for ( $bin, $name ) {
     my $list = _get_pecl_installed_for($bin);
 
-    cpev::remove_from_stage_file("pecl.$name");
+    Elevate::StageFile::remove_from_stage_file("pecl.$name");
 
     return unless ref $list && scalar keys $list->%*;
 
-    cpev::update_stage_file( { pecl => { $name => $list } } );
+    Elevate::StageFile::update_stage_file( { pecl => { $name => $list } } );
 
     return;
 }

--- a/lib/Elevate/Components/PerlXS.pm
+++ b/lib/Elevate/Components/PerlXS.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::Notify    ();
+use Elevate::StageFile ();
 
 use Config;
 use Cwd           ();
@@ -104,13 +105,13 @@ sub purge_perl_xs ( $self, $path ) {
         }
     }
 
-    cpev::update_stage_file($stash);
+    Elevate::StageFile::update_stage_file($stash);
 
     return;
 }
 
 sub restore_perl_xs ( $self, $path ) {
-    my $stash = cpev::read_stage_file();
+    my $stash = Elevate::StageFile::read_stage_file();
 
     if ( $path eq DISTRO_PERL_XS_PATH ) {
         my $rpms = $stash->{'restore'}->{ DISTRO_PERL_XS_PATH() }->{'rpm'};

--- a/lib/Elevate/Components/WPToolkit.pm
+++ b/lib/Elevate/Components/WPToolkit.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::Fetch     ();
+use Elevate::StageFile ();
 
 use Cpanel::SafeRun::Errors ();
 use Cwd                     ();
@@ -51,13 +52,13 @@ sub _remove_wordpress_toolkit ($self) {
     cpev::yum_list(1);    # Invalidate the cache since we just ran an rpm -e by hand.
     $self->remove_rpms_from_repos(qw/wp-toolkit-cpanel wp-toolkit-thirdparties/);
 
-    cpev::update_stage_file( { 'reinstall' => { 'wordpress_toolkit' => 1 } } );
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'wordpress_toolkit' => 1 } } );
 
     return;
 }
 
 sub _reinstall_wordpress_toolkit ($self) {
-    return unless cpev::read_stage_file('reinstall')->{'wordpress_toolkit'};
+    return unless Elevate::StageFile::read_stage_file('reinstall')->{'wordpress_toolkit'};
 
     INFO("Restoring Wordpress Toolkit");
     my $installer_script = Elevate::Fetch::script( 'https://wp-toolkit.plesk.com/cPanel/installer.sh', 'wptk_installer' );

--- a/lib/Elevate/Components/cPanelPlugins.pm
+++ b/lib/Elevate/Components/cPanelPlugins.pm
@@ -13,6 +13,7 @@ Remove and reinstall some arch RPMs. (plugins)
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::StageFile ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -32,7 +33,7 @@ sub pre_leapp ($self) {
 
     return unless @installed_arch_cpanel_plugins;
 
-    cpev::update_stage_file( { restore => { yum => \@installed_arch_cpanel_plugins } } );
+    Elevate::StageFile::update_stage_file( { restore => { yum => \@installed_arch_cpanel_plugins } } );
 
     return;
 }
@@ -41,7 +42,7 @@ sub post_leapp ($self) {
 
     # Restore YUM arch plugins.
 
-    my $stash            = cpev::read_stage_file();
+    my $stash            = Elevate::StageFile::read_stage_file();
     my $yum_arch_plugins = $stash->{'restore'}->{'yum'} // [];
     return unless scalar @$yum_arch_plugins;
 

--- a/lib/Elevate/Database.pm
+++ b/lib/Elevate/Database.pm
@@ -12,7 +12,8 @@ Helper/Utility logic for database related tasks.
 
 use cPstrict;
 
-use Elevate::OS ();
+use Elevate::OS        ();
+use Elevate::StageFile ();
 
 use Cpanel::Pkgr ();
 
@@ -21,7 +22,7 @@ use constant MYSQL_BIN => '/usr/sbin/mysqld';
 sub is_database_provided_by_cloudlinux ( $use_cache = 1 ) {
 
     if ($use_cache) {
-        my $cloudlinux_database_installed = cpev::read_stage_file( 'cloudlinux_database_installed', '' );
+        my $cloudlinux_database_installed = Elevate::StageFile::read_stage_file( 'cloudlinux_database_installed', '' );
 
         # cloudlinux_database_installed should only ever be 1 or 0 if it is set
         # by default, read_stage_file() will return '{}', but we are telling it to send back ''
@@ -31,7 +32,7 @@ sub is_database_provided_by_cloudlinux ( $use_cache = 1 ) {
     }
 
     if ( !Elevate::OS::provides_mysql_governor() ) {
-        cpev::update_stage_file( { cloudlinux_database_installed => 0 } );
+        Elevate::StageFile::update_stage_file( { cloudlinux_database_installed => 0 } );
         return 0;
     }
 
@@ -47,7 +48,7 @@ sub is_database_provided_by_cloudlinux ( $use_cache = 1 ) {
 sub get_db_info_if_provided_by_cloudlinux ( $use_cache = 1 ) {
 
     if ($use_cache) {
-        my $cloudlinux_database_info = cpev::read_stage_file( 'cloudlinux_database_info', '' );
+        my $cloudlinux_database_info = Elevate::StageFile::read_stage_file( 'cloudlinux_database_info', '' );
         return ( $cloudlinux_database_info->{db_type}, $cloudlinux_database_info->{db_version} )
           if length $cloudlinux_database_info;
     }
@@ -58,10 +59,10 @@ sub get_db_info_if_provided_by_cloudlinux ( $use_cache = 1 ) {
 
     # cache this data so we only need to query the package manager for it once
     my $cloudlinux_database_installed = ( $db_type && $db_version ) ? 1 : 0;
-    cpev::update_stage_file( { cloudlinux_database_installed => $cloudlinux_database_installed } );
+    Elevate::StageFile::update_stage_file( { cloudlinux_database_installed => $cloudlinux_database_installed } );
 
     if ($cloudlinux_database_installed) {
-        cpev::update_stage_file(
+        Elevate::StageFile::update_stage_file(
             {
                 cloudlinux_database_info => {
                     db_type    => lc $db_type,

--- a/lib/Elevate/Leapp.pm
+++ b/lib/Elevate/Leapp.pm
@@ -15,8 +15,9 @@ use cPstrict;
 use Cpanel::JSON ();
 use Cpanel::Pkgr ();
 
-use Elevate::OS  ();
-use Elevate::YUM ();
+use Elevate::OS        ();
+use Elevate::StageFile ();
+use Elevate::YUM       ();
 
 use Config::Tiny ();
 
@@ -92,7 +93,7 @@ sub upgrade ($self) {
     INFO("Running leapp upgrade");
 
     my $ok = eval {
-        local $ENV{LEAPP_OVL_SIZE} = cpev::read_stage_file('env')->{'LEAPP_OVL_SIZE'} || 3000;
+        local $ENV{LEAPP_OVL_SIZE} = Elevate::StageFile::read_stage_file('env')->{'LEAPP_OVL_SIZE'} || 3000;
         $self->cpev->ssystem_and_die( { keep_env => 1 }, $leapp_bin, @leapp_args );
         1;
     };

--- a/lib/Elevate/Marker.pm
+++ b/lib/Elevate/Marker.pm
@@ -1,0 +1,77 @@
+package Elevate::Marker;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Marker
+
+This library provides logic to add information about the elevate process to the
+stage file
+
+=cut
+
+use cPstrict;
+
+use POSIX ();
+
+use Cpanel::LoadFile      ();
+use Cpanel::MD5           ();
+use Cpanel::Version::Tiny ();
+
+use Elevate::StageFile ();
+
+use Log::Log4perl qw(:easy);
+
+sub startup ( $sum = undef ) {
+
+    $sum //= Cpanel::MD5::getmd5sum($0);
+    chomp($sum);
+    _write_debug_line($sum);
+
+    Elevate::StageFile::update_stage_file(
+        {
+            '_elevate_process' => {
+                script_md5            => $sum,
+                cpanel_build          => $Cpanel::Version::Tiny::VERSION_BUILD,
+                started_at            => _bq_now(),
+                redhat_release_pre    => _read_redhat_release(),
+                elevate_version_start => cpev::VERSION(),
+            }
+        }
+    );
+
+    return;
+}
+
+sub success () {
+
+    Elevate::StageFile::update_stage_file(
+        {
+            '_elevate_process' => {
+                finished_at            => _bq_now(),
+                redhat_release_post    => _read_redhat_release(),
+                elevate_version_finish => cpev::VERSION(),
+            }
+        }
+    );
+
+    return;
+}
+
+sub _bq_now () {
+    return POSIX::strftime( '%FT%T', gmtime );
+}
+
+sub _read_redhat_release() {
+    my ($first_line) = split( "\n", Cpanel::LoadFile::loadfile('/etc/redhat-release') // '' );
+
+    return $first_line;
+}
+
+sub _write_debug_line ($sum) {
+    DEBUG( sprintf( "Running $0 (%s/%s)", -s $0, $sum ) );
+    return;
+}
+
+1;

--- a/lib/Elevate/Notify.pm
+++ b/lib/Elevate/Notify.pm
@@ -12,6 +12,8 @@ Helpers to display or send some notifications to the customer during the elevati
 
 use cPstrict;
 
+use Elevate::StageFile ();
+
 use Log::Log4perl qw(:easy);
 
 # separate sub, so that it can be silenced during tests:
@@ -21,11 +23,11 @@ sub warn_skip_version_check {
 }
 
 sub add_final_notification ( $msg, $warn_now = 0 ) {
-    my $stage_info = cpev::read_stage_file();
+    my $stage_info = Elevate::StageFile::read_stage_file();
 
     return unless defined $msg && length $msg;
 
-    cpev::update_stage_file( { final_notifications => [$msg] } );    # stacked to the previously stored
+    Elevate::StageFile::update_stage_file( { final_notifications => [$msg] } );    # stacked to the previously stored
 
     if ($warn_now) {
         foreach my $l ( split( "\n", $msg ) ) {

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -14,6 +14,8 @@ use cPstrict;
 
 use Carp ();
 
+use Elevate::StageFile ();
+
 use Log::Log4perl qw(:easy);
 
 use constant SUPPORTED_DISTROS => (
@@ -24,7 +26,7 @@ use constant SUPPORTED_DISTROS => (
 our $OS;
 
 sub factory {
-    my $distro_with_version = cpev::read_stage_file( 'upgrade_from', '' );
+    my $distro_with_version = Elevate::StageFile::read_stage_file( 'upgrade_from', '' );
 
     my $distro;
     my $major;
@@ -103,10 +105,10 @@ sub AUTOLOAD {
     my $sub = $AUTOLOAD;
     $sub =~ s/.*:://;
 
-    exists $methods{$sub} or Carp::Croak("$sub is not a supported data variable for Elevate::OS");
+    exists $methods{$sub} or Carp::croak("$sub is not a supported data variable for Elevate::OS");
 
     my $i   = instance();
-    my $can = $i->can($sub) or Carp::Croak( ref($i) . " does not implement $sub" );
+    my $can = $i->can($sub) or Carp::croak( ref($i) . " does not implement $sub" );
     return $can->( $i, @_ );
 }
 
@@ -132,17 +134,17 @@ within the stages file.
 
 sub upgrade_to () {
     my $default = Elevate::OS::default_upgrade_to();
-    return cpev::read_stage_file( 'upgrade_to', $default );
+    return Elevate::StageFile::read_stage_file( 'upgrade_to', $default );
 }
 
 sub clear_cache () {
     undef $OS unless $INC{'Test/Elevate.pm'};
-    cpev::remove_from_stage_file('upgrade_from');
+    Elevate::StageFile::remove_from_stage_file('upgrade_from');
     return;
 }
 
 sub _set_cache () {
-    cpev::update_stage_file( { upgrade_from => Elevate::OS::name() } );
+    Elevate::StageFile::update_stage_file( { upgrade_from => Elevate::OS::name() } );
     return;
 }
 

--- a/lib/Elevate/Service.pm
+++ b/lib/Elevate/Service.pm
@@ -20,6 +20,7 @@ use Elevate::Constants ();
 use Log::Log4perl qw(:easy);
 
 use Elevate::Roles::Run ();    # for fatpck
+use Elevate::Stages     ();
 
 use Simple::Accessor qw{
   name
@@ -86,7 +87,7 @@ sub install ($self) {
     $self->ssystem_and_die( '/usr/bin/systemctl', 'daemon-reload' );
     $self->ssystem_and_die( '/usr/bin/systemctl', 'enable', $name );
 
-    $self->cpev->bump_stage();
+    Elevate::Stages::bump_stage();
 
     my $pid = fork();
     die qq[Failed to fork: $!] unless defined $pid;

--- a/lib/Elevate/StageFile.pm
+++ b/lib/Elevate/StageFile.pm
@@ -1,0 +1,88 @@
+package Elevate::StageFile;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::StageFile
+
+Library to get/set values in the stage file
+
+=cut
+
+use cPstrict;
+
+use Cpanel::JSON ();
+
+use File::Copy  ();
+use Hash::Merge ();
+
+use Log::Log4perl qw(:easy);
+
+use constant ELEVATE_STAGE_FILE   => '/var/cpanel/elevate';
+use constant ELEVATE_SUCCESS_FILE => '/var/cpanel/version/elevate';
+
+sub create_success_file () {
+    File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
+    return;
+}
+
+sub read_stage_file ( $k = undef, $default = {} ) {
+    my $stage_info = Elevate::StageFile::_read_stage_file() // {};
+
+    return $stage_info->{$k} // $default if defined $k;
+    return $stage_info;
+}
+
+sub remove_from_stage_file ($key) {
+    return unless length $key;
+
+    my $stage = Elevate::StageFile::read_stage_file();
+
+    my @list = split( qr/\./, $key );
+    return unless scalar @list;
+
+    my $to_delete = pop @list;
+
+    my $h = $stage;
+    while ( my $k = shift @list ) {
+        $h = $h->{$k};
+        last unless ref $h;
+    }
+
+    return if scalar @list;
+    return unless exists $h->{$to_delete};
+
+    delete $h->{$to_delete};
+
+    return Elevate::StageFile::_save_stage_file($stage);
+}
+
+sub remove_stage_file () {
+    unlink ELEVATE_STAGE_FILE;
+    return;
+}
+
+sub update_stage_file ($data) {
+
+    die q[Need a hash] unless ref $data eq 'HASH';
+
+    my $current = Elevate::StageFile::read_stage_file();
+    my $merged  = Hash::Merge::merge( $data, $current );
+
+    return Elevate::StageFile::_save_stage_file($merged);
+}
+
+sub _read_stage_file () {
+    return eval { Cpanel::JSON::LoadFile(ELEVATE_STAGE_FILE) };
+}
+
+sub _save_stage_file ($stash) {
+    open( my $fh, '>', ELEVATE_STAGE_FILE ) or LOGDIE( "Failed to open " . ELEVATE_STAGE_FILE . ": $!" );
+    print {$fh} Cpanel::JSON::pretty_canonical_dump($stash);
+    close $fh;
+
+    return 1;
+}
+
+1;

--- a/lib/Elevate/Stages.pm
+++ b/lib/Elevate/Stages.pm
@@ -1,0 +1,39 @@
+package Elevate::Stages;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Stages
+
+Library to handle the various stages of the elevate process.
+
+1.  This contains the run stage logic
+2.  This contains the logic to determine get/set the stage we are in
+
+=cut
+
+use cPstrict;
+
+sub bump_stage ( $by = 1 ) {
+
+    return Elevate::Stages::update_stage_number( Elevate::Stages::get_stage() + $by );
+}
+
+sub get_stage {
+    return Elevate::StageFile::read_stage_file( 'stage_number', 0 );
+}
+
+sub update_stage_number ($stage_id) {
+
+    if ( $stage_id > 10 ) {    # protection for stage
+        require Carp;
+        Carp::confess("Invalid stage number $stage_id");
+    }
+
+    Elevate::StageFile::update_stage_file( { stage_number => $stage_id } );
+
+    return $stage_id;
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -314,12 +314,15 @@ use Elevate::Database         ();
 use Elevate::Fetch            ();
 use Elevate::Leapp            ();
 use Elevate::Logger           ();
+use Elevate::Marker           ();
 use Elevate::Motd             ();
 use Elevate::Notify           ();
 use Elevate::Roles::Run       ();    # used as parent, but ensure fatpack
 use Elevate::RPM              ();
 use Elevate::Script           ();
 use Elevate::Service          ();
+use Elevate::StageFile        ();
+use Elevate::Stages           ();
 use Elevate::SystemctlService ();
 use Elevate::Usage            ();
 use Elevate::DNF              ();
@@ -330,8 +333,6 @@ use constant VERSION => 1;
 #>>V *** DO NOT EDIT THESE LINES MANUALLY ***
 
 use constant CHKSRVD_SUSPEND_FILE => q[/var/run/chkservd.suspend];
-use constant ELEVATE_STAGE_FILE   => '/var/cpanel/elevate';
-use constant ELEVATE_SUCCESS_FILE => '/var/cpanel/version/elevate';
 
 use constant VALID_STAGES => 5;
 
@@ -425,7 +426,7 @@ sub run ( $pkg, @args ) {
     return $self->do_cleanup()      if $self->getopt('clean');
     return $self->blockers->check() if defined $self->getopt('check');
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( $stage == 0 ) {
         print_box_no_log( <<~EOS );
@@ -557,7 +558,7 @@ sub upgrade_to_pretty_name ($self) {    # used by output messages
 }
 
 sub monitor_upgrade ($self) {
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     my $tail_msg = q[Running: tail -f ] . Elevate::Constants::LOG_FILE;
 
@@ -580,7 +581,7 @@ sub monitor_upgrade ($self) {
 }
 
 sub start ($self) {
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
     if ( $stage != 0 ) {
         my $header;
         if ( $stage > VALID_STAGES ) {
@@ -612,12 +613,12 @@ sub start ($self) {
 
     system touch => Elevate::Constants::LOG_FILE;
 
-    $self->bump_stage();    # init stage number to 1
+    Elevate::Stages::bump_stage();    # init stage number to 1
 
     # store the manual reboots flag
     if ( $self->getopt('manual-reboots') ) {
         WARN('Manual Reboot would be required between each stages');
-        update_stage_file( { manual_reboots => 1 } );
+        Elevate::StageFile::update_stage_file( { manual_reboots => 1 } );
     }
 
     $self->_capture_env_variables();    # capture at startup
@@ -632,7 +633,7 @@ sub start ($self) {
         Once the system has been successfully upgraded from 7 to 8 you can then remove that file
         to let the elevation process continue and update cPanel for the updated distribution.
         EOS
-        update_stage_file( { no_leapp => 1 } );
+        Elevate::StageFile::update_stage_file( { no_leapp => 1 } );
     }
 
     # prefer over running step1: so status and notifications are enabled
@@ -642,7 +643,7 @@ sub start ($self) {
 sub _capture_env_variables ($self) {
 
     if ( my $ovl_size = $ENV{LEAPP_OVL_SIZE} ) {
-        update_stage_file( { env => { LEAPP_OVL_SIZE => $ovl_size } } );
+        Elevate::StageFile::update_stage_file( { env => { LEAPP_OVL_SIZE => $ovl_size } } );
     }
 
     return;
@@ -724,7 +725,7 @@ sub continue_elevation ($self) {
     # check that no process is running and remove the pidfile for the other
     $self->check_and_create_pidfile()->remove_pid_file;
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
     if ( $stage == 0 ) {
         Elevate::Logger::ERROR_nolog("Looks like no elevate process was started. Please consider running: /scripts/elevate-cpanel --start");
         return;
@@ -756,7 +757,7 @@ sub do_cleanup ($self) {
     $self->service->remove;
 
     $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
-    unlink ELEVATE_STAGE_FILE;
+    Elevate::StageFile::remove_stage_file();
     unlink Elevate::Constants::PID_FILE;
 
     unlink Elevate::Blockers::OVH::OVH_MONITORING_TOUCH_FILE;
@@ -771,11 +772,11 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
     # check it outside the eval block to avoid notification from the command line
     $self->check_and_create_pidfile();
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( $stage >= 2 ) {
         my $status = $self->get_current_status();
-        update_stage_file( { status => q[running] } ) if $status ne 'paused';
+        Elevate::StageFile::update_stage_file( { status => q[running] } ) if $status ne 'paused';
     }
 
     my $action_todo;
@@ -790,13 +791,13 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
 
         # only notify a success when reaching the last stage
         if ( $stage == VALID_STAGES ) {
-            update_stage_file( { status => q[success] } );
+            Elevate::StageFile::update_stage_file( { status => q[success] } );
             $self->_notify_success();
-            File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
+            Elevate::StageFile::create_success_file();
         }
 
         if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
-            update_stage_file( { status => q[paused] } );
+            Elevate::StageFile::update_stage_file( { status => q[paused] } );
         }
         elsif ( $action_todo == ACTION_REBOOT_NEEDED ) {
             $self->reboot();
@@ -805,7 +806,7 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
     else {
         my $error = $@ // q[Unknown error];
 
-        update_stage_file( { status => q[failed] } );
+        Elevate::StageFile::update_stage_file( { status => q[failed] } );
         $self->_notify_error($error);
 
         LOGDIE($error);
@@ -825,7 +826,7 @@ sub check_and_create_pidfile ($self) {
 }
 
 sub check_status ($self) {
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( !$stage ) {
         Elevate::Logger::ERROR_nolog('Elevation process has not started yet.');
@@ -866,7 +867,7 @@ sub _notify_success ($self) {
 The cPanel & WHM server has completed the elevation process from $upgrade_from_name to $pretty_distro_name.
 EOS
 
-    if ( my $warnings = read_stage_file( 'final_notifications', [] ) ) {
+    if ( my $warnings = Elevate::StageFile::read_stage_file( 'final_notifications', [] ) ) {
         if ( scalar @$warnings ) {
             $msg .= "\nThe update to $pretty_distro_name was successful but please note that one ore more notifications require your attention:\n";
 
@@ -883,7 +884,7 @@ EOS
 
 sub _notify_error ( $self, $error = '' ) {
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     my $msg = <<"EOS";
 The elevation process failed during stage $stage.
@@ -910,7 +911,7 @@ EOS
 
 sub _run_service ($self) {
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     print_box( "Starting stage $stage of " . VALID_STAGES ) if $stage > 1;
 
@@ -920,7 +921,7 @@ sub _run_service ($self) {
     if ( Cpanel::OS::major() == 8 && 2 <= $stage && $stage <= 3 ) {
         WARN( "Detected " . Cpanel::OS::pretty_distro() . " while running stage $stage: swtiching to stage 4" );
         $stage = 4;
-        _update_stage_number($stage);
+        Elevate::Stages::update_stage_number($stage);
     }
 
     return $stage == 1
@@ -938,7 +939,7 @@ sub _wait_on_pause ($self) {
     my $pause_file = PAUSE_ELEVATE_TOUCHFILE;
     return unless -e $pause_file;
 
-    update_stage_file( { status => q[paused] } );
+    Elevate::StageFile::update_stage_file( { status => q[paused] } );
 
     WARN( <<~"EOS" );
     The elevation process is currently paused by $pause_file
@@ -949,9 +950,9 @@ sub _wait_on_pause ($self) {
         sleep 5;
     }
 
-    update_stage_file( { status => q[running] } );
+    Elevate::StageFile::update_stage_file( { status => q[running] } );
 
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
     INFO("The pause file was removed. Continuing elevate process to stage $stage.");
 
     return 1;
@@ -1022,7 +1023,7 @@ sub run_stage_1 ($self) {
     print_box( "Starting stage 1 of " . VALID_STAGES . ": Installing " . $self->service->name . " service" );
 
     # store 'upgrade_to' early so later stages can access it
-    update_stage_file( { upgrade_to => $self->upgrade_to } );
+    Elevate::StageFile::update_stage_file( { upgrade_to => $self->upgrade_to } );
 
     return $self->service->install();
 }
@@ -1035,11 +1036,7 @@ Update the current distro packages then reboot.
 
 sub run_stage_2 ($self) {
 
-    my $sum = `/usr/bin/md5sum $0`;
-    chomp $sum;
-    DEBUG( sprintf( "Running $0 (%s/%s)", -s $0, $sum ) );
-
-    $self->elevation_startup_marker($sum);
+    Elevate::Marker::startup();
 
     # Remove scripts/upcp and bin/backup to make sure they don't
     # end up running while ELevate is running.
@@ -1146,7 +1143,7 @@ sub run_stage_4 ($self) {
 
         if ( Cpanel::OS::major() == 7 ) {
             WARN("Detected $current_distro from stage 4, reverting back to stage 3.");
-            _update_stage_number(3);
+            Elevate::Stages::update_stage_number(3);
         }
 
         die( <<~"END");
@@ -1164,7 +1161,7 @@ sub run_stage_4 ($self) {
         END
     }
 
-    my $stash = read_stage_file();
+    my $stash = Elevate::StageFile::read_stage_file();
 
     $stash->{stage4} //= {};    # run once each blocks
 
@@ -1232,7 +1229,8 @@ sub run_stage_5 ($self) {
 
     $self->run_component_once( 'Grub2' => 'post_leapp' );
 
-    $self->elevation_success_marker();
+    Elevate::Marker::success();
+
     $self->restore_outdated_services();
 
     INFO("Updating all packages before final reboot");
@@ -1243,44 +1241,6 @@ sub run_stage_5 ($self) {
     print_box("Great SUCCESS! Your upgrade to $pretty_distro_name is complete.");
 
     return ACTION_REBOOT_NEEDED;
-}
-
-sub _bq_now () {
-    require POSIX;
-    return POSIX::strftime( '%FT%T', gmtime );
-}
-
-sub elevation_startup_marker ( $self, $sum = 'unknown' ) {
-
-    # store some generic informations about the update process
-    update_stage_file(
-        {
-            '_elevate_process' => {
-                script_md5            => $sum,
-                cpanel_build          => $Cpanel::Version::Tiny::VERSION_BUILD,
-                started_at            => _bq_now(),
-                redhat_release_pre    => read_redhat_release(),
-                elevate_version_start => VERSION,
-            }
-        }
-    );
-
-    return;
-}
-
-sub elevation_success_marker ($self) {
-
-    update_stage_file(
-        {
-            '_elevate_process' => {
-                finished_at            => _bq_now(),
-                redhat_release_post    => read_redhat_release(),
-                elevate_version_finish => VERSION,
-            }
-        }
-    );
-
-    return;
 }
 
 sub run_component_once ( $self, $name, $function ) {
@@ -1306,10 +1266,10 @@ sub run_once ( $self, $label, $code = undef ) {
 
     die unless ref $code eq 'CODE';
 
-    my $current_stage = get_stage() // 0;
+    my $current_stage = Elevate::Stages::get_stage() // 0;
     my $stage_name    = 'stage' . $current_stage;
 
-    my $stash = read_stage_file();
+    my $stash = Elevate::StageFile::read_stage_file();
     $stash->{'_run_once'} //= {};
 
     my $full_label = $stage_name . '_' . $label;
@@ -1323,7 +1283,7 @@ sub run_once ( $self, $label, $code = undef ) {
     $code->($self);
 
     # successfully run that block
-    update_stage_file( { _run_once => { $full_label => 1 } } );
+    Elevate::StageFile::update_stage_file( { _run_once => { $full_label => 1 } } );
 
     return;
 }
@@ -1415,7 +1375,7 @@ sub restore_outdated_services ($self) {
 }
 
 sub enable_all_cpanel_services ($self) {
-    my $services = read_stage_file( 'disabled_cpanel_services', [] );
+    my $services = Elevate::StageFile::read_stage_file( 'disabled_cpanel_services', [] );
     unless (@$services) {
         WARN('No cPanel services were disabled!');
     }
@@ -1459,7 +1419,7 @@ sub disable_all_cpanel_services ($self) {
 
         push @disabled_services, $name;
     }
-    update_stage_file( { 'disabled_cpanel_services' => [ sort @disabled_services ] } );
+    Elevate::StageFile::update_stage_file( { 'disabled_cpanel_services' => [ sort @disabled_services ] } );
 
     return;
 }
@@ -1639,93 +1599,19 @@ sub should_run_leapp ($self) {
     # we store the no_leapp option, but prefer using a positive check instead
     # we need to check to see if the no-leapp option is passed via CLI here too in order
     # to allow users to run this script with the '--check --no-leapp' options
-    my $no_leapp = read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
+    my $no_leapp = Elevate::StageFile::read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
     return !$no_leapp;
 }
 
 sub get_current_status ($self) {
-    return read_stage_file( 'status', 'unknown' );
-}
-
-sub read_stage_file ( $k = undef, $default = {} ) {
-    my $stage_info = _read_stage_file() // {};
-
-    return $stage_info->{$k} // $default if defined $k;
-    return $stage_info;
-}
-
-sub _read_stage_file {    # can be mocked during unit tests
-    return eval { Cpanel::JSON::LoadFile(ELEVATE_STAGE_FILE) };
-}
-
-sub save_stage_file ($stash) {
-    open( my $fh, '>', ELEVATE_STAGE_FILE ) or LOGDIE( "Failed to open " . ELEVATE_STAGE_FILE . ": $!" );
-    print {$fh} Cpanel::JSON::pretty_canonical_dump($stash);
-    close $fh;
-
-    return 1;
-}
-
-sub update_stage_file ($data) {
-
-    die q[Need a hash] unless ref $data eq 'HASH';
-
-    my $current = read_stage_file();
-    my $merged  = Hash::Merge::merge( $data, $current );
-
-    return save_stage_file($merged);
-}
-
-sub remove_from_stage_file ($key) {
-    return unless length $key;
-
-    my $stage = read_stage_file();
-
-    my @list = split( qr/\./, $key );
-    return unless scalar @list;
-
-    my $to_delete = pop @list;
-
-    my $h = $stage;
-    while ( my $k = shift @list ) {
-        $h = $h->{$k};
-        last unless ref $h;
-    }
-
-    return if scalar @list;
-    return unless exists $h->{$to_delete};
-
-    delete $h->{$to_delete};
-
-    return save_stage_file($stage);
-}
-
-sub get_stage {
-    return read_stage_file( 'stage_number', 0 );
-}
-
-sub bump_stage ( $self, $by = 1 ) {
-
-    return _update_stage_number( get_stage() + $by );
-}
-
-sub _update_stage_number ($stage_id) {
-
-    if ( $stage_id > 10 ) {    # protection for stage
-        require Carp;
-        Carp::confess("Invalid stage number $stage_id");
-    }
-
-    update_stage_file( { stage_number => $stage_id } );
-
-    return $stage_id;
+    return Elevate::StageFile::read_stage_file( 'status', 'unknown' );
 }
 
 sub reboot ($self) {
-    $self->bump_stage();
+    Elevate::Stages::bump_stage();
 
     # protection
-    my $stage = get_stage();
+    my $stage = Elevate::Stages::get_stage();
 
     if ( $stage > VALID_STAGES + 1 ) {
         LOGDIE(qq[Cannot reboot reaching stage $stage]);
@@ -1749,13 +1635,7 @@ sub reboot ($self) {
 }
 
 sub request_manual_reboots() {
-    return !!read_stage_file( 'manual_reboots', 0 );
-}
-
-sub read_redhat_release() {
-    my ($first_line) = split( "\n", Cpanel::LoadFile::loadfile('/etc/redhat-release') // '' );
-
-    return $first_line;
+    return !!Elevate::StageFile::read_stage_file( 'manual_reboots', 0 );
 }
 
 1;

--- a/t/blocker-Grub2.t
+++ b/t/blocker-Grub2.t
@@ -77,7 +77,7 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
         "uncertainty about whether GRUB2 workaround is present/needed blocks"
     );
 
-    my $mock_cpev = Test::MockModule->new('cpev');
+    my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
 
     #$grub2 = $blockers->_get_blocker_for('Grub2');
     my $stash = undef;
@@ -86,7 +86,7 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
 
         #update_stage_file       => sub ( $, $data ) { $stash = $data },
     );
-    $mock_cpev->redefine(
+    $mock_stagefile->redefine(
         update_stage_file => sub ($data) { $stash = $data },
     );
 

--- a/t/blocker-Python.t
+++ b/t/blocker-Python.t
@@ -5,6 +5,8 @@ use cPstrict;
 use FindBin;
 
 use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/lib";
+use Test::Elevate::OS;
 
 use Test2::Bundle::Extended;
 use Test2::Tools::Explain;
@@ -14,13 +16,13 @@ use Test::MockModule qw{strict};
 use Elevate::Blockers::Python ();
 use Elevate::OS               ();
 
+set_os_to_centos_7();
+
 my %mocks = map { $_ => Test::MockModule->new($_); } qw{
   Cpanel::Pkgr
   Elevate::Blockers
   Elevate::Blockers::Base
-  Elevate::OS
 };
-$mocks{'Elevate::OS'}->redefine( _set_cache => 0 );
 $mocks{'Cpanel::Pkgr'}->redefine( "what_provides" => '', "is_installed" => 1 );
 my $obj = bless {}, 'Elevate::Blockers::Python';
 ok( !$obj->check(), "Returns early on no provider of python36" );
@@ -43,11 +45,3 @@ my $expected = {
 is( $obj->check, $expected, "Got expected blocker returned when found" );
 
 done_testing();
-
-# ------------------------------ #
-
-package cpev;
-
-sub read_stage_file {
-    return 'CentOS7';
-}

--- a/t/components-ea4.t
+++ b/t/components-ea4.t
@@ -38,7 +38,7 @@ sub startup : Test(startup) ($self) {
         }
     );
 
-    $stage_file = Test::MockFile->file( cpev::ELEVATE_STAGE_FILE() );
+    $stage_file = Test::MockFile->file( Elevate::StageFile::ELEVATE_STAGE_FILE() );
 
     $self->{mock_profile} = Test::MockFile->file(PROFILE_FILE);
 
@@ -94,7 +94,7 @@ sub test_backup_and_restore_not_using_ea4 : Test(7) ($self) {
     is $ea4->_backup_ea4_profile(), undef, "backup_ea4_profile - not using ea4";
     message_seen( 'WARN' => q[Skipping EA4 backup. EA4 does not appear to be enabled on this system] );
 
-    is cpev::read_stage_file(), { ea4 => { enable => 0 } }, "stage file - ea4 is disabled";
+    is Elevate::StageFile::read_stage_file(), { ea4 => { enable => 0 } }, "stage file - ea4 is disabled";
 
     is $ea4->_restore_ea4_profile(), undef, "restore_ea4_profile: nothing to restore";
     message_seen( 'WARN' => q[Skipping EA4 restore. EA4 does not appear to be enabled on this system.] );
@@ -266,7 +266,7 @@ sub backup_non_existing_profile : Test(16) ($self) {
         _message_run_ea_current_to_profile($os);
     }
 
-    is cpev::read_stage_file(), { ea4 => { enable => 1 } }, "stage file - ea4 is enabled but we failed";
+    is Elevate::StageFile::read_stage_file(), { ea4 => { enable => 1 } }, "stage file - ea4 is enabled but we failed";
     is $ea4->_restore_ea4_profile(), undef, "restore_ea4_profile: nothing to restore";
 
     message_seen( 'WARN' => q[Unable to restore EA4 profile. Is EA4 enabled?] );
@@ -289,7 +289,7 @@ sub test_backup_and_restore_ea4_profile : Test(13) ($self) {
         _message_run_ea_current_to_profile( $os, 1 );
     }
 
-    is cpev::read_stage_file(), { ea4 => { enable => 1, profile => PROFILE_FILE } }, "stage file - ea4 is enabled / profile is backup";
+    is Elevate::StageFile::read_stage_file(), { ea4 => { enable => 1, profile => PROFILE_FILE } }, "stage file - ea4 is enabled / profile is backup";
 
     is( $ea4->_restore_ea4_profile(), 1, "restore_ea4_profile: profile restored" );
     is $self->{last_ssystem_call}, [qw{ /usr/local/bin/ea_install_profile --install /var/my.profile}], "call ea_install_profile to restore it"
@@ -321,7 +321,7 @@ sub test_backup_and_restore_ea4_profile_dropped_packages : Test(28) ($self) {
         is $ea4->_backup_ea4_profile(), 1, "backup_ea4_profile - using ea4";
         _message_run_ea_current_to_profile( $os, 1 );
 
-        is cpev::read_stage_file(), {
+        is Elevate::StageFile::read_stage_file(), {
             ea4 => {
                 enable       => 1,                                        #
                 profile      => PROFILE_FILE,                             #
@@ -373,7 +373,7 @@ sub test_backup_and_restore_ea4_profile_cleanup_dropped_packages : Test(28) ($se
         is $ea4->_backup_ea4_profile(), 1, "backup_ea4_profile - using ea4";
         _message_run_ea_current_to_profile( $os, 1 );
 
-        is cpev::read_stage_file(), {
+        is Elevate::StageFile::read_stage_file(), {
             ea4 => {
                 enable       => 1,                                        #
                 profile      => PROFILE_FILE,                             #
@@ -394,7 +394,7 @@ sub test_backup_and_restore_ea4_profile_cleanup_dropped_packages : Test(28) ($se
         is $ea4->_backup_ea4_profile(), 1, "backup_ea4_profile - using ea4";
         _message_run_ea_current_to_profile( $os, 1 );
 
-        my $stage = cpev::read_stage_file();
+        my $stage = Elevate::StageFile::read_stage_file();
         is $stage, {
             ea4 => {
                 enable  => 1,               #
@@ -431,7 +431,7 @@ sub test_backup_and_restore_config_files : Test(10) ($self) {
     is( $ea4->_backup_config_files(), undef, '_backup_config_files() successfully completes' );
 
     is(
-        cpev::read_stage_file(),
+        Elevate::StageFile::read_stage_file(),
         {
             ea4_config_files => {
                 'ea-foo'   => ['/tmp/foo.conf'],

--- a/t/grub2_workaround.t
+++ b/t/grub2_workaround.t
@@ -72,13 +72,13 @@ subtest 'Testing _grub2_workaround_state' => sub {
 
 subtest 'Testing _update_grub2_workaround_if_needed' => sub {
     {
-        my $cpev_mock = Test::MockModule->new('cpev');
-        my $g2_mock   = Test::MockModule->new('Elevate::Components::Grub2');
+        my $g2_mock        = Test::MockModule->new('Elevate::Components::Grub2');
+        my $stagefile_mock = Test::MockModule->new('Elevate::StageFile');
 
         my $cpev = cpev->new;
         my $g2   = $cpev->component('Grub2');
 
-        $cpev_mock->redefine(
+        $stagefile_mock->redefine(
             _read_stage_file => { grub2_workaround => { needs_workaround_update => 0 } },
         );
 
@@ -92,8 +92,8 @@ subtest 'Testing _update_grub2_workaround_if_needed' => sub {
 
     subtest "needs workaround, clean run" => sub {
 
-        my $cpev_mock = Test::MockModule->new('cpev');
-        my $g2_mock   = Test::MockModule->new('Elevate::Components::Grub2');
+        my $g2_mock        = Test::MockModule->new('Elevate::Components::Grub2');
+        my $stagefile_mock = Test::MockModule->new('Elevate::StageFile');
 
         my $cpev = cpev->new;
         my $g2   = $cpev->component('Grub2');
@@ -105,7 +105,7 @@ subtest 'Testing _update_grub2_workaround_if_needed' => sub {
         symlink "../grub2/grub.cfg", "$mocked_boot/grub/grub.cfg";
 
         my $stage_update;
-        $cpev_mock->redefine(
+        $stagefile_mock->redefine(
             _read_stage_file  => { grub2_workaround => { needs_workaround_update => 1 } },
             update_stage_file => sub { $stage_update = $_[0]; return 1; },
         );
@@ -134,8 +134,8 @@ subtest 'Testing _update_grub2_workaround_if_needed' => sub {
     };
 
     subtest "needs workaround, recovery run" => sub {
-        my $cpev_mock = Test::MockModule->new('cpev');
-        my $g2_mock   = Test::MockModule->new('Elevate::Components::Grub2');
+        my $g2_mock        = Test::MockModule->new('Elevate::Components::Grub2');
+        my $stagefile_mock = Test::MockModule->new('Elevate::StageFile');
 
         my $cpev = cpev->new;
         my $g2   = $cpev->component('Grub2');
@@ -148,7 +148,7 @@ subtest 'Testing _update_grub2_workaround_if_needed' => sub {
 
         my $now = CORE::time();
         my $stage_update;
-        $cpev_mock->redefine(
+        $stagefile_mock->redefine(
             _read_stage_file  => { grub2_workaround => { needs_workaround_update => 1, backup_dir => "$mocked_boot/grub-$now" } },
             update_stage_file => sub { die 'this should not reached' },
         );
@@ -172,14 +172,14 @@ subtest 'Testing _update_grub2_workaround_if_needed' => sub {
 
 subtest 'Testing _merge_grub_directories_if_needed' => sub {
 
-    my $cpev_mock = Test::MockModule->new('cpev');
-    my $g2_mock   = Test::MockModule->new('Elevate::Components::Grub2');
+    my $g2_mock        = Test::MockModule->new('Elevate::Components::Grub2');
+    my $stagefile_mock = Test::MockModule->new('Elevate::StageFile');
 
     my $cpev = cpev->new;
     my $g2   = $cpev->component('Grub2');
 
     {
-        $cpev_mock->redefine(
+        $stagefile_mock->redefine(
             _read_stage_file => { grub2_workaround => { needs_workaround_update => 0 } },
         );
         $g2_mock->redefine(
@@ -200,7 +200,7 @@ subtest 'Testing _merge_grub_directories_if_needed' => sub {
     symlink "../grub2/grub.cfg", "$mocked_boot/grub-$now/grub.cfg";
     symlink "grub2",             "$mocked_boot/grub";
 
-    $cpev_mock->redefine(
+    $stagefile_mock->redefine(
         _read_stage_file => { grub2_workaround => { needs_workaround_update => 1, backup_dir => "$mocked_boot/grub-$now" } },
     );
     $g2_mock->redefine(

--- a/t/lib/Test/Elevate/OS.pm
+++ b/t/lib/Test/Elevate/OS.pm
@@ -1,0 +1,76 @@
+#!perl
+
+package Test::Elevate::OS;
+
+use cPstrict;
+
+use Test::More;
+use Test::MockModule;
+
+use Elevate::OS        ();
+use Elevate::StageFile ();
+
+our @ISA       = qw(Exporter);
+our @EXPORT    = qw(set_os_to_centos_7 set_os_to_cloudlinux_7 set_os_to set_os_to);
+our @EXPORT_OK = @EXPORT;
+
+my $mock_os;
+
+INIT {
+    $mock_os = Test::MockModule->new('Elevate::OS');
+    $mock_os->redefine(
+        _set_cache => 0,
+    );
+}
+
+sub set_os_to_centos_7 {
+    unmock_os();
+
+    note 'Mock Elevate::OS singleton to think this server is CentOS 7';
+
+    my $real_read_stage_file = \&Elevate::StageFile::read_stage_file;
+    my $mock_stagefile       = Test::MockModule->new('Elevate::StageFile')->redefine(
+        read_stage_file => sub { return 'CentOS7'; },
+    );
+
+    Elevate::OS::name();
+
+    $mock_stagefile->redefine(
+        read_stage_file => $real_read_stage_file,
+    );
+
+    return;
+}
+
+sub set_os_to_cloudlinux_7 {
+    unmock_os();
+
+    note 'Mock Elevate::OS singleton to think this server is CloudLinux 7';
+
+    my $real_read_stage_file = \&Elevate::StageFile::read_stage_file;
+    my $mock_stagefile       = Test::MockModule->new('Elevate::StageFile')->redefine(
+        read_stage_file => sub { return 'CloudLinux7'; },
+    );
+
+    Elevate::OS::name();
+
+    $mock_stagefile->redefine(
+        read_stage_file => $real_read_stage_file,
+    );
+
+    return;
+}
+
+sub set_os_to ($os) {
+    return set_os_to_centos_7()   if $os =~ m/^cent/i;
+    return set_os_to_cloudlinux_7 if $os =~ m/^cloud/i;
+
+    die "Unknown os:  $os\n";
+}
+
+sub unmock_os {
+    note 'Elevate::OS is no longer mocked';
+    $Elevate::OS::OS = undef;
+}
+
+1;

--- a/t/notify.t
+++ b/t/notify.t
@@ -38,7 +38,7 @@ my $cpev = bless {}, 'cpev';
 for my $os ( 'cent', 'cloud' ) {
     set_os_to($os);
 
-    my $stage_file = Test::MockFile->file( cpev::ELEVATE_STAGE_FILE() );
+    my $stage_file = Test::MockFile->file( Elevate::StageFile::ELEVATE_STAGE_FILE() );
 
     my $expect_title = $os eq 'cent' ? 'Successfully updated to AlmaLinux 8' : 'Successfully updated to CloudLinux 8';
     my $expect_body =
@@ -60,16 +60,16 @@ for my $os ( 'cent', 'cloud' ) {
 
     ok Elevate::Notify::add_final_notification("My First Notification"), 'add_final_notification';
 
-    is cpev::read_stage_file(), { final_notifications => ['My First Notification'] }, "stage file - notifications";
+    is Elevate::StageFile::read_stage_file(), { final_notifications => ['My First Notification'] }, "stage file - notifications";
 
     ok !Elevate::Notify::add_final_notification(undef), q[cannot add_final_notification(undef)];
     ok !Elevate::Notify::add_final_notification(''),    q[cannot add_final_notification('')];
 
-    is cpev::read_stage_file(), { final_notifications => ['My First Notification'] }, "stage file - notifications";
+    is Elevate::StageFile::read_stage_file(), { final_notifications => ['My First Notification'] }, "stage file - notifications";
 
     Elevate::Notify::add_final_notification("My Second Notification\nwith two lines.");
 
-    is cpev::read_stage_file(), {
+    is Elevate::StageFile::read_stage_file(), {
         final_notifications => [
             "My Second Notification\nwith two lines.",
             'My First Notification',

--- a/t/pecl.t
+++ b/t/pecl.t
@@ -28,7 +28,7 @@ $INC{'scripts/ElevateCpanel.pm'} = '__TEST__';
 my $mock_elevate = Test::MockModule->new('cpev');
 my $mock_pecl    = Test::MockModule->new('Elevate::Components::PECL');
 
-my $mock_stage_file = Test::MockFile->file( cpev::ELEVATE_STAGE_FILE() );
+my $mock_stage_file = Test::MockFile->file( Elevate::StageFile::ELEVATE_STAGE_FILE() );
 
 my $list_output;
 
@@ -79,18 +79,18 @@ is Elevate::Components::PECL::_get_pecl_installed_for('/my/pecl/bin'), {
 
 {
 
-    is cpev::read_stage_file(), {}, "stage file is empty";
+    is Elevate::StageFile::read_stage_file(), {}, "stage file is empty";
 
     $mock_pecl->redefine( _get_pecl_installed_for => sub { { module_one => 1.2 } } );
 
     Elevate::Components::PECL::_store_pecl_for( '/whatever', 'cpanel' );
 
-    is cpev::read_stage_file(), { pecl => { cpanel => { module_one => 1.2 } } }, "stage file: store pecl for cpanel";
+    is Elevate::StageFile::read_stage_file(), { pecl => { cpanel => { module_one => 1.2 } } }, "stage file: store pecl for cpanel";
 
     $mock_pecl->redefine( _get_pecl_installed_for => sub { { xyz => 5.6 } } );
     Elevate::Components::PECL::_store_pecl_for( '/whatever', 'ea-php80' );
 
-    is cpev::read_stage_file(), {
+    is Elevate::StageFile::read_stage_file(), {
         pecl => {
             cpanel     => { module_one => 1.2 },
             'ea-php80' => { xyz        => 5.6 }
@@ -102,7 +102,9 @@ is Elevate::Components::PECL::_get_pecl_installed_for('/my/pecl/bin'), {
 
 {
     $mock_pecl->redefine( _get_pecl_installed_for => undef );
-    $mock_elevate->redefine(
+
+    my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
+    $mock_stagefile->redefine(
         _read_stage_file => sub {
             return {
                 pecl => {

--- a/t/stage_file.t
+++ b/t/stage_file.t
@@ -20,74 +20,74 @@ use Test::Elevate;
 
 my $mock_elevate = Test::MockModule->new('cpev');
 
-my $mock_stage_file = Test::MockFile->file( cpev::ELEVATE_STAGE_FILE() );
+my $mock_stage_file = Test::MockFile->file( Elevate::StageFile::ELEVATE_STAGE_FILE() );
 
-is cpev::read_stage_file(),            {}, 'read_stage_file empty file';
-is cpev::read_stage_file('something'), {}, 'read_stage_file("something") = {}';
-is cpev::read_stage_file( 'something', 0 ),     0,     'read_stage_file("something", 0) = 0';
-is cpev::read_stage_file( 'something', 42 ),    42,    'read_stage_file("something", 42) = 43';
-is cpev::read_stage_file( 'something', [] ),    [],    'read_stage_file("something", []) = []';
-is cpev::read_stage_file( 'something', undef ), undef, 'read_stage_file("something", undef) = undef';
+is Elevate::StageFile::read_stage_file(),            {}, 'read_stage_file empty file';
+is Elevate::StageFile::read_stage_file('something'), {}, 'read_stage_file("something") = {}';
+is Elevate::StageFile::read_stage_file( 'something', 0 ),     0,     'read_stage_file("something", 0) = 0';
+is Elevate::StageFile::read_stage_file( 'something', 42 ),    42,    'read_stage_file("something", 42) = 43';
+is Elevate::StageFile::read_stage_file( 'something', [] ),    [],    'read_stage_file("something", []) = []';
+is Elevate::StageFile::read_stage_file( 'something', undef ), undef, 'read_stage_file("something", undef) = undef';
 
-ok cpev::save_stage_file( { fruits => ['cherry'] } ), 'save_stage_file';
-is cpev::read_stage_file(), { fruits => ['cherry'] }, 'read_stage_file';
-is cpev::read_stage_file('fruits'), ['cherry'], 'read_stage_file("fruits")';
+ok Elevate::StageFile::_save_stage_file( { fruits => ['cherry'] } ), 'save_stage_file';
+is Elevate::StageFile::read_stage_file(), { fruits => ['cherry'] }, 'read_stage_file';
+is Elevate::StageFile::read_stage_file('fruits'), ['cherry'], 'read_stage_file("fruits")';
 
-ok cpev::update_stage_file( { veggies => ['carrots'] } ), 'update_stage_file';
-is cpev::read_stage_file(), { fruits => ['cherry'], veggies => ['carrots'] }, 'read_stage_file';
+ok Elevate::StageFile::update_stage_file( { veggies => ['carrots'] } ), 'update_stage_file';
+is Elevate::StageFile::read_stage_file(), { fruits => ['cherry'], veggies => ['carrots'] }, 'read_stage_file';
 
 $mock_stage_file->contents('');
-is cpev::read_stage_file(), {}, 'read_stage_file empty file';
+is Elevate::StageFile::read_stage_file(), {}, 'read_stage_file empty file';
 
-ok cpev::update_stage_file( { ea4 => { profile => q[myprofile] } } ), 'update_stage_file: ea4 profile';
-ok cpev::update_stage_file( { ea4 => { enable  => 1 } } ),            'update_stage_file: ea4 enable';
+ok Elevate::StageFile::update_stage_file( { ea4 => { profile => q[myprofile] } } ), 'update_stage_file: ea4 profile';
+ok Elevate::StageFile::update_stage_file( { ea4 => { enable  => 1 } } ),            'update_stage_file: ea4 enable';
 
-is cpev::read_stage_file(), { ea4 => { profile => q[myprofile], enable => 1 } }, 'read_stage_file merging hashes';
+is Elevate::StageFile::read_stage_file(), { ea4 => { profile => q[myprofile], enable => 1 } }, 'read_stage_file merging hashes';
 
 {
     note "bumping the stage";
 
     $mock_stage_file->contents('');
 
-    is cpev::get_stage(), 0, 'stage 0';
-    ok( cpev->bump_stage(), 'bump_stage' );
+    is Elevate::Stages::get_stage(), 0, 'stage 0';
+    ok( Elevate::Stages::bump_stage(), 'bump_stage' );
 
-    is cpev::get_stage(), 1, 'stage 1';
-    ok( cpev->bump_stage(), 'bump_stage' );
+    is Elevate::Stages::get_stage(), 1, 'stage 1';
+    ok( Elevate::Stages::bump_stage(), 'bump_stage' );
 
-    is cpev::get_stage(), 2, 'stage 2';
-    ok( cpev->bump_stage(), 'bump_stage' );
+    is Elevate::Stages::get_stage(), 2, 'stage 2';
+    ok( Elevate::Stages::bump_stage(), 'bump_stage' );
 
-    ok cpev::update_stage_file( { key => 'value' } ), 'update_stage_file: add an extra entry';
+    ok Elevate::StageFile::update_stage_file( { key => 'value' } ), 'update_stage_file: add an extra entry';
 
-    is cpev::get_stage(), 3, 'stage 3';
-    is cpev::read_stage_file(), { stage_number => 3, key => 'value' }, 'read_stage_file: stage is preserved';
+    is Elevate::Stages::get_stage(), 3, 'stage 3';
+    is Elevate::StageFile::read_stage_file(), { stage_number => 3, key => 'value' }, 'read_stage_file: stage is preserved';
 }
 
 subtest 'read / delete' => sub {
     $mock_stage_file->contents('');
 
-    ok cpev::save_stage_file( { root => { fruits => [qw/banana/], veggies => [qw/carrot/] } } ), 'save_stage_file';
-    is cpev::read_stage_file(), { root => { fruits => ['banana'], veggies => ['carrot'] } }, 'read_stage_file';
+    ok Elevate::StageFile::_save_stage_file( { root => { fruits => [qw/banana/], veggies => [qw/carrot/] } } ), 'save_stage_file';
+    is Elevate::StageFile::read_stage_file(), { root => { fruits => ['banana'], veggies => ['carrot'] } }, 'read_stage_file';
 
-    ok cpev::update_stage_file( { root => { fruits => [qw/cherry/] } } ), 'update_stage_file';
-    is cpev::read_stage_file(), { root => { fruits => [qw{cherry banana}], veggies => ['carrot'] } }, 'update_stage_file merge...'
-      or diag explain cpev::read_stage_file();
+    ok Elevate::StageFile::update_stage_file( { root => { fruits => [qw/cherry/] } } ), 'update_stage_file';
+    is Elevate::StageFile::read_stage_file(), { root => { fruits => [qw{cherry banana}], veggies => ['carrot'] } }, 'update_stage_file merge...'
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok cpev::remove_from_stage_file('root.fruits'), "can remove root.fruits";
-    is cpev::read_stage_file(), { root => { veggies => ['carrot'] } }, 'fruits entry was removed'
-      or diag explain cpev::read_stage_file();
+    ok Elevate::StageFile::remove_from_stage_file('root.fruits'), "can remove root.fruits";
+    is Elevate::StageFile::read_stage_file(), { root => { veggies => ['carrot'] } }, 'fruits entry was removed'
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok cpev::update_stage_file( { root => { fruits => [qw/cherry/] } } ), 'update_stage_file';
-    is cpev::read_stage_file(), { root => { fruits => [qw{cherry}], veggies => ['carrot'] } }, 'update_stage_file after a partial cleanup'
-      or diag explain cpev::read_stage_file();
+    ok Elevate::StageFile::update_stage_file( { root => { fruits => [qw/cherry/] } } ), 'update_stage_file';
+    is Elevate::StageFile::read_stage_file(), { root => { fruits => [qw{cherry}], veggies => ['carrot'] } }, 'update_stage_file after a partial cleanup'
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok cpev::remove_from_stage_file('root'), "can remove root";
-    is cpev::read_stage_file(), {}, 'removed root entry'
-      or diag explain cpev::read_stage_file();
+    ok Elevate::StageFile::remove_from_stage_file('root'), "can remove root";
+    is Elevate::StageFile::read_stage_file(), {}, 'removed root entry'
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok cpev::save_stage_file( { root => { levelone => { leveltwo => {qw/bla bla/} }, veggies => [qw/carrot/] } } ), 'save_stage_file';
-    is cpev::read_stage_file(),
+    ok Elevate::StageFile::_save_stage_file( { root => { levelone => { leveltwo => {qw/bla bla/} }, veggies => [qw/carrot/] } } ), 'save_stage_file';
+    is Elevate::StageFile::read_stage_file(),
       {
         'root' => {
             'levelone' => { 'leveltwo' => { 'bla' => 'bla' } },
@@ -95,12 +95,12 @@ subtest 'read / delete' => sub {
         }
       },
       'check stage file'
-      or diag explain cpev::read_stage_file();
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok !cpev::remove_from_stage_file('not-there'),      "nothing to remove";
-    ok !cpev::remove_from_stage_file('root.not-there'), "nothing to remove";
+    ok !Elevate::StageFile::remove_from_stage_file('not-there'),      "nothing to remove";
+    ok !Elevate::StageFile::remove_from_stage_file('root.not-there'), "nothing to remove";
 
-    is cpev::read_stage_file(),
+    is Elevate::StageFile::read_stage_file(),
       {
         'root' => {
             'levelone' => { 'leveltwo' => { 'bla' => 'bla' } },
@@ -108,10 +108,10 @@ subtest 'read / delete' => sub {
         }
       },
       'check stage file'
-      or diag explain cpev::read_stage_file();
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok cpev::remove_from_stage_file('root.levelone.leveltwo'), "remove root.levelone.leveltwo";
-    is cpev::read_stage_file(),
+    ok Elevate::StageFile::remove_from_stage_file('root.levelone.leveltwo'), "remove root.levelone.leveltwo";
+    is Elevate::StageFile::read_stage_file(),
       {
         'root' => {
             'levelone' => {},
@@ -119,12 +119,12 @@ subtest 'read / delete' => sub {
         }
       },
       'check stage file'
-      or diag explain cpev::read_stage_file();
+      or diag explain Elevate::StageFile::read_stage_file();
 
-    ok cpev::remove_from_stage_file('root'), "remove root";
-    is cpev::read_stage_file(), {}, 'removed root entry'
-      or diag explain cpev::read_stage_file();
-    ok !cpev::remove_from_stage_file('root'), "cannot remove root twice";
+    ok Elevate::StageFile::remove_from_stage_file('root'), "remove root";
+    is Elevate::StageFile::read_stage_file(), {}, 'removed root entry'
+      or diag explain Elevate::StageFile::read_stage_file();
+    ok !Elevate::StageFile::remove_from_stage_file('root'), "cannot remove root twice";
 
 };
 


### PR DESCRIPTION
Case RE-250: This change refactors the stage logic from the main script to three modules:

* Elevate::StageFile - This module contains all the logic to manage the '/var/cpanel/elevate' file

* Elevate::Stages - This module contains the get/set logic for the stage of the elevate process that the script is currently in

* Elevate::Marker - This module contains the logic to add debug information about the elevate process to the stage file

Changelog: Modularize stage logic

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

