### PR TITLE
Update documentation to reflect that CloudLinux upgrades are supported

### DIFF
--- a/docs-website-src/content/_index.md
+++ b/docs-website-src/content/_index.md
@@ -11,7 +11,12 @@ Read more from the [Elevate website](https://cpanel.github.io/elevate/).
 
 ## Goal
 
-The cPanel ELevate Project provides a script to upgrade an existing `cPanel & WHM` [CentOS&nbsp;7](https://centos.org) server installation to [AlmaLinux&nbsp;8](https://almalinux.org).
+The cPanel ELevate Project provides a script to upgrade an existing `cPanel & WHM` RHEL 7 based server installation to a RHEL 8 based installation.
+
+For example:
+
+1.  CentOS 7 to AlmaLinux 8
+2.  CloudLinux 7 to CloudLinux 8
 
 ## Disclaimer
 
@@ -27,7 +32,7 @@ Please contact [cPanel Technical Support](https://docs.cpanel.net/knowledge-base
 
 This project builds on the [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project, which leans heavily on the [LEAPP Project](https://leapp.readthedocs.io/en/latest/) created for in-place upgrades of RedHat-based systems.
 
-The [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project is very effective at upgrading the distro packages from [CentOS&nbsp;7](https://centos.org/) to [AlmaLinux&nbsp;8](https://almalinux.org/). However if you attempt use it directly on a CentOS 7-based [cPanel&nbsp;install](https://cpanel.net/), you will end up with a broken system.
+The [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project is very effective at upgrading the distro packages. However, if you attempt use it directly on a RHEL 7-based [cPanel&nbsp;install](https://cpanel.net/), you will end up with a broken system.
 
 This project was designed to be a wrapper around the [Alma Linux ELevate](https://wiki.almalinux.org/elevate/ELevate-quickstart-guide.html) project to allow you to successfully upgrade a [cPanel install](https://cpanel.net/) with an aim to minimize outages.
 
@@ -89,7 +94,7 @@ and then [running pre-checks](#pre-upgrade-checks).
 * x86_64 RPMs not in the primary CentOS repos are upgraded.
   * `rpm -qa|grep el7`
 * EA4 RPMs are incorrect
-  * EA4 provides different dependencies and linkage on C7/A8
+  * EA4 provides different dependencies and linkage on C7/A8 and CL7/CL8
 * cPanel binaries (cpanelsync) are invalid.
 * 3rdparty repo packages are not upgraded (imunify 360, epel, ...).
 * Manually installed Perl XS (arch) CPAN installs invalid.
@@ -98,6 +103,7 @@ and then [running pre-checks](#pre-upgrade-checks).
 * Cpanel::OS distro setting is wrong.
 * MySQL might now not be upgradable (MySQL versions < 8.0 are not normally present on A8).
 * The `nobody` user does not switch from UID 99 to UID 65534 even after upgrading to A8.
+* The cPanel CCS service may not start.
 
 ## Using the script
 
@@ -115,9 +121,9 @@ chmod 700 /scripts/elevate-cpanel
 
 We recommend you check for known blockers before you upgrade. The check is designed to not make any changes to your system.
 
-You can check if your system is ready to upgrade to **AlmaLinux 8** by running:
+You can check if your system is ready to upgrade by running:
 ```bash
-# Check AlmaLinux 8 upgrade (dry run mode)
+# Check upgrade (dry run mode)
 /scripts/elevate-cpanel --check
 ```
 
@@ -129,9 +135,8 @@ Once you have a backup of your server (**The cPanel elevate script does not back
 unreachable during this time.
 
 
-You can upgrade to **AlmaLinux 8** by running:
+You can upgrade by running:
 ```bash
-# Start the migration to AlmaLinux 8
 /scripts/elevate-cpanel --start
 ```
 
@@ -159,7 +164,7 @@ You can upgrade to **AlmaLinux 8** by running:
 /scripts/elevate-cpanel --continue
 ```
 
-## SumUp of upgrade process
+## Summary of upgrade process
 
 The elevate process is divided in multiple `stages`.
 Each `stage` is repsonsible for one part of the upgrade.
@@ -167,7 +172,7 @@ Between each stage a `reboot` is performed before doing a final reboot at the ve
 
 ### Stage 1
 
-Start the elevation process by installing the `elevate-cpanel` service responsible of the multiple reboots.
+Start the elevation process by installing the `elevate-cpanel` service responsible for the multiple reboots.
 
 ### Stage 2
 
@@ -176,7 +181,7 @@ Disable cPanel services and setup motd.
 
 ### Stage 3
 
-Setup the `elevate-release-latest-el7` repo and install leapp packages.
+Setup the elevate repo and install leapp packages.
 Prepare the cPanel packages for the update.
 
 Remove some known conflicting packages and backup some existing configurations. (these packages will be reinstalled druing the next stage).
@@ -189,7 +194,7 @@ In case of failure you probably want to reply to a few extra questions or remove
 
 ### Stage 4
 
-At this stage we should now run Alamalinux 8.
+At this stage we should now run an RHEL 8 based distro.
 Update cPanel product for the new distro.
 
 Restore removed packages during the previous stage.

--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -13,9 +13,8 @@ The following is a list of install states which the script will intentionally pr
 
 The following conditions are assumed to be in place any time you run this script:
 
-* You have **CentOS 7.9** or greater installed.
-  * We DO NOT support alternative RHEL 7 (including CloudLinux) variants.
-* You have cPanel version 102 or greater installed.
+* You have **CentOS** or **CloudLinux** 7.9 or greater installed.
+* You have cPanel version 110 installed.
 * You are logged in as **root**.
 
 ## Conflicting Processes
@@ -45,19 +44,16 @@ The following software is known to lead to a corrupt install if this script is u
 
 You can discover many of these issues by downloading `elevate-cpanel` and running `/scripts/elevate-cpanel --check`. Below is a summary of the major blockers people might encounter.
 
-* **distro is up to date**
-  * We expect yum update to indicate there is nothing to do.
-  * Mitigation: `yum update`
 * **cPanel is up to date**
   * You will need to be on a version mentioned in the "Latest cPanel & WHM Builds (All Architectures)" section at http://httpupdate.cpanel.net/
   * Mitigation: `/usr/local/cpanel/scripts/upcp`
 * **nameserver**
-  * cPanel provides support for a myriad of nameservers. (MyDNS, nsd, bind, powerdns). On AlmaLinux 8, it is preferred that you always be on PowerDNS.
+  * cPanel provides support for a myriad of nameservers. (MyDNS, nsd, bind, powerdns). On RHEL 8 based distros, it is preferred that you always be on PowerDNS.
   * Mitigation: `/scripts/setupnameserver powerdns`
 * **MySQL**
   * We will upgrade you automatically to MariaDB 10.6 during elevation if you do not do this in advance.
 * Some **EA4 packages** are not supported on AlmaLinux 8.
-  * Example: PHP versions 5.4 through 7.1 are available on CentOS 7 but not AlmaLinux 8. You would need to remove these packages before the upgrading to AlmaLinux 8. Doing so might impact your system users. Proceed with caution.
+  * Example: PHP versions 5.4 through 7.1 are available on CentOS 7 but not AlmaLinux 8. You would need to remove these packages before upgrading. Doing so might impact your system users. Proceed with caution.
 * The system **must** be able to control the boot process by changing the GRUB2 configuration.
   * The reason for this is that the framework which performs the upgrade of distro-provided software needs to be able to run a custom early boot environment (initrd) in order to safely upgrade the distro.
   * We check for this by seeing whether the kernel the system is currently running is the same version as that which the system believes is the default boot option.


### PR DESCRIPTION
Case RE-144:  In case RE-18, we added support for CloudLinux 7 to CloudLinux 8 upgrades.  At the time, this was deemed experimental, so we held off on updating our documentation to reflect this.  However, in version 33 of this script, the experimental tag for CloudLinux was removed.  As such, we now need to update the documentation to reflect that CloudLinux is supported.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

