### PR TITLE
Remove blocker for when /usr is a separate private mount point

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1527,7 +1527,6 @@ EOS
     INIT { Log::Log4perl->import(qw{:easy}); }
 
     sub check ($self) {
-        $self->_check_for_rhel_23449();
         $self->_ensure_mount_dash_a_succeeds();
         return;
     }
@@ -1564,23 +1563,6 @@ EOS
         }
 
         return;
-    }
-
-    sub _check_for_rhel_23449 ($self) {
-
-        my $out = $self->ssystem_capture_output( FINDMNT_BIN, '-no', 'PROPAGATION', '/usr' );
-
-        return unless $out->{status} == 0;
-        return unless grep { $_ =~ m/private/ } @{ $out->{stdout} };
-
-        return $self->has_blocker( <<~'EOS');
-    The current filesystem setup on your server will prevent 'leapp' from being
-    able to load these packages which will result in 'leapp' failing which will
-    lead to a broken system.  This is being addressed by CloudLinux in
-    CLOS-2492.  A potential fix is currently in testing as of May 6th 2024.
-    Once the fix is released to the public, this blocker will be removed.
-
-    EOS
     }
 
     1;

--- a/lib/Elevate/Blockers/MountPoints.pm
+++ b/lib/Elevate/Blockers/MountPoints.pm
@@ -20,7 +20,6 @@ use constant MOUNT_BIN   => '/usr/bin/mount';
 use Log::Log4perl qw(:easy);
 
 sub check ($self) {
-    $self->_check_for_rhel_23449();
     $self->_ensure_mount_dash_a_succeeds();
     return;
 }
@@ -59,24 +58,6 @@ sub _ensure_mount_dash_a_succeeds ($self) {
     }
 
     return;
-}
-
-sub _check_for_rhel_23449 ($self) {
-
-    my $out = $self->ssystem_capture_output( FINDMNT_BIN, '-no', 'PROPAGATION', '/usr' );
-
-    # This will return 1 if '/usr' is not a separate mount point
-    return unless $out->{status} == 0;
-    return unless grep { $_ =~ m/private/ } @{ $out->{stdout} };
-
-    return $self->has_blocker( <<~'EOS');
-    The current filesystem setup on your server will prevent 'leapp' from being
-    able to load these packages which will result in 'leapp' failing which will
-    lead to a broken system.  This is being addressed by CloudLinux in
-    CLOS-2492.  A potential fix is currently in testing as of May 6th 2024.
-    Once the fix is released to the public, this blocker will be removed.
-
-    EOS
 }
 
 1;

--- a/t/blocker-MountPoints.t
+++ b/t/blocker-MountPoints.t
@@ -39,44 +39,6 @@ $cpev_mock->redefine(
 );
 
 {
-    note 'Test _check_for_rhel_23449';
-
-    $capture_output_status = 1;
-    is( $mp->_check_for_rhel_23449(), undef, 'No blockers are returned when /usr is NOT a separate mount point' );
-    is(
-        \@cmds,
-        [
-            [
-                '/usr/bin/findmnt',
-                '-no',
-                'PROPAGATION',
-                '/usr',
-            ],
-        ],
-        'The expected command is called',
-    ) or diag explain \@cmds;
-
-    $capture_output_status = 0;
-    $stdout[0] = 'shared';
-    is( $mp->_check_for_rhel_23449(), undef, 'No blockers are returned when /usr is a separate shared mount point' );
-
-    $stdout[0] = 'private';
-    my $blocker = $mp->_check_for_rhel_23449();
-    like(
-        $blocker,
-        {
-            id  => 'Elevate::Blockers::MountPoints::_check_for_rhel_23449',
-            msg => qr/The current filesystem setup on your server will prevent/,
-        },
-        'A blocker is returned when /usr is a separate private mount point',
-    );
-
-    message_seen( WARN => qr/The current filesystem setup on your server will prevent/ );
-
-    no_messages_seen();
-}
-
-{
     note 'Test _ensure_mount_dash_a_succeeds';
 
     undef @cmds;


### PR DESCRIPTION
This change reverts 'e3caac31b1793b852101de22c88fe93333ebcbb0' which was added via RE-306.  Since CloudLinux has an upstream fix for this issue, it is no longer necessary for us to block in this scenario.

Changelog: Remove blocker for when '/usr' is a separate private mount
 point

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

