### PR TITLE
Ignore *.code-workspace file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .tdy
 /tags
 /.vscode
+*.code-workspace


### PR DESCRIPTION
Just a small modification to gitignore to also ignore VSCode workspace files in addition to the `.vscode` folder.