### PR TITLE
Restore Imunify before EA4 post_leapp

### DIFF
--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1089,7 +1089,8 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->run_component_once( 'EA4' => 'post_leapp' );
+    $self->run_component_once( 'Imunify' => 'post_leapp' );
+    $self->run_component_once( 'EA4'     => 'post_leapp' );
 
     $self->run_once(
         upcp => sub {
@@ -1331,7 +1332,6 @@ sub post_leapp_update_restore ($self) {
     $self->run_component_once( 'JetBackup'     => 'post_leapp' );
     $self->run_component_once( 'Kernel'        => 'post_leapp' );
     $self->run_component_once( 'KernelCare'    => 'post_leapp' );
-    $self->run_component_once( 'Imunify'       => 'post_leapp' );
     $self->run_component_once( 'NixStats'      => 'post_leapp' );
     $self->run_component_once( 'LiteSpeed'     => 'post_leapp' );
 


### PR DESCRIPTION
Case RE-313:  Imunify needs to be restored before EA4 post_leapp to ensure that hardened PHP versions remain in place if they are installed. This changes the ordering of the post_leapp components so that Imunify is restored before EA4.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

