### PR TITLE
Have pre_leapp component remove packages that leapp will remove

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4915,6 +4915,17 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
+    use constant OBSOLETE_PACKAGES => (
+        'compat-db',
+        'gd-progs',
+        'python-tools',
+        'python2-dnf',
+        'python2-libcomps',
+        'tcp_wrappers-devel',
+        'tkinter',
+        'yum-plugin-universal-hooks',
+    );
+
     sub pre_leapp ($self) {
 
         $self->run_once("_cleanup_rpms");
@@ -4926,6 +4937,14 @@ EOS
 
         $self->rpm->remove_cpanel_arch_rpms();
 
+        $self->_remove_obsolete_packages();
+
+        return;
+    }
+
+    sub _remove_obsolete_packages ($self) {
+        my @pkgs_to_remove = OBSOLETE_PACKAGES();
+        $self->yum->remove(@pkgs_to_remove);
         return;
     }
 

--- a/lib/Elevate/Components/RpmDB.pm
+++ b/lib/Elevate/Components/RpmDB.pm
@@ -24,6 +24,17 @@ use Cpanel::Yum::Vars ();
 
 use parent qw{Elevate::Components::Base};
 
+use constant OBSOLETE_PACKAGES => (
+    'compat-db',
+    'gd-progs',
+    'python-tools',
+    'python2-dnf',
+    'python2-libcomps',
+    'tcp_wrappers-devel',
+    'tkinter',
+    'yum-plugin-universal-hooks',
+);
+
 sub pre_leapp ($self) {
 
     $self->run_once("_cleanup_rpms");
@@ -36,6 +47,18 @@ sub _cleanup_rpms ($self) {
     # potential to remove other things, but the goal here to remove cpanel packages provided by rpm.versions
     $self->rpm->remove_cpanel_arch_rpms();
 
+    # These packages are not available on 8 variants and will be removed by
+    # leapp if we do not remove them manually.  Not necessarily a bug per se,
+    # but it is better if we go ahead and handle removing these packages before
+    # starting leapp
+    $self->_remove_obsolete_packages();
+
+    return;
+}
+
+sub _remove_obsolete_packages ($self) {
+    my @pkgs_to_remove = OBSOLETE_PACKAGES();
+    $self->yum->remove(@pkgs_to_remove);
     return;
 }
 


### PR DESCRIPTION
Case RE-132:  The leapp utility will remove some packages due to incompatibility/dependency related issues after the upgrade to AlmaLinux/CloudLinux 8 has been completed.  Rather than relying on leapp to handle the removal of these packages (potential upstream bugs), we should instead manually remove them as part of a pre_leapp component. This change updates a component to perform this removal prior to leapp executing.

Changelog:  Have pre_leapp component remove packages that leapp will
 remove

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

