### PR TITLE
Add blocker if '/usr' is a separate private mount point

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -26,6 +26,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Blockers/Grub2.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/IsContainer.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/JetBackup.pm'}            = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/MountPoints.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/NICs.pm'}                 = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/OVH.pm'}                  = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Python.pm'}               = 'script/elevate-cpanel.PL.static';
@@ -240,6 +241,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Elevate::Blockers::Grub2            ();
     use Elevate::Blockers::IsContainer      ();
     use Elevate::Blockers::JetBackup        ();
+    use Elevate::Blockers::MountPoints      ();
     use Elevate::Blockers::NICs             ();
     use Elevate::Blockers::OVH              ();
     use Elevate::Blockers::Python           ();
@@ -263,6 +265,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
       IsContainer
       ElevateScript
+      MountPoints
       SSH
 
       DiskSpace
@@ -1422,6 +1425,42 @@ EOS
     1;
 
 }    # --- END lib/Elevate/Blockers/JetBackup.pm
+
+{    # --- BEGIN lib/Elevate/Blockers/MountPoints.pm
+
+    package Elevate::Blockers::MountPoints;
+
+    use cPstrict;
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    use constant FINDMNT_BIN => '/usr/bin/findmnt';
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    sub check ($self) {
+
+        my $out = $self->ssystem_capture_output( FINDMNT_BIN, '-no', 'PROPAGATION', '/usr' );
+
+        return unless $out->{status} == 0;
+        return unless grep { $_ =~ m/private/ } @{ $out->{stdout} };
+
+        return $self->has_blocker( <<~'EOS');
+    The current filesystem setup on your server will prevent 'leapp' from being
+    able to load these packages which will result in 'leapp' failing which will
+    lead to a broken system.  This is being addressed by CloudLinux in
+    CLOS-2492.  A potential fix is currently in testing as of May 6th 2024.
+    Once the fix is released to the public, this blocker will be removed.
+
+    EOS
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Blockers/MountPoints.pm
 
 {    # --- BEGIN lib/Elevate/Blockers/NICs.pm
 
@@ -7306,6 +7345,7 @@ use Elevate::Blockers::ElevateScript    ();
 use Elevate::Blockers::Grub2            ();
 use Elevate::Blockers::IsContainer      ();
 use Elevate::Blockers::JetBackup        ();
+use Elevate::Blockers::MountPoints      ();
 use Elevate::Blockers::NICs             ();
 use Elevate::Blockers::OVH              ();    # using a constant
 use Elevate::Blockers::Python           ();

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -28,6 +28,7 @@ use Elevate::Blockers::EA4              ();
 use Elevate::Blockers::Grub2            ();
 use Elevate::Blockers::IsContainer      ();
 use Elevate::Blockers::JetBackup        ();
+use Elevate::Blockers::MountPoints      ();
 use Elevate::Blockers::NICs             ();
 use Elevate::Blockers::OVH              ();
 use Elevate::Blockers::Python           ();
@@ -52,6 +53,7 @@ our @BLOCKERS = qw{
 
   IsContainer
   ElevateScript
+  MountPoints
   SSH
 
   DiskSpace

--- a/lib/Elevate/Blockers/MountPoints.pm
+++ b/lib/Elevate/Blockers/MountPoints.pm
@@ -1,0 +1,39 @@
+package Elevate::Blockers::MountPoints;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::MountPoints
+
+Blocker to check if '/usr' is a private mount point on a separate partition
+
+=cut
+
+use cPstrict;
+
+use parent qw{Elevate::Blockers::Base};
+
+use constant FINDMNT_BIN => '/usr/bin/findmnt';
+
+use Log::Log4perl qw(:easy);
+
+sub check ($self) {
+
+    my $out = $self->ssystem_capture_output( FINDMNT_BIN, '-no', 'PROPAGATION', '/usr' );
+
+    # This will return 1 if '/usr' is not a separate mount point
+    return unless $out->{status} == 0;
+    return unless grep { $_ =~ m/private/ } @{ $out->{stdout} };
+
+    return $self->has_blocker( <<~'EOS');
+    The current filesystem setup on your server will prevent 'leapp' from being
+    able to load these packages which will result in 'leapp' failing which will
+    lead to a broken system.  This is being addressed by CloudLinux in
+    CLOS-2492.  A potential fix is currently in testing as of May 6th 2024.
+    Once the fix is released to the public, this blocker will be removed.
+
+    EOS
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -245,6 +245,7 @@ use Elevate::Blockers::ElevateScript    ();
 use Elevate::Blockers::Grub2            ();
 use Elevate::Blockers::IsContainer      ();
 use Elevate::Blockers::JetBackup        ();
+use Elevate::Blockers::MountPoints      ();
 use Elevate::Blockers::NICs             ();
 use Elevate::Blockers::OVH              ();    # using a constant
 use Elevate::Blockers::Python           ();

--- a/t/blocker-MountPoints.t
+++ b/t/blocker-MountPoints.t
@@ -1,0 +1,62 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockFile 0.032;
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $cpev_mock = Test::MockModule->new('cpev');
+
+my $cpev = cpev->new;
+my $mp   = $cpev->get_blocker('MountPoints');
+
+my @cmds;
+my @stdout;
+my $capture_output_status;
+$cpev_mock->redefine(
+    ssystem_capture_output => sub ( $, @args ) {
+        push @cmds, [@args];
+        return { status => $capture_output_status, stdout => \@stdout, stderr => [] };
+    },
+);
+
+$capture_output_status = 1;
+is( $mp->check(), undef, 'No blockers are returned when /usr is NOT a separate mount point' );
+
+$capture_output_status = 0;
+$stdout[0] = 'shared';
+is( $mp->check(), undef, 'No blockers are returned when /usr is a separate shared mount point' );
+
+$stdout[0] = 'private';
+my $blocker = $mp->check();
+like(
+    $blocker,
+    {
+        id  => 'Elevate::Blockers::MountPoints::check',
+        msg => qr/The current filesystem setup on your server will prevent/,
+    },
+    'A blocker is returned when /usr is a separate private mount point',
+);
+
+message_seen( WARN => qr/The current filesystem setup on your server will prevent/ );
+
+no_messages_seen();
+
+done_testing();


### PR DESCRIPTION
Case RE-306:  The 'leapp' utility needs to be able to load packages stored within the
'/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms' directory.  If '/usr' is a separate private bind mount, the 'leapp' utility will be unable to load the packages stored within this directory which will result in 'leapp' failing, and leaving systems in a broken state.  In order to avoid this, we now detect this scenario and block the elevation.

Changelog: Add blocker if '/usr' is a separaate private mount point

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

