### PR TITLE
Fix DNS name server blocker

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -957,6 +957,8 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
 
+    use Cpanel::Config::LoadCpConf ();
+
     use Cwd ();
 
     # use Log::Log4perl qw(:easy);
@@ -964,7 +966,13 @@ EOS
 
     sub check ($self) {
 
-        return $self->_blocker_non_bind_powerdns;
+        return $self->_blocker_non_bind_powerdns( _get_nameserver_type() );
+    }
+
+    sub _get_nameserver_type () {
+
+        my $cpconf = Cpanel::Config::LoadCpConf::loadcpconf();
+        return $cpconf->{'local_nameserver_type'} // '';
     }
 
     sub _blocker_non_bind_powerdns ( $self, $nameserver = '' ) {

--- a/lib/Elevate/Blockers/DNS.pm
+++ b/lib/Elevate/Blockers/DNS.pm
@@ -16,12 +16,20 @@ use Elevate::Constants ();
 
 use parent qw{Elevate::Blockers::Base};
 
+use Cpanel::Config::LoadCpConf ();
+
 use Cwd           ();
 use Log::Log4perl qw(:easy);
 
 sub check ($self) {
 
-    return $self->_blocker_non_bind_powerdns;
+    return $self->_blocker_non_bind_powerdns( _get_nameserver_type() );
+}
+
+sub _get_nameserver_type () {
+
+    my $cpconf = Cpanel::Config::LoadCpConf::loadcpconf();
+    return $cpconf->{'local_nameserver_type'} // '';
 }
 
 sub _blocker_non_bind_powerdns ( $self, $nameserver = '' ) {


### PR DESCRIPTION
Case RE-318:  Updated to check name server type the system is using in order to determine whether to block on it.

Changelog: Fix DNS blocker to check the systems name server type.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

