### PR TITLE
Ensure all system calls are executable absolute paths

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5609,6 +5609,9 @@ EOS
 
     sub _ssystem ( $command, %opts ) {
         my @args = @{ $command // [] };
+
+        return 42 if $args[0] !~ '^/' || !-x $args[0];
+
         INFO( "Running: " . join( " ", @args ) );
         INFO();    # Buffer so they can more easily read the output.
 

--- a/lib/Elevate/Roles/Run.pm
+++ b/lib/Elevate/Roles/Run.pm
@@ -70,6 +70,10 @@ sub ssystem_and_die ( $self, @args ) {
 
 sub _ssystem ( $command, %opts ) {
     my @args = @{ $command // [] };
+
+    # Only allow the program to be an executable absolute path
+    return 42 if $args[0] !~ '^/' || !-x $args[0];
+
     INFO( "Running: " . join( " ", @args ) );
     INFO();    # Buffer so they can more easily read the output.
 

--- a/t/ssystem.t
+++ b/t/ssystem.t
@@ -23,6 +23,11 @@ my $mock_log_file = Test::MockFile->file('/var/log/elevate-cpanel.log');
 
 my $cpev = cpev->new->_init;
 
+is( cpev->ssystem('nope'), 42, q[ssystem( 'nope' ) is disallowed] );
+is( cpev->ssystem('grep'), 42, 'Commands that are not absolute paths are not allowed' );
+
+is( cpev->ssystem('/etc/apache2/conf/httpd.conf'), 42, 'Commands that are not executable are not allowed' );
+
 is( cpev->ssystem("/bin/true"), 0, q[ssystem( "/bin/true" ) == 0] );
 isnt( my $status_false = cpev->ssystem("/bin/false"), 0, q[ssystem( "/bin/false" ) != 0] );
 


### PR DESCRIPTION
Case RE-260: C::S::O has a bug in 110 where it does not detect missing scripts (see CPANEL-40343).  The change in CPANEL-40343 was deemed medium/high risk, and was rejected as a backport candidate for 110.  As such, we need to work around this issue.  Since elevate-cpanel can only be executed as root, it was determined that all commands that it executes should be executabl absolute paths.  This change enforces that.

Changelog:  Ensure all system calls are executable absolute paths

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

