### PR TITLE
Teach EA4 blocker about hardened PHP provided by Imunify 360

### DIFF
--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -12,10 +12,12 @@ Blocker to check EasyApache profile compatibility.
 
 use cPstrict;
 
+use Elevate::Constants ();
 use Elevate::EA4       ();
 use Elevate::StageFile ();
 
 use Cpanel::JSON            ();
+use Cpanel::Pkgr            ();
 use Cpanel::SafeRun::Simple ();
 
 use parent qw{Elevate::Blockers::Base};
@@ -64,6 +66,7 @@ sub _get_incompatible_packages ($self) {
     return unless scalar keys $dropped_pkgs->%*;
 
     my @incompatible;
+    my @imunify_pkgs;
     foreach my $pkg ( sort keys %$dropped_pkgs ) {
         my $type = $dropped_pkgs->{$pkg} // '';
         next if $type eq 'exp';                          # use of experimental packages is a non blocker
@@ -72,12 +75,31 @@ sub _get_incompatible_packages ($self) {
         if ( $pkg =~ m/^(ea-php[0-9]+)/ ) {
             my $php_pkg = $1;
             next unless $self->_php_version_is_in_use($php_pkg);
+
+            if ( $self->_php_is_provided_by_imunify_360($php_pkg) ) {
+                push @imunify_pkgs, $pkg;
+                next;
+            }
         }
 
         push @incompatible, $pkg;
     }
 
+    if (@imunify_pkgs) {
+        Elevate::StageFile::update_stage_file( { ea4_imunify_packages => \@imunify_pkgs } );
+    }
+
     return @incompatible;
+}
+
+sub _php_is_provided_by_imunify_360 ( $self, $php ) {
+    return 0 unless -x Elevate::Constants::IMUNIFY_AGENT;
+
+    my $version = Cpanel::Pkgr::get_package_version($php);
+
+    # If the package is coming from CL, then we can assume
+    # that it is provided by Imunify 360 at this point
+    return $version =~ m/cloudlinux/ ? 1 : 0;
 }
 
 sub _php_version_is_in_use ( $self, $php ) {

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -32,6 +32,7 @@ sub post_leapp ($self) {
 
     $self->run_once('_restore_ea4_profile');
     $self->run_once('_restore_ea_addons');
+    $self->run_once('_restore_imunify_phps');
 
     # This needs to happen last (after EA4 has been reinstalled)
     #
@@ -146,6 +147,15 @@ sub _restore_config_files ($self) {
         $self->rpm->restore_config_files(@config_files_to_restore);
     }
 
+    return;
+}
+
+sub _restore_imunify_phps ($self) {
+
+    my $php_pkgs = Elevate::StageFile::read_stage_file('ea4_imunify_packages');
+    return unless scalar $php_pkgs->@*;
+
+    $self->dnf->install(@$php_pkgs);
     return;
 }
 


### PR DESCRIPTION
Case RE-313: Imunify 360 is a paid product that provides hardened PHP versions that are available on newer OS versions.  Currently, the EA4 blocker would block on older PHP versions such as ea-php54 since they are EOL and not provided on AlmaLinux 8 by cPanel.  However, Imunify 360 provides these versions of PHP on AlmaLlinux 8 as well as 7 so elevate should not block if the hardened PHP version is provided by Imunify 360. This change updates the EA4 blocker to no longer block on hardened PHP versions that are provided by Imunify 360.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

