### PR TITLE
Restore PHP vhost versions post elevate

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1081,6 +1081,7 @@ EOS
         }
 
         if (@imunify_pkgs) {
+            Elevate::StageFile::remove_from_stage_file('ea4_imunify_packages');
             Elevate::StageFile::update_stage_file( { ea4_imunify_packages => \@imunify_pkgs } );
         }
 
@@ -1123,7 +1124,11 @@ EOS
             return $php_versions_in_use;
         }
 
-        foreach my $domain_info ( @{ $result->{data}{versions} } ) {
+        my $data = $result->{data}{versions};
+        Elevate::StageFile::remove_from_stage_file('php_get_vhost_versions');
+        Elevate::StageFile::update_stage_file( { php_get_vhost_versions => $data } );
+
+        foreach my $domain_info (@$data) {
             my $php_version = $domain_info->{version};
             $php_versions_in_use->{$php_version} = 1;
         }
@@ -3179,6 +3184,9 @@ EOS
     use Elevate::EA4       ();
     use Elevate::StageFile ();
 
+    use Cpanel::JSON            ();
+    use Cpanel::SafeRun::Simple ();
+
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
@@ -3202,6 +3210,8 @@ EOS
         $self->run_once('_restore_imunify_phps');
 
         $self->run_once('_restore_config_files');
+
+        $self->run_once('_ensure_sites_use_correct_php_version');
 
         return;
     }
@@ -3311,6 +3321,45 @@ EOS
         return unless scalar $php_pkgs->@*;
 
         $self->dnf->install(@$php_pkgs);
+        return;
+    }
+
+    sub _ensure_sites_use_correct_php_version ($self) {
+
+        my $vhost_versions = Elevate::StageFile::read_stage_file('php_get_vhost_versions');
+        return unless ref $vhost_versions eq 'ARRAY';
+        return unless scalar $vhost_versions->@*;
+
+        foreach my $vhost_entry (@$vhost_versions) {
+            my $version = $vhost_entry->{version};
+            my $vhost   = $vhost_entry->{vhost};
+            my $fpm     = $vhost_entry->{php_fpm};
+
+            my @api_cmd = (
+                '/usr/local/cpanel/bin/whmapi1',
+                '--output=json',
+                'php_set_vhost_versions',
+                "version=$version",
+                "vhost=$vhost",
+                "php_fpm=$fpm",
+            );
+
+            my $out    = Cpanel::SafeRun::Simple::saferunnoerror(@api_cmd);
+            my $result = eval { Cpanel::JSON::Load($out); } // {};
+
+            my $api_string = join( ' ', @api_cmd );
+            unless ( $result->{metadata}{result} ) {
+
+                WARN( <<~"EOS" );
+            Unable to set $vhost back to its desired PHP version.  This site may
+            be using the incorrect version of PHP.  To set it back to its
+            original PHP version, execute the following command:
+
+            $api_string
+            EOS
+            }
+        }
+
         return;
     }
 

--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -87,6 +87,7 @@ sub _get_incompatible_packages ($self) {
     }
 
     if (@imunify_pkgs) {
+        Elevate::StageFile::remove_from_stage_file('ea4_imunify_packages');
         Elevate::StageFile::update_stage_file( { ea4_imunify_packages => \@imunify_pkgs } );
     }
 
@@ -132,7 +133,11 @@ sub _get_php_versions_in_use ($self) {
         return $php_versions_in_use;
     }
 
-    foreach my $domain_info ( @{ $result->{data}{versions} } ) {
+    my $data = $result->{data}{versions};
+    Elevate::StageFile::remove_from_stage_file('php_get_vhost_versions');
+    Elevate::StageFile::update_stage_file( { php_get_vhost_versions => $data } );
+
+    foreach my $domain_info (@$data) {
         my $php_version = $domain_info->{version};
         $php_versions_in_use->{$php_version} = 1;
     }

--- a/t/blocker-ea4.t
+++ b/t/blocker-ea4.t
@@ -114,6 +114,7 @@ EOS
             update_stage_file => sub ($data) {
                 $update_stage_file_data = $data;
             },
+            remove_from_stage_file => 1,
         );
 
         ok( !$ea4->_blocker_ea4_profile(), "no ea4 blockers: profile without any dropped_pkgs" );
@@ -267,7 +268,7 @@ Please remove these packages before continuing the update.
 
     $mock_ea4->unmock('_get_php_versions_in_use');
 
-    my $mock_result;
+    my $mock_result = 'nope';
     my @saferun_calls;
     my $mock_saferunnoerror = Test::MockModule->new('Cpanel::SafeRun::Simple');
     $mock_saferunnoerror->redefine(
@@ -275,6 +276,12 @@ Please remove these packages before continuing the update.
             @saferun_calls = @_;
             return $mock_result;
         },
+    );
+
+    my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
+    $mock_stagefile->redefine(
+        update_stage_file      => 1,
+        remove_from_stage_file => 1,
     );
 
     is( $ea4->_get_php_versions_in_use(), { api_fail => 1, }, 'api_fail is set when the API call does not return valid JSON' );


### PR DESCRIPTION
Case RE-358:  If the version of PHP being installed is provided by Imunify 360 post elevate, it is possible that any domains using it will be reset to use the inherited version of PHP instead.  Since this can break the website for those domains, we need to ensure that they are set to the correct version of PHP after elevate completes.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

