### PR TITLE
Teach EA4 blocker about ea-profiles-cloudlinux provided by Imunify 360

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1071,10 +1071,15 @@ EOS
                 my $php_pkg = $1;
                 next unless $self->_php_version_is_in_use($php_pkg);
 
-                if ( $self->_php_is_provided_by_imunify_360($php_pkg) ) {
+                if ( $self->_pkg_is_provided_by_imunify_360($php_pkg) ) {
                     push @imunify_pkgs, $pkg;
                     next;
                 }
+            }
+
+            if ( $pkg eq 'ea-profiles-cloudlinux' && $self->_pkg_is_provided_by_imunify_360($pkg) ) {
+                push @imunify_pkgs, $pkg;
+                next;
             }
 
             push @incompatible, $pkg;
@@ -1087,10 +1092,10 @@ EOS
         return @incompatible;
     }
 
-    sub _php_is_provided_by_imunify_360 ( $self, $php ) {
+    sub _pkg_is_provided_by_imunify_360 ( $self, $pkg ) {
         return 0 unless -x Elevate::Constants::IMUNIFY_AGENT;
 
-        my $version = Cpanel::Pkgr::get_package_version($php);
+        my $version = Cpanel::Pkgr::get_package_version($pkg);
 
         return $version =~ m/cloudlinux/ ? 1 : 0;
     }

--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -77,10 +77,15 @@ sub _get_incompatible_packages ($self) {
             my $php_pkg = $1;
             next unless $self->_php_version_is_in_use($php_pkg);
 
-            if ( $self->_php_is_provided_by_imunify_360($php_pkg) ) {
+            if ( $self->_pkg_is_provided_by_imunify_360($php_pkg) ) {
                 push @imunify_pkgs, $pkg;
                 next;
             }
+        }
+
+        if ( $pkg eq 'ea-profiles-cloudlinux' && $self->_pkg_is_provided_by_imunify_360($pkg) ) {
+            push @imunify_pkgs, $pkg;
+            next;
         }
 
         push @incompatible, $pkg;
@@ -93,10 +98,10 @@ sub _get_incompatible_packages ($self) {
     return @incompatible;
 }
 
-sub _php_is_provided_by_imunify_360 ( $self, $php ) {
+sub _pkg_is_provided_by_imunify_360 ( $self, $pkg ) {
     return 0 unless -x Elevate::Constants::IMUNIFY_AGENT;
 
-    my $version = Cpanel::Pkgr::get_package_version($php);
+    my $version = Cpanel::Pkgr::get_package_version($pkg);
 
     # If the package is coming from CL, then we can assume
     # that it is provided by Imunify 360 at this point

--- a/t/blocker-ea4.t
+++ b/t/blocker-ea4.t
@@ -155,7 +155,7 @@ Please remove these packages before continuing the update.
 
         $mock_ea4->redefine(
             _php_version_is_in_use          => 1,
-            _php_is_provided_by_imunify_360 => 0,
+            _pkg_is_provided_by_imunify_360 => 0,
         );
 
         $stage_ea4->{'dropped_pkgs'} = {
@@ -185,7 +185,7 @@ Please remove these packages before continuing the update.
 
         $mock_ea4->redefine(
             _php_version_is_in_use          => 0,
-            _php_is_provided_by_imunify_360 => 0,
+            _pkg_is_provided_by_imunify_360 => 0,
         );
 
         $stage_ea4->{'dropped_pkgs'} = {
@@ -197,7 +197,7 @@ Please remove these packages before continuing the update.
 
         $mock_ea4->redefine(
             _php_version_is_in_use          => 0,
-            _php_is_provided_by_imunify_360 => 1,
+            _pkg_is_provided_by_imunify_360 => 1,
         );
 
         ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is an ea-php version that is in use but provided by Imunify 360';
@@ -209,9 +209,25 @@ Please remove these packages before continuing the update.
             'No ea-php packages need to be installed for Imunify 360 when the PHP version is not in use'
         ) or diag explain $update_stage_file_data;
 
+        $stage_ea4->{'dropped_pkgs'} = {
+            'ea-php42'               => 'reg',
+            'ea-profiles-cloudlinux' => 'reg',
+        };
+
+        ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is "ea-profiles-cloudlinux" and provided by Imunify 360';
+        ea_info_check($target_os);
+
+        is(
+            $update_stage_file_data,
+            {
+                ea4_imunify_packages => ['ea-profiles-cloudlinux'],
+            },
+            'No blocker for ea-profiles-cloudlinux provided by Imunify 360'
+        );
+
         $mock_ea4->redefine(
             _php_version_is_in_use          => 1,
-            _php_is_provided_by_imunify_360 => 1,
+            _pkg_is_provided_by_imunify_360 => 1,
         );
 
         ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is an ea-php version that is in use but provided by Imunify 360';
@@ -220,7 +236,7 @@ Please remove these packages before continuing the update.
         is(
             $update_stage_file_data,
             {
-                ea4_imunify_packages => ['ea-php42'],
+                ea4_imunify_packages => [ 'ea-php42', 'ea-profiles-cloudlinux' ],
             },
             'No ea-php packages need to be installed for Imunify 360 when the PHP version is not in use'
         ) or diag explain $update_stage_file_data;


### PR DESCRIPTION
Case RE-362: When Imunify 360 is installed, it is possible to install the ea-profiles-cloudlinux package which is provided by Imunify 360 and available on C7 and A8.  Previously, the EA4 blocker would consider ea-profiles-cloudlinux a dropped package and block based on it being installed.  This change teaches the blocker to check to see if this package is provided by Imunify 360 and allows it the elevation to continue if it is.  It also adds this package to the list of packages provided by Imunify 360 that need to be reinstalled after the elevation completes if it is installed and provided by Imunify 360.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

