### PR TITLE
Do not block on dropped PHP packages if no domains use them

### DIFF
--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -15,6 +15,9 @@ use cPstrict;
 use Elevate::EA4       ();
 use Elevate::StageFile ();
 
+use Cpanel::JSON            ();
+use Cpanel::SafeRun::Simple ();
+
 use parent qw{Elevate::Blockers::Base};
 
 use Cwd           ();
@@ -41,17 +44,7 @@ sub _blocker_ea4_profile ($self) {
 
     Elevate::EA4::backup();
 
-    my $stash        = Elevate::StageFile::read_stage_file();
-    my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
-    return unless scalar keys $dropped_pkgs->%*;
-
-    my @incompatible_packages;
-    foreach my $pkg ( sort keys $dropped_pkgs->%* ) {
-        my $type = $dropped_pkgs->{$pkg} // '';
-        next if $type eq 'exp';                          # use of experimental packages is a non blocker
-        next if $pkg =~ m/^ea-openssl(?:11)?-devel$/;    # ignore these packages, as they can be orphans
-        push @incompatible_packages, $pkg;
-    }
+    my @incompatible_packages = $self->_get_incompatible_packages();
 
     return unless @incompatible_packages;
 
@@ -62,6 +55,66 @@ sub _blocker_ea4_profile ($self) {
     Please remove these packages before continuing the update.
     $list
     EOS
+}
+
+sub _get_incompatible_packages ($self) {
+
+    my $stash        = Elevate::StageFile::read_stage_file();
+    my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
+    return unless scalar keys $dropped_pkgs->%*;
+
+    my @incompatible;
+    foreach my $pkg ( sort keys %$dropped_pkgs ) {
+        my $type = $dropped_pkgs->{$pkg} // '';
+        next if $type eq 'exp';                          # use of experimental packages is a non blocker
+        next if $pkg =~ m/^ea-openssl(?:11)?-devel$/;    # ignore these packages, as they can be orphans
+
+        if ( $pkg =~ m/^(ea-php[0-9]+)/ ) {
+            my $php_pkg = $1;
+            next unless $self->_php_version_is_in_use($php_pkg);
+        }
+
+        push @incompatible, $pkg;
+    }
+
+    return @incompatible;
+}
+
+sub _php_version_is_in_use ( $self, $php ) {
+    my $current_php_usage = $self->_get_php_versions_in_use();
+
+    # Always return true if the api call failed
+    return 1 if $current_php_usage->{api_fail};
+
+    return $current_php_usage->{$php} ? 1 : 0;
+}
+
+my $php_versions_in_use;
+
+sub _get_php_versions_in_use ($self) {
+    return $php_versions_in_use if defined $php_versions_in_use && ref $php_versions_in_use eq 'HASH';
+
+    my $out    = Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 --output=json php_get_vhost_versions});
+    my $result = eval { Cpanel::JSON::Load($out); } // {};
+
+    unless ( $result->{metadata}{result} ) {
+
+        WARN( <<~"EOS" );
+        Unable to determine if PHP versions that will be dropped are in use by
+        a domain.  Assuming that they are in use and blocking to be safe.
+
+        EOS
+
+        $php_versions_in_use->{api_fail} = 1;
+        return $php_versions_in_use;
+    }
+
+    foreach my $domain_info ( @{ $result->{data}{versions} } ) {
+        my $php_version = $domain_info->{version};
+        $php_versions_in_use->{$php_version} = 1;
+    }
+
+    return $php_versions_in_use;
 }
 
 1;


### PR DESCRIPTION
Case RE-313:  Currently, the EA4 blocker will block if there are any packages that will be dropped (not provided on the newer OS) during the elevation.  This change teaches the blocker to check to see if any domains are using the installed version of PHP.  If there are no domains using the version of PHP that will be dropped, then we no longer block for that version of PHP and allow the elevation to continue if that was the only thing blocking it.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

