### PR TITLE
Update warning string in last chance message

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6815,9 +6815,10 @@ sub _capture_env_variables ($self) {
 # This code used to be in stage 1, but it makes more sense for it to take place before a stage has been set.
 sub give_last_chance ($self) {
 
+    my $upgrade_from_name  = Elevate::OS::pretty_name();
     my $pretty_distro_name = $self->upgrade_to_pretty_name();
 
-    print_box(qq[/!\ Warning: You are about to convert your cPanel & WHM CentOS 7 to $pretty_distro_name server.]);
+    print_box(qq[/!\ Warning: You are about to convert your cPanel & WHM $upgrade_from_name to $pretty_distro_name server.]);
 
     present_noc_recommendations();
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -651,9 +651,10 @@ sub _capture_env_variables ($self) {
 # This code used to be in stage 1, but it makes more sense for it to take place before a stage has been set.
 sub give_last_chance ($self) {
 
+    my $upgrade_from_name  = Elevate::OS::pretty_name();
     my $pretty_distro_name = $self->upgrade_to_pretty_name();
 
-    print_box(qq[/!\ Warning: You are about to convert your cPanel & WHM CentOS 7 to $pretty_distro_name server.]);
+    print_box(qq[/!\ Warning: You are about to convert your cPanel & WHM $upgrade_from_name to $pretty_distro_name server.]);
 
     present_noc_recommendations();
 


### PR DESCRIPTION
Case RE-274: The warning string in the last chance message was hard coded to CentOS 7.  Since we now support multiple OSs, this string needs to be updated to be a variable showing the proper OS that is being updated.

Changelog:  Update string in last chance message to inform the user of
 the correct OS that is being updated

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

