### PR TITLE
Have script block if mount -a fails to exit cleanly

### DIFF
--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -74,6 +74,10 @@ You can discover many of these issues by downloading `elevate-cpanel` and runnin
 
 The following is a list of other known issues that could prevent your server's successful elevation.
 
+## Filesystem
+
+Since elevate needs to reboot your system multiple times as part of the upgrade process, we ensure that the command 'mount -a' succeeds successfully before allowing the elevation to proceed.  The reason for this is that we need to be able to trust that the filesystem remains the same between each reboot.
+
 ## PostgreSQL
 
 If you are using the PostgreSQL software provided by your distribution (which includes PostgreSQL as installed by cPanel), ELevate will upgrade the software packages. However, your PostgreSQL service is unlikely to start properly. The reason for this is that ELevate will **not** attempt to update the data directory being used by your PostgreSQL instance to store settings and databases; and PostgreSQL will detect this condition and refuse to start, to protect your data from corruption, until you have performed this update.

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1143,12 +1143,11 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
-    use constant {
-        GRUB2_WORKAROUND_NONE      => 0,
-        GRUB2_WORKAROUND_OLD       => 1,
-        GRUB2_WORKAROUND_NEW       => 2,
-        GRUB2_WORKAROUND_UNCERTAIN => -1,
-    };
+    use constant GRUB2_WORKAROUND_NONE => 0;
+    use constant GRUB2_WORKAROUND_OLD  => 1;
+    use constant GRUB2_WORKAROUND_NEW  => 2;
+
+    use constant GRUB2_WORKAROUND_UNCERTAIN => -1;
 
     sub GRUB2_PREFIX_DEBIAN { return '/boot/grub' }
     sub GRUB2_PREFIX_RHEL   { return '/boot/grub2' }

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1437,11 +1437,52 @@ EOS
     BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
 
     use constant FINDMNT_BIN => '/usr/bin/findmnt';
+    use constant MOUNT_BIN   => '/usr/bin/mount';
 
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
     sub check ($self) {
+        $self->_check_for_rhel_23449();
+        $self->_ensure_mount_dash_a_succeeds();
+        return;
+    }
+
+    sub _ensure_mount_dash_a_succeeds ($self) {
+
+        return if $self->is_check_mode();
+
+        my $ret    = $self->ssystem_capture_output( MOUNT_BIN, '-a' );
+        my $stderr = join "\n", @{ $ret->{stderr} };
+        if ( $ret->{status} != 0 ) {
+
+            $self->blockers->abort_on_first_blocker(1);
+
+            my $bin = MOUNT_BIN();
+            return $self->has_blocker( <<~"EOS");
+        The following command failed to execute successfully on your server:
+
+        $bin -a
+
+        The following message was given as the reason for the failure:
+
+        $stderr
+
+        Since this script will need to reboot your server, we need to ensure a
+        consistent file system in between in each reboot.  Please review the
+        entries in '/etc/fstab' and ensure that each entry is valid and that
+        '$bin -a' returns exit code 0 before continuing.
+
+        If your '/etc/fstab' file has not been customized, you may want to
+        consider reaching out to cPanel Support for assistance:
+        https://docs.cpanel.net/knowledge-base/technical-support-services/how-to-open-a-technical-support-ticket/
+        EOS
+        }
+
+        return;
+    }
+
+    sub _check_for_rhel_23449 ($self) {
 
         my $out = $self->ssystem_capture_output( FINDMNT_BIN, '-no', 'PROPAGATION', '/usr' );
 

--- a/lib/Elevate/Blockers/Grub2.pm
+++ b/lib/Elevate/Blockers/Grub2.pm
@@ -22,12 +22,11 @@ use parent qw{Elevate::Blockers::Base};
 use Cwd           ();
 use Log::Log4perl qw(:easy);
 
-use constant {
-    GRUB2_WORKAROUND_NONE      => 0,
-    GRUB2_WORKAROUND_OLD       => 1,
-    GRUB2_WORKAROUND_NEW       => 2,
-    GRUB2_WORKAROUND_UNCERTAIN => -1,
-};
+use constant GRUB2_WORKAROUND_NONE => 0;
+use constant GRUB2_WORKAROUND_OLD  => 1;
+use constant GRUB2_WORKAROUND_NEW  => 2;
+
+use constant GRUB2_WORKAROUND_UNCERTAIN => -1;
 
 sub GRUB2_PREFIX_DEBIAN { return '/boot/grub' }
 sub GRUB2_PREFIX_RHEL   { return '/boot/grub2' }

--- a/lib/Elevate/Blockers/MountPoints.pm
+++ b/lib/Elevate/Blockers/MountPoints.pm
@@ -15,10 +15,53 @@ use cPstrict;
 use parent qw{Elevate::Blockers::Base};
 
 use constant FINDMNT_BIN => '/usr/bin/findmnt';
+use constant MOUNT_BIN   => '/usr/bin/mount';
 
 use Log::Log4perl qw(:easy);
 
 sub check ($self) {
+    $self->_check_for_rhel_23449();
+    $self->_ensure_mount_dash_a_succeeds();
+    return;
+}
+
+sub _ensure_mount_dash_a_succeeds ($self) {
+
+    # Only do this in start mode because it can change the file system mounts
+    return if $self->is_check_mode();
+
+    my $ret    = $self->ssystem_capture_output( MOUNT_BIN, '-a' );
+    my $stderr = join "\n", @{ $ret->{stderr} };
+    if ( $ret->{status} != 0 ) {
+
+        # No use in letting leapp preupgrade execute if this fails
+        $self->blockers->abort_on_first_blocker(1);
+
+        my $bin = MOUNT_BIN();
+        return $self->has_blocker( <<~"EOS");
+        The following command failed to execute successfully on your server:
+
+        $bin -a
+
+        The following message was given as the reason for the failure:
+
+        $stderr
+
+        Since this script will need to reboot your server, we need to ensure a
+        consistent file system in between in each reboot.  Please review the
+        entries in '/etc/fstab' and ensure that each entry is valid and that
+        '$bin -a' returns exit code 0 before continuing.
+
+        If your '/etc/fstab' file has not been customized, you may want to
+        consider reaching out to cPanel Support for assistance:
+        https://docs.cpanel.net/knowledge-base/technical-support-services/how-to-open-a-technical-support-ticket/
+        EOS
+    }
+
+    return;
+}
+
+sub _check_for_rhel_23449 ($self) {
 
     my $out = $self->ssystem_capture_output( FINDMNT_BIN, '-no', 'PROPAGATION', '/usr' );
 


### PR DESCRIPTION
Case RE-134: Since the script reboots the server and relies on the file system to be consistent between reboots, we need to ensure that mount -a exits cleanly before starting the elevate process.  This change adds a blocker to the script is mount -a fails to exit cleanly.

Changelog: Have script block if mount -a fails to exit cleanly

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

