### PR TITLE
Add blocker for an invalid Imunify license

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -24,6 +24,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Blockers/EA4.pm'}                  = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/ElevateScript.pm'}        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/Grub2.pm'}                = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Blockers/Imunify.pm'}              = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/IsContainer.pm'}          = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/JetBackup.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Blockers/MountPoints.pm'}          = 'script/elevate-cpanel.PL.static';
@@ -240,6 +241,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Elevate::Blockers::DNS              ();
     use Elevate::Blockers::EA4              ();
     use Elevate::Blockers::Grub2            ();
+    use Elevate::Blockers::Imunify          ();
     use Elevate::Blockers::IsContainer      ();
     use Elevate::Blockers::JetBackup        ();
     use Elevate::Blockers::MountPoints      ();
@@ -273,6 +275,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       WHM
       Distros
       CloudLinux
+      Imunify
       DNS
 
       Databases
@@ -1412,6 +1415,52 @@ EOS
     1;
 
 }    # --- END lib/Elevate/Blockers/Grub2.pm
+
+{    # --- BEGIN lib/Elevate/Blockers/Imunify.pm
+
+    package Elevate::Blockers::Imunify;
+
+    use cPstrict;
+
+    use Elevate::Constants ();
+
+    use Cpanel::JSON ();
+
+    # use Elevate::Blockers::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    sub check ($self) {
+        return $self->_check_imunify_license();
+    }
+
+    sub _check_imunify_license ($self) {
+        return unless -x Elevate::Constants::IMUNIFY_AGENT;
+
+        my $agent_bin    = Elevate::Constants::IMUNIFY_AGENT;
+        my $out          = $self->ssystem_capture_output( $agent_bin, 'version', '--json' );
+        my $raw_data     = join "\n", @{ $out->{stdout} };
+        my $license_data = eval { Cpanel::JSON::Load($raw_data) } // {};
+
+        if ( !ref $license_data->{license} || !$license_data->{license}->{status} ) {
+
+            my $pretty_distro_name = $self->upgrade_to_pretty_name();
+            return $self->has_blocker( <<~"EOS");
+        The Imunify license is reporting that it is not currently valid.  Since
+        Imunify is installed on this system, a valid Imunify license is required
+        to ELevate to $pretty_distro_name.
+        EOS
+        }
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Blockers/Imunify.pm
 
 {    # --- BEGIN lib/Elevate/Blockers/IsContainer.pm
 
@@ -7520,6 +7569,7 @@ use Elevate::Blockers::DNS              ();
 use Elevate::Blockers::EA4              ();
 use Elevate::Blockers::ElevateScript    ();
 use Elevate::Blockers::Grub2            ();
+use Elevate::Blockers::Imunify          ();
 use Elevate::Blockers::IsContainer      ();
 use Elevate::Blockers::JetBackup        ();
 use Elevate::Blockers::MountPoints      ();

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -26,6 +26,7 @@ use Elevate::Blockers::Distros          ();
 use Elevate::Blockers::DNS              ();
 use Elevate::Blockers::EA4              ();
 use Elevate::Blockers::Grub2            ();
+use Elevate::Blockers::Imunify          ();
 use Elevate::Blockers::IsContainer      ();
 use Elevate::Blockers::JetBackup        ();
 use Elevate::Blockers::MountPoints      ();
@@ -60,6 +61,7 @@ our @BLOCKERS = qw{
   WHM
   Distros
   CloudLinux
+  Imunify
   DNS
 
   Databases

--- a/lib/Elevate/Blockers/Imunify.pm
+++ b/lib/Elevate/Blockers/Imunify.pm
@@ -1,0 +1,48 @@
+package Elevate::Blockers::Imunify;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Blockers::Imunify
+
+Blocker to check that the Imunify license is valid when Imunify is installed.
+
+=cut
+
+use cPstrict;
+
+use Elevate::Constants ();
+
+use Cpanel::JSON ();
+
+use parent qw{Elevate::Blockers::Base};
+
+use Log::Log4perl qw(:easy);
+
+sub check ($self) {
+    return $self->_check_imunify_license();
+}
+
+sub _check_imunify_license ($self) {
+    return unless -x Elevate::Constants::IMUNIFY_AGENT;
+
+    my $agent_bin    = Elevate::Constants::IMUNIFY_AGENT;
+    my $out          = $self->ssystem_capture_output( $agent_bin, 'version', '--json' );
+    my $raw_data     = join "\n", @{ $out->{stdout} };
+    my $license_data = eval { Cpanel::JSON::Load($raw_data) } // {};
+
+    if ( !ref $license_data->{license} || !$license_data->{license}->{status} ) {
+
+        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        return $self->has_blocker( <<~"EOS");
+        The Imunify license is reporting that it is not currently valid.  Since
+        Imunify is installed on this system, a valid Imunify license is required
+        to ELevate to $pretty_distro_name.
+        EOS
+    }
+
+    return;
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -242,6 +242,7 @@ use Elevate::Blockers::DNS              ();
 use Elevate::Blockers::EA4              ();
 use Elevate::Blockers::ElevateScript    ();
 use Elevate::Blockers::Grub2            ();
+use Elevate::Blockers::Imunify          ();
 use Elevate::Blockers::IsContainer      ();
 use Elevate::Blockers::JetBackup        ();
 use Elevate::Blockers::MountPoints      ();

--- a/t/blocker-Imunify.t
+++ b/t/blocker-Imunify.t
@@ -1,0 +1,136 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::blockers;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockFile 0.032;
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+use Cpanel::JSON ();
+
+my $cpev_mock    = Test::MockModule->new('cpev');
+my $imunify_mock = Test::MockModule->new('Elevate::Blockers::Imunify');
+
+my $cpev    = cpev->new;
+my $imunify = $cpev->get_blocker('Imunify');
+
+{
+    note 'testing _check_imunify_license';
+
+    my @cmds;
+    my @stdout;
+    $cpev_mock->redefine(
+        ssystem_capture_output => sub ( $, @args ) {
+            push @cmds, [@args];
+            return { status => 0, stdout => \@stdout, stderr => [] };
+        },
+    );
+
+    my $mf_imunify360_agent = Test::MockFile->file( '/usr/bin/imunify360-agent', '', { mode => 0755, } );
+
+    @stdout = (
+        'this is not json',
+    );
+
+    my $blocker = $imunify->_check_imunify_license();
+
+    is ref $blocker, 'cpev::Blocker', 'A blocker object is returned when a blocker is found';
+    is(
+        \@cmds,
+        [
+            [
+                '/usr/bin/imunify360-agent',
+                'version',
+                '--json',
+            ],
+        ],
+        'The expected system call is made',
+    );
+
+    check_blocker_content($blocker);
+
+    undef @cmds;
+
+    my $imunify360_agent_stdout = {
+        license => {
+            status => Cpanel::JSON::false(),
+        }
+    };
+    my $imunify360_agent_json = Cpanel::JSON::Dump($imunify360_agent_stdout);
+
+    @stdout = (
+        $imunify360_agent_json,
+    );
+
+    $blocker = $imunify->_check_imunify_license();
+
+    is ref $blocker, 'cpev::Blocker', 'A blocker object is returned when a blocker is found';
+    is(
+        \@cmds,
+        [
+            [
+                '/usr/bin/imunify360-agent',
+                'version',
+                '--json',
+            ],
+        ],
+        'The expected system call is made',
+    );
+
+    check_blocker_content($blocker);
+
+    undef @cmds;
+
+    $imunify360_agent_stdout = {
+        license => {
+            status => Cpanel::JSON::true(),
+        }
+    };
+    $imunify360_agent_json = Cpanel::JSON::Dump($imunify360_agent_stdout);
+
+    @stdout = (
+        $imunify360_agent_json,
+    );
+
+    is $imunify->_check_imunify_license(), undef, 'No blockers are found when Imunify has a valid license';
+
+    $mf_imunify360_agent->unlink;
+
+    is $imunify->_check_imunify_license(), undef, 'The blocker check is skipped when Imunify is not installed';
+
+    no_messages_seen();
+}
+
+sub check_blocker_content ($blocker) {
+
+    like(
+        $blocker,
+        {
+            id  => 'Elevate::Blockers::Imunify::_check_imunify_license',
+            msg => qr/^The Imunify license is reporting that it is not currently valid/,
+        },
+        'The expected blocker is returned'
+    );
+
+    message_seen( WARN => qr/The Imunify license is reporting that it is not currently valid/ );
+
+    return;
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-373: If a server has an invalid Imunify license, then the Imunify component can fail in expected ways.  This can further lead to the elevate script failing in stage 4 due to the Imunify post_leapp component failing and the EA4 component relying on the Imunify component to succeed.

Changelog: Add blocker for an invalid Imunify license

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

