### PR TITLE
Attempt "yum clean all" if "yum makecache" fails

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1978,20 +1978,32 @@ EOS
     sub _yum_is_stable ($self) {
         my $errors = Cpanel::SafeRun::Errors::saferunonlyerrors(qw{/usr/bin/yum makecache});
         if ( $errors =~ m/\S/ms ) {
-            ERROR('yum appears to be unstable. Please address this before upgrading');
-            ERROR($errors);
-            my $id = ref($self) . '::YumMakeCacheError';
-            $self->has_blocker(
-                "yum appears to be unstable. Please address this before upgrading\n$errors",
-                info => {
-                    name  => $id,
-                    error => $errors,
-                },
-                blocker_id => $id,
-                quiet      => 1,
-            );
 
-            return 0;
+            WARN("Initial run of \"yum makecache\" failed: $errors");
+            WARN("Running \"yum clean all\" in an attempt to fix yum");
+
+            my $ret = $self->ssystem_capture_output(qw{/usr/bin/yum clean all});
+            if ( $ret->{status} != 0 ) {
+                WARN( "Errors encountered running \"yum clean all\": " . $ret->{stderr} );
+            }
+
+            $errors = Cpanel::SafeRun::Errors::saferunonlyerrors(qw{/usr/bin/yum makecache});
+            if ( $errors =~ m/\S/ms ) {
+                ERROR('yum appears to be unstable. Please address this before upgrading');
+                ERROR($errors);
+                my $id = ref($self) . '::YumMakeCacheError';
+                $self->has_blocker(
+                    "yum appears to be unstable. Please address this before upgrading\n$errors",
+                    info => {
+                        name  => $id,
+                        error => $errors,
+                    },
+                    blocker_id => $id,
+                    quiet      => 1,
+                );
+
+                return 0;
+            }
         }
 
         if ( opendir( my $dfh, '/var/lib/yum' ) ) {

--- a/lib/Elevate/Blockers/Repositories.pm
+++ b/lib/Elevate/Blockers/Repositories.pm
@@ -90,20 +90,32 @@ sub _yum_status_hr_contains_blocker ($status_hr) {
 sub _yum_is_stable ($self) {
     my $errors = Cpanel::SafeRun::Errors::saferunonlyerrors(qw{/usr/bin/yum makecache});
     if ( $errors =~ m/\S/ms ) {
-        ERROR('yum appears to be unstable. Please address this before upgrading');
-        ERROR($errors);
-        my $id = ref($self) . '::YumMakeCacheError';
-        $self->has_blocker(
-            "yum appears to be unstable. Please address this before upgrading\n$errors",
-            info => {
-                name  => $id,
-                error => $errors,
-            },
-            blocker_id => $id,
-            quiet      => 1,
-        );
 
-        return 0;
+        WARN("Initial run of \"yum makecache\" failed: $errors");
+        WARN("Running \"yum clean all\" in an attempt to fix yum");
+
+        my $ret = $self->ssystem_capture_output(qw{/usr/bin/yum clean all});
+        if ( $ret->{status} != 0 ) {
+            WARN( "Errors encountered running \"yum clean all\": " . $ret->{stderr} );
+        }
+
+        $errors = Cpanel::SafeRun::Errors::saferunonlyerrors(qw{/usr/bin/yum makecache});
+        if ( $errors =~ m/\S/ms ) {
+            ERROR('yum appears to be unstable. Please address this before upgrading');
+            ERROR($errors);
+            my $id = ref($self) . '::YumMakeCacheError';
+            $self->has_blocker(
+                "yum appears to be unstable. Please address this before upgrading\n$errors",
+                info => {
+                    name  => $id,
+                    error => $errors,
+                },
+                blocker_id => $id,
+                quiet      => 1,
+            );
+
+            return 0;
+        }
     }
 
     if ( opendir( my $dfh, '/var/lib/yum' ) ) {


### PR DESCRIPTION
Case RE-343:

During the test of yum's stability, try running "yum clean all" and retry running "yum makecache" if it fails on the first try. Hopefully this will prevent blockers.

Changelog: Runs "yum clean all" and retries "yum makecache" if it
  had initially failed.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

