### PR TITLE
Provide more information with leapp preuprade blockers

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2245,6 +2245,10 @@ EOS
 
         $self->_check_for_fatal_errors($out);
 
+        if ( $self->blockers->num_blockers_found() > 0 ) {
+            INFO('Leapp found issues which would prevent the upgrade, more information can be obtained in the files under /var/log/leapp');
+        }
+
         return;
     }
 

--- a/lib/Elevate/Blockers/Leapp.pm
+++ b/lib/Elevate/Blockers/Leapp.pm
@@ -39,6 +39,10 @@ sub check ($self) {
 
     $self->_check_for_fatal_errors($out);
 
+    if ( $self->blockers->num_blockers_found() > 0 ) {
+        INFO('Leapp found issues which would prevent the upgrade, more information can be obtained in the files under /var/log/leapp');
+    }
+
     return;
 }
 


### PR DESCRIPTION
Case RE-261:

When an unknown blockage happens, a generic message is provided to the user. We wish to to provide a more meaningful message to help the user find more information to why they were blocked. The files under'/var/log/leapp' will sometimes contain more detailed information about leapp preupgrade blockers.

Changelog: In the event of a blocker found by performing
  a leapp preupgrade, direct the user to the /var/log/leapp
  directory to find more information.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

