### PR TITLE
Report potential failures of LEAPP.

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4951,6 +4951,7 @@ EOS
 
     use Cpanel::Binaries ();
     use Cpanel::JSON     ();
+    use Cpanel::LoadFile ();
     use Cpanel::Pkgr     ();
 
     use Elevate::OS        ();
@@ -4962,8 +4963,10 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
-    use constant LEAPP_REPORT_JSON => q[/var/log/leapp/leapp-report.json];
-    use constant LEAPP_REPORT_TXT  => q[/var/log/leapp/leapp-report.txt];
+    use constant LEAPP_REPORT_JSON    => q[/var/log/leapp/leapp-report.json];
+    use constant LEAPP_REPORT_TXT     => q[/var/log/leapp/leapp-report.txt];
+    use constant LEAPP_UPGRADE_LOG    => q[/var/log/leapp/leapp-upgrade.log];
+    use constant LEAPP_FAIL_CONT_FILE => q[/var/cpanel/elevate_leap_fail_continue];
 
     use Simple::Accessor qw{
       cpev
@@ -5150,6 +5153,71 @@ EOS
         }
 
         return $error_block;
+    }
+
+    sub check_upgrade_log_for_failures ($self) {
+        my $upgrade_log   = LEAPP_UPGRADE_LOG;
+        my $cont_file     = LEAPP_FAIL_CONT_FILE;
+        my $max_delay     = 60 * 10;                                     # 10 minutes. If changed don't forget to update the INFO line below.
+        my $search_string = 'Starting stage After of phase FirstBoot';
+
+        if ( !-e $upgrade_log ) {
+            ERROR("No LEAPP upgrade log detected at [$upgrade_log]");
+
+            return 1;
+        }
+
+        my $contents;
+        my $not_found = 1;
+        my $elapsed   = 0;
+        INFO( "Waiting to ensure the LEAPP upgrade process completes. This process may take up to " . int( $max_delay / 60 ) . " minutes." );
+        my $found = $self->_wait_for_log_contents( $search_string, $max_delay );
+
+        if ( !$found ) {
+            if ( -e $cont_file ) {
+                INFO("LEAPP does not appear to have completed successfully, but continuing anyway because [$cont_file] exists");
+
+                return 0;
+            }
+            else {
+                my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
+                $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
+                $msg .= sprintf( "    %s\n", "touch $cont_file" );
+                $msg .= sprintf( "    %s\n", '/scripts/elevate-cpanel --continue' );
+                $msg .= sprintf("The following log files may help in your investigation.\n");
+                $msg .= sprintf( "    %s\n", $upgrade_log );
+                $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
+                ERROR($msg);
+
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    sub _wait_for_log_contents ( $self, $search_string, $max_delay ) {
+        my $upgrade_log = LEAPP_UPGRADE_LOG;
+        my $found       = 0;
+        my $elapsed     = 0;
+        my $sleep_time  = 3;                   # Time to sleep, in seconds, between checks
+
+        while ( !$found && $elapsed < $max_delay ) {
+            my $contents = Cpanel::LoadFile::loadfile($upgrade_log) // '';
+            if ( $contents =~ /$search_string/ ) {
+                $found = 1;
+            }
+            else {
+                sleep $sleep_time;
+                $elapsed += $sleep_time;
+            }
+
+            if ( $elapsed > 0 && $elapsed % 30 == 0 ) {
+                INFO("Still waiting for the LEAPP upgrade process to complete.");
+            }
+        }
+
+        return $found;
     }
 
     sub _report_leapp_failure_and_die ($self) {
@@ -7522,7 +7590,14 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
-    Cpanel::OS::clear_cache_after_cloudlinux_update();    # I didn't pick the "clear cache but don't die" name...
+    Cpanel::OS::clear_cache_after_cloudlinux_update();
+
+    my $upgrade_errors = $self->leapp->check_upgrade_log_for_failures();
+    if ($upgrade_errors) {
+        my $message = sprintf("The LEAPP upgrade process did not succeed\n");
+        $message .= sprintf( "Review the log at %s for more details\n", Elevate::Constants::LOG_FILE );
+        die($message);
+    }
 
     if ( Cpanel::OS::major() != 8 ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1132,7 +1132,14 @@ Restore removed packages during the previous stage.
 
 sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
-    Cpanel::OS::clear_cache_after_cloudlinux_update();    # I didn't pick the "clear cache but don't die" name...
+    Cpanel::OS::clear_cache_after_cloudlinux_update();
+
+    my $upgrade_errors = $self->leapp->check_upgrade_log_for_failures();
+    if ($upgrade_errors) {
+        my $message = sprintf("The LEAPP upgrade process did not succeed\n");
+        $message .= sprintf( "Review the log at %s for more details\n", Elevate::Constants::LOG_FILE );
+        die($message);
+    }
 
     if ( Cpanel::OS::major() != 8 ) {
         my $pretty_distro_name = $self->upgrade_to_pretty_name();


### PR DESCRIPTION
Case RE-224: This commit adds in some extra checks to help determine if the LEAPP process failed or not. It also introduces a new potential touch file at /var/cpanel/elevate_leap_fail_continue that can be used to continue even if the new checks detect a possible error.

Changelog: Added in more checks to report potential failures of
 LEAPP.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

