### PR TITLE
Remove unsupported software section from blockers documentation

### DIFF
--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -34,12 +34,6 @@ At any given time, the upgrade process may use at or more than 5 GB. If you have
 * **/usr/local/cpanel**: 1.5 GB
 * **/var/lib**: 5 GB
 
-## Unsupported software
-
-The following software is known to lead to a corrupt install if this script is used. We block elevation when it is detected:
-
-* **cPanel CCS Calendar Server** - Requires Postgresql older than 10.0
-
 ## Things you need to upgrade first.
 
 You can discover many of these issues by downloading `elevate-cpanel` and running `/scripts/elevate-cpanel --check`. Below is a summary of the major blockers people might encounter.


### PR DESCRIPTION
Case RE-78:  This code in this case converts the CCS blocker to a component.  This change updates the documentation to remove an unsupported software section from the blockers documentation page since the only thing that the unsupported software section contains is that CCS is unsupported.  Since CCS is now supported, we might as well remove the entire section from the page.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

