### PR TITLE
Update docs to remove references to Rocky Linux

### DIFF
--- a/docs-website-src/content/_index.md
+++ b/docs-website-src/content/_index.md
@@ -11,7 +11,7 @@ Read more from the [Elevate website](https://cpanel.github.io/elevate/).
 
 ## Goal
 
-The cPanel ELevate Project provides a script to upgrade an existing `cPanel & WHM` [CentOS&nbsp;7](https://centos.org) server installation to [AlmaLinux&nbsp;8](https://almalinux.org) or [Rocky&nbsp;Linux&nbsp;8](https://rockylinux.org).
+The cPanel ELevate Project provides a script to upgrade an existing `cPanel & WHM` [CentOS&nbsp;7](https://centos.org) server installation to [AlmaLinux&nbsp;8](https://almalinux.org).
 
 ## Disclaimer
 
@@ -27,7 +27,7 @@ Please contact [cPanel Technical Support](https://docs.cpanel.net/knowledge-base
 
 This project builds on the [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project, which leans heavily on the [LEAPP Project](https://leapp.readthedocs.io/en/latest/) created for in-place upgrades of RedHat-based systems.
 
-The [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project is very effective at upgrading the distro packages from [CentOS&nbsp;7](https://centos.org/) to [AlmaLinux&nbsp;8](https://almalinux.org/) or [Rocky&nbsp;Linux&nbsp;8](https://rockylinux.org). However if you attempt use it directly on a CentOS 7-based [cPanel&nbsp;install](https://cpanel.net/), you will end up with a broken system.
+The [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project is very effective at upgrading the distro packages from [CentOS&nbsp;7](https://centos.org/) to [AlmaLinux&nbsp;8](https://almalinux.org/). However if you attempt use it directly on a CentOS 7-based [cPanel&nbsp;install](https://cpanel.net/), you will end up with a broken system.
 
 This project was designed to be a wrapper around the [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project to allow you to successfully upgrade a [cPanel install](https://cpanel.net/) with an aim to minimize outages.
 
@@ -118,13 +118,7 @@ We recommend you check for known blockers before you upgrade. The check is desig
 You can check if your system is ready to upgrade to **AlmaLinux 8** by running:
 ```bash
 # Check AlmaLinux 8 upgrade (dry run mode)
-/scripts/elevate-cpanel --check --upgrade-to=almalinux
-```
-
-You can check if your system is ready to upgrade to **Rocky Linux 8** by running:
-```bash
-# Check Rocky Linux 8 upgrade (dry run mode)
-/scripts/elevate-cpanel --check --upgrade-to=rocky
+/scripts/elevate-cpanel --check
 ```
 
 ### To upgrade
@@ -138,13 +132,7 @@ unreachable during this time.
 You can upgrade to **AlmaLinux 8** by running:
 ```bash
 # Start the migration to AlmaLinux 8
-/scripts/elevate-cpanel --start --upgrade-to=almalinux
-```
-
-You can upgrade to **Rocky Linux 8** by running:
-```bash
-# Start the migration to Rocky Linux 8
-/scripts/elevate-cpanel --start --upgrade-to=rocky
+/scripts/elevate-cpanel --start
 ```
 
 ### Command line options
@@ -154,14 +142,10 @@ You can upgrade to **Rocky Linux 8** by running:
 /scripts/elevate-cpanel --help
 
 # Check if your server is ready for elevation (dry run mode)
-/scripts/elevate-cpanel --check # defaults to AlmaLinux
-/scripts/elevate-cpanel --check --upgrade-to=almalinux
-/scripts/elevate-cpanel --check --upgrade-to=rocky
+/scripts/elevate-cpanel --check
 
 # Start the migration
-/scripts/elevate-cpanel --start # defaults to AlmaLinux
-/scripts/elevate-cpanel --start --upgrade-to=almalinux
-/scripts/elevate-cpanel --start --upgrade-to=rocky
+/scripts/elevate-cpanel --start
 
 ... # expect multiple reboots (~30 min)
 
@@ -205,7 +189,7 @@ In case of failure you probably want to reply to a few extra questions or remove
 
 ### Stage 4
 
-At this stage we should now run Alamalinux 8 (or RockyLinux 8).
+At this stage we should now run Alamalinux 8.
 Update cPanel product for the new distro.
 
 Restore removed packages during the previous stage.

--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -52,12 +52,12 @@ You can discover many of these issues by downloading `elevate-cpanel` and runnin
   * You will need to be on a version mentioned in the "Latest cPanel & WHM Builds (All Architectures)" section at http://httpupdate.cpanel.net/
   * Mitigation: `/usr/local/cpanel/scripts/upcp`
 * **nameserver**
-  * cPanel provides support for a myriad of nameservers. (MyDNS, nsd, bind, powerdns). On AlmaLinux 8 / Rocky 8, it is preferred that you always be on PowerDNS.
+  * cPanel provides support for a myriad of nameservers. (MyDNS, nsd, bind, powerdns). On AlmaLinux 8, it is preferred that you always be on PowerDNS.
   * Mitigation: `/scripts/setupnameserver powerdns`
 * **MySQL**
   * We will upgrade you automatically to MariaDB 10.6 during elevation if you do not do this in advance.
-* Some **EA4 packages** are not supported on AlmaLinux 8 / Rocky 8.
-  * Example: PHP versions 5.4 through 7.1 are available on CentOS 7 but not AlmaLinux 8 / Rocky 8. You would need to remove these packages before the upgrading to AlmaLinux 8 / Rocky 8. Doing so might impact your system users. Proceed with caution.
+* Some **EA4 packages** are not supported on AlmaLinux 8.
+  * Example: PHP versions 5.4 through 7.1 are available on CentOS 7 but not AlmaLinux 8. You would need to remove these packages before the upgrading to AlmaLinux 8. Doing so might impact your system users. Proceed with caution.
 * The system **must** be able to control the boot process by changing the GRUB2 configuration.
   * The reason for this is that the framework which performs the upgrade of distro-provided software needs to be able to run a custom early boot environment (initrd) in order to safely upgrade the distro.
   * We check for this by seeing whether the kernel the system is currently running is the same version as that which the system believes is the default boot option.


### PR DESCRIPTION
Case RE-218:  Since we no longer support Rocky Linux or the 'upgrade-to' option, we need to remove references to both of them in our documentation.  This change updates the documentation to remove references to both Rocky Linux and the upgrade-to option.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

