### PR TITLE
Do not delay 10 minutes when elevate_leap_fail_continue is put in place

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5065,10 +5065,13 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
-    use constant LEAPP_REPORT_JSON    => q[/var/log/leapp/leapp-report.json];
-    use constant LEAPP_REPORT_TXT     => q[/var/log/leapp/leapp-report.txt];
-    use constant LEAPP_UPGRADE_LOG    => q[/var/log/leapp/leapp-upgrade.log];
-    use constant LEAPP_FAIL_CONT_FILE => q[/var/cpanel/elevate_leap_fail_continue];
+    use constant LEAPP_REPORT_JSON       => q[/var/log/leapp/leapp-report.json];
+    use constant LEAPP_REPORT_TXT        => q[/var/log/leapp/leapp-report.txt];
+    use constant LEAPP_UPGRADE_LOG       => q[/var/log/leapp/leapp-upgrade.log];
+    use constant LEAPP_FAIL_CONT_FILE    => q[/var/cpanel/elevate_leap_fail_continue];
+    use constant LEAPP_COMPLETION_STRING => qr/Starting stage After of phase FirstBoot/;
+
+    our $time_to_wait_for_leapp_completion = 10 * 60;
 
     use Simple::Accessor qw{
       cpev
@@ -5257,69 +5260,48 @@ EOS
         return $error_block;
     }
 
-    sub check_upgrade_log_for_failures ($self) {
-        my $upgrade_log   = LEAPP_UPGRADE_LOG;
-        my $cont_file     = LEAPP_FAIL_CONT_FILE;
-        my $max_delay     = 60 * 10;                                     # 10 minutes. If changed don't forget to update the INFO line below.
-        my $search_string = 'Starting stage After of phase FirstBoot';
+    sub wait_for_leapp_completion ($self) {
+        my $upgrade_log = LEAPP_UPGRADE_LOG;
 
         if ( !-e $upgrade_log ) {
             ERROR("No LEAPP upgrade log detected at [$upgrade_log]");
-
-            return 1;
+            return 0;
         }
 
-        my $contents;
-        my $not_found = 1;
-        my $elapsed   = 0;
-        INFO( "Waiting to ensure the LEAPP upgrade process completes. This process may take up to " . int( $max_delay / 60 ) . " minutes." );
-        my $found = $self->_wait_for_log_contents( $search_string, $max_delay );
+        my $elapsed    = 0;
+        my $sleep_time = 3;    # Time to sleep, in seconds, between checks
 
-        if ( !$found ) {
-            if ( -e $cont_file ) {
-                INFO("LEAPP does not appear to have completed successfully, but continuing anyway because [$cont_file] exists");
+        while ( $elapsed < $time_to_wait_for_leapp_completion ) {
+            my $contents = Cpanel::LoadFile::loadfile(LEAPP_UPGRADE_LOG) // '';
+            return 1 if $contents =~ LEAPP_COMPLETION_STRING;
 
-                return 0;
+            if ( -e LEAPP_FAIL_CONT_FILE ) {
+                INFO( 'LEAPP does not appear to have completed successfully, but continuing anyway because [' . LEAPP_FAIL_CONT_FILE . '] exists' );
+                return 2;
             }
-            else {
-                my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
-                $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
-                $msg .= sprintf( "    %s\n", "touch $cont_file" );
-                $msg .= sprintf( "    %s\n", '/scripts/elevate-cpanel --continue' );
-                $msg .= sprintf("The following log files may help in your investigation.\n");
-                $msg .= sprintf( "    %s\n", $upgrade_log );
-                $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
-                ERROR($msg);
 
-                return 1;
+            if ( $elapsed % 30 == 0 ) {
+                INFO('Waiting for the LEAPP upgrade process to complete.');
+                if ( $elapsed == 0 ) {    # First loop give extra advice
+                    INFO( 'This process may take up to ' . int( $time_to_wait_for_leapp_completion / 60 ) . ' minutes.' );
+                    INFO( sprintf( "You can `touch %s` if you would like to skip this check.", LEAPP_FAIL_CONT_FILE ) );
+                }
             }
+
+            sleep $sleep_time;
+            $elapsed += $sleep_time;
         }
+
+        my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
+        $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
+        $msg .= sprintf( "    %s %s\n", "touch", LEAPP_FAIL_CONT_FILE );
+        $msg .= sprintf( "    %s\n",    '/scripts/elevate-cpanel --continue' );
+        $msg .= sprintf("The following log files may help in your investigation.\n");
+        $msg .= sprintf( "    %s\n", $upgrade_log );
+        $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
+        ERROR($msg);
 
         return 0;
-    }
-
-    sub _wait_for_log_contents ( $self, $search_string, $max_delay ) {
-        my $upgrade_log = LEAPP_UPGRADE_LOG;
-        my $found       = 0;
-        my $elapsed     = 0;
-        my $sleep_time  = 3;                   # Time to sleep, in seconds, between checks
-
-        while ( !$found && $elapsed < $max_delay ) {
-            my $contents = Cpanel::LoadFile::loadfile($upgrade_log) // '';
-            if ( $contents =~ /$search_string/ ) {
-                $found = 1;
-            }
-            else {
-                sleep $sleep_time;
-                $elapsed += $sleep_time;
-            }
-
-            if ( $elapsed > 0 && $elapsed % 30 == 0 ) {
-                INFO("Still waiting for the LEAPP upgrade process to complete.");
-            }
-        }
-
-        return $found;
     }
 
     sub _report_leapp_failure_and_die ($self) {
@@ -7611,8 +7593,8 @@ sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
     Cpanel::OS::clear_cache_after_cloudlinux_update();
 
-    my $upgrade_errors = $self->leapp->check_upgrade_log_for_failures();
-    if ($upgrade_errors) {
+    # 10 minute timeout if no completion is seen.
+    unless ( $self->leapp->wait_for_leapp_completion ) {
         my $message = sprintf("The LEAPP upgrade process did not succeed\n");
         $message .= sprintf( "Review the log at %s for more details\n", Elevate::Constants::LOG_FILE );
         die($message);

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5284,7 +5284,7 @@ EOS
                 INFO('Waiting for the LEAPP upgrade process to complete.');
                 if ( $elapsed == 0 ) {    # First loop give extra advice
                     INFO( 'This process may take up to ' . int( $time_to_wait_for_leapp_completion / 60 ) . ' minutes.' );
-                    INFO( sprintf( "You can `touch %s` if you would like to skip this check.", LEAPP_FAIL_CONT_FILE ) );
+                    INFO( 'You can `touch ' . LEAPP_FAIL_CONT_FILE . '` if you would like to skip this check.' );
                 }
             }
 
@@ -5292,13 +5292,17 @@ EOS
             $elapsed += $sleep_time;
         }
 
-        my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
-        $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
-        $msg .= sprintf( "    %s %s\n", "touch", LEAPP_FAIL_CONT_FILE );
-        $msg .= sprintf( "    %s\n",    '/scripts/elevate-cpanel --continue' );
-        $msg .= sprintf("The following log files may help in your investigation.\n");
-        $msg .= sprintf( "    %s\n", $upgrade_log );
-        $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
+        my $touch_file = LEAPP_FAIL_CONT_FILE;
+        my $leapp_txt  = LEAPP_REPORT_TXT;
+        my $msg        = <<~"END";
+    The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.
+    Once resolved, you can continue the upgrade by running the following commands:
+        touch $touch_file
+        /scripts/elevate-cpanel --continue
+    The following log files may help in your investigation.
+        $upgrade_log
+        $leapp_txt
+    END
         ERROR($msg);
 
         return 0;
@@ -7595,9 +7599,11 @@ sub run_stage_4 ($self) {
 
     # 10 minute timeout if no completion is seen.
     unless ( $self->leapp->wait_for_leapp_completion ) {
-        my $message = sprintf("The LEAPP upgrade process did not succeed\n");
-        $message .= sprintf( "Review the log at %s for more details\n", Elevate::Constants::LOG_FILE );
-        die($message);
+        my $log_file = Elevate::Constants::LOG_FILE;
+        die(<<~"END");
+        The LEAPP upgrade process did not succeed
+        Review the log at $log_file for more details
+        END
     }
 
     if ( Cpanel::OS::major() != 8 ) {    ## no critic(Cpanel::CpanelOS)

--- a/lib/Elevate/Leapp.pm
+++ b/lib/Elevate/Leapp.pm
@@ -267,7 +267,7 @@ sub wait_for_leapp_completion ($self) {
             INFO('Waiting for the LEAPP upgrade process to complete.');
             if ( $elapsed == 0 ) {    # First loop give extra advice
                 INFO( 'This process may take up to ' . int( $time_to_wait_for_leapp_completion / 60 ) . ' minutes.' );
-                INFO( sprintf( "You can `touch %s` if you would like to skip this check.", LEAPP_FAIL_CONT_FILE ) );
+                INFO( 'You can `touch ' . LEAPP_FAIL_CONT_FILE . '` if you would like to skip this check.' );
             }
         }
 
@@ -277,13 +277,17 @@ sub wait_for_leapp_completion ($self) {
 
     # We failed to find the completion message within 10 minutes.
 
-    my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
-    $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
-    $msg .= sprintf( "    %s %s\n", "touch", LEAPP_FAIL_CONT_FILE );
-    $msg .= sprintf( "    %s\n",    '/scripts/elevate-cpanel --continue' );
-    $msg .= sprintf("The following log files may help in your investigation.\n");
-    $msg .= sprintf( "    %s\n", $upgrade_log );
-    $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
+    my $touch_file = LEAPP_FAIL_CONT_FILE;
+    my $leapp_txt  = LEAPP_REPORT_TXT;
+    my $msg        = <<~"END";
+    The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.
+    Once resolved, you can continue the upgrade by running the following commands:
+        touch $touch_file
+        /scripts/elevate-cpanel --continue
+    The following log files may help in your investigation.
+        $upgrade_log
+        $leapp_txt
+    END
     ERROR($msg);
 
     return 0;

--- a/lib/Elevate/Leapp.pm
+++ b/lib/Elevate/Leapp.pm
@@ -25,10 +25,13 @@ use Config::Tiny ();
 
 use Log::Log4perl qw(:easy);
 
-use constant LEAPP_REPORT_JSON    => q[/var/log/leapp/leapp-report.json];
-use constant LEAPP_REPORT_TXT     => q[/var/log/leapp/leapp-report.txt];
-use constant LEAPP_UPGRADE_LOG    => q[/var/log/leapp/leapp-upgrade.log];
-use constant LEAPP_FAIL_CONT_FILE => q[/var/cpanel/elevate_leap_fail_continue];
+use constant LEAPP_REPORT_JSON       => q[/var/log/leapp/leapp-report.json];
+use constant LEAPP_REPORT_TXT        => q[/var/log/leapp/leapp-report.txt];
+use constant LEAPP_UPGRADE_LOG       => q[/var/log/leapp/leapp-upgrade.log];
+use constant LEAPP_FAIL_CONT_FILE    => q[/var/cpanel/elevate_leap_fail_continue];
+use constant LEAPP_COMPLETION_STRING => qr/Starting stage After of phase FirstBoot/;
+
+our $time_to_wait_for_leapp_completion = 10 * 60;
 
 use Simple::Accessor qw{
   cpev
@@ -236,69 +239,54 @@ sub extract_error_block_from_output ( $self, $text_ar ) {
     return $error_block;
 }
 
-sub check_upgrade_log_for_failures ($self) {
-    my $upgrade_log   = LEAPP_UPGRADE_LOG;
-    my $cont_file     = LEAPP_FAIL_CONT_FILE;
-    my $max_delay     = 60 * 10;                                     # 10 minutes. If changed don't forget to update the INFO line below.
-    my $search_string = 'Starting stage After of phase FirstBoot';
+# Returns 0 on failure.
+
+sub wait_for_leapp_completion ($self) {
+    my $upgrade_log = LEAPP_UPGRADE_LOG;
 
     if ( !-e $upgrade_log ) {
         ERROR("No LEAPP upgrade log detected at [$upgrade_log]");
-
-        return 1;
+        return 0;
     }
 
-    my $contents;
-    my $not_found = 1;
-    my $elapsed   = 0;
-    INFO( "Waiting to ensure the LEAPP upgrade process completes. This process may take up to " . int( $max_delay / 60 ) . " minutes." );
-    my $found = $self->_wait_for_log_contents( $search_string, $max_delay );
+    my $elapsed    = 0;
+    my $sleep_time = 3;    # Time to sleep, in seconds, between checks
 
-    if ( !$found ) {
-        if ( -e $cont_file ) {
-            INFO("LEAPP does not appear to have completed successfully, but continuing anyway because [$cont_file] exists");
+    # Wait to see the completion message from leapp. It may take a little after boot.
+    while ( $elapsed < $time_to_wait_for_leapp_completion ) {
+        my $contents = Cpanel::LoadFile::loadfile(LEAPP_UPGRADE_LOG) // '';
+        return 1 if $contents =~ LEAPP_COMPLETION_STRING;
 
-            return 0;
+        # Check each loop so they can drop the skip file in live.
+        if ( -e LEAPP_FAIL_CONT_FILE ) {
+            INFO( 'LEAPP does not appear to have completed successfully, but continuing anyway because [' . LEAPP_FAIL_CONT_FILE . '] exists' );
+            return 2;
         }
-        else {
-            my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
-            $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
-            $msg .= sprintf( "    %s\n", "touch $cont_file" );
-            $msg .= sprintf( "    %s\n", '/scripts/elevate-cpanel --continue' );
-            $msg .= sprintf("The following log files may help in your investigation.\n");
-            $msg .= sprintf( "    %s\n", $upgrade_log );
-            $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
-            ERROR($msg);
 
-            return 1;
+        if ( $elapsed % 30 == 0 ) {
+            INFO('Waiting for the LEAPP upgrade process to complete.');
+            if ( $elapsed == 0 ) {    # First loop give extra advice
+                INFO( 'This process may take up to ' . int( $time_to_wait_for_leapp_completion / 60 ) . ' minutes.' );
+                INFO( sprintf( "You can `touch %s` if you would like to skip this check.", LEAPP_FAIL_CONT_FILE ) );
+            }
         }
+
+        sleep $sleep_time;
+        $elapsed += $sleep_time;
     }
+
+    # We failed to find the completion message within 10 minutes.
+
+    my $msg = sprintf("The command 'leapp upgrade' did not complete successfully. Please investigate and resolve the issue.\n");
+    $msg .= sprintf("Once resolved, you can continue the upgrade by running the following commands:\n");
+    $msg .= sprintf( "    %s %s\n", "touch", LEAPP_FAIL_CONT_FILE );
+    $msg .= sprintf( "    %s\n",    '/scripts/elevate-cpanel --continue' );
+    $msg .= sprintf("The following log files may help in your investigation.\n");
+    $msg .= sprintf( "    %s\n", $upgrade_log );
+    $msg .= sprintf( "    %s\n", LEAPP_REPORT_TXT );
+    ERROR($msg);
 
     return 0;
-}
-
-sub _wait_for_log_contents ( $self, $search_string, $max_delay ) {
-    my $upgrade_log = LEAPP_UPGRADE_LOG;
-    my $found       = 0;
-    my $elapsed     = 0;
-    my $sleep_time  = 3;                   # Time to sleep, in seconds, between checks
-
-    while ( !$found && $elapsed < $max_delay ) {
-        my $contents = Cpanel::LoadFile::loadfile($upgrade_log) // '';
-        if ( $contents =~ /$search_string/ ) {
-            $found = 1;
-        }
-        else {
-            sleep $sleep_time;
-            $elapsed += $sleep_time;
-        }
-
-        if ( $elapsed > 0 && $elapsed % 30 == 0 ) {
-            INFO("Still waiting for the LEAPP upgrade process to complete.");
-        }
-    }
-
-    return $found;
 }
 
 sub _report_leapp_failure_and_die ($self) {

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1050,9 +1050,11 @@ sub run_stage_4 ($self) {
 
     # 10 minute timeout if no completion is seen.
     unless ( $self->leapp->wait_for_leapp_completion ) {
-        my $message = sprintf("The LEAPP upgrade process did not succeed\n");
-        $message .= sprintf( "Review the log at %s for more details\n", Elevate::Constants::LOG_FILE );
-        die($message);
+        my $log_file = Elevate::Constants::LOG_FILE;
+        die(<<~"END");
+        The LEAPP upgrade process did not succeed
+        Review the log at $log_file for more details
+        END
     }
 
     if ( Cpanel::OS::major() != 8 ) {    ## no critic(Cpanel::CpanelOS)

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1048,8 +1048,8 @@ sub run_stage_4 ($self) {
     Cpanel::OS::flush_disk_caches();
     Cpanel::OS::clear_cache_after_cloudlinux_update();
 
-    my $upgrade_errors = $self->leapp->check_upgrade_log_for_failures();
-    if ($upgrade_errors) {
+    # 10 minute timeout if no completion is seen.
+    unless ( $self->leapp->wait_for_leapp_completion ) {
         my $message = sprintf("The LEAPP upgrade process did not succeed\n");
         $message .= sprintf( "Review the log at %s for more details\n", Elevate::Constants::LOG_FILE );
         die($message);


### PR DESCRIPTION
Case RE-305: Also restructured _wait_for_log_contents to handle corner cases for a better flow

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

