### PR TITLE
Use 'CloudLinux_8' target to backup EA4 profile with I360 installed

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1064,7 +1064,6 @@ EOS
         return unless scalar keys $dropped_pkgs->%*;
 
         my @incompatible;
-        my @imunify_pkgs;
         foreach my $pkg ( sort keys %$dropped_pkgs ) {
             my $type = $dropped_pkgs->{$pkg} // '';
             next if $type eq 'exp';                          # use of experimental packages is a non blocker
@@ -1074,34 +1073,11 @@ EOS
                 my $php_pkg = $1;
                 next unless $self->_php_version_is_in_use($php_pkg);
 
-                if ( $self->_pkg_is_provided_by_imunify_360($php_pkg) ) {
-                    push @imunify_pkgs, $pkg;
-                    next;
-                }
             }
-
-            if ( $pkg eq 'ea-profiles-cloudlinux' && $self->_pkg_is_provided_by_imunify_360($pkg) ) {
-                push @imunify_pkgs, $pkg;
-                next;
-            }
-
             push @incompatible, $pkg;
         }
 
-        if (@imunify_pkgs) {
-            Elevate::StageFile::remove_from_stage_file('ea4_imunify_packages');
-            Elevate::StageFile::update_stage_file( { ea4_imunify_packages => \@imunify_pkgs } );
-        }
-
         return @incompatible;
-    }
-
-    sub _pkg_is_provided_by_imunify_360 ( $self, $pkg ) {
-        return 0 unless -x Elevate::Constants::IMUNIFY_AGENT;
-
-        my $version = Cpanel::Pkgr::get_package_version($pkg);
-
-        return $version =~ m/cloudlinux/ ? 1 : 0;
     }
 
     sub _php_version_is_in_use ( $self, $php ) {
@@ -3266,7 +3242,6 @@ EOS
 
         $self->run_once('_restore_ea4_profile');
         $self->run_once('_restore_ea_addons');
-        $self->run_once('_restore_imunify_phps');
 
         $self->run_once('_restore_config_files');
 
@@ -3370,16 +3345,6 @@ EOS
             $self->rpm->restore_config_files(@config_files_to_restore);
         }
 
-        return;
-    }
-
-    sub _restore_imunify_phps ($self) {
-
-        my $php_pkgs = Elevate::StageFile::read_stage_file('ea4_imunify_packages');
-        return unless ref $php_pkgs eq 'ARRAY';
-        return unless scalar $php_pkgs->@*;
-
-        $self->dnf->install(@$php_pkgs);
         return;
     }
 
@@ -5712,6 +5677,7 @@ EOS
 
     use File::Temp ();
 
+    use Elevate::Constants ();
     use Elevate::OS        ();
     use Elevate::StageFile ();
 
@@ -5722,6 +5688,8 @@ EOS
 
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
+
+    use constant IMUNIFY_AGENT => Elevate::Constants::IMUNIFY_AGENT;
 
     sub backup ( $check_mode = 0 ) {
         Elevate::EA4::_backup_ea4_profile($check_mode);
@@ -5755,9 +5723,36 @@ EOS
         return;
     }
 
+    sub _imunify360_is_installed_and_provides_hardened_php () {
+        return 0 unless -x IMUNIFY_AGENT;
+
+        my $out          = Cpanel::SafeRun::Simple::saferunnoerror( IMUNIFY_AGENT, qw{version --json} );
+        my $license_data = eval { Cpanel::JSON::Load($out) } // {};
+
+        return 0 unless ref $license_data->{license};
+
+        if ( $license_data->{'license'}->{'license_type'} eq 'imunify360' ) {
+
+            my $output   = Cpanel::SafeRun::Simple::saferunnoerror( IMUNIFY_AGENT, qw{features list} );
+            my @features = map {
+                my $trim_spaces = $_;
+                $trim_spaces =~ s/\s+//g;
+                $trim_spaces;
+            } grep { m/\S/ } split( "\n", $output );
+
+            foreach my $feature (@features) {
+                return 1 if $feature eq 'hardened-php';
+            }
+        }
+
+        return 0;
+    }
+
     sub _get_ea4_profile ($check_mode) {
 
         my $ea_alias = Elevate::OS::ea_alias();
+
+        $ea_alias = 'CloudLinux_8' if Elevate::EA4::_imunify360_is_installed_and_provides_hardened_php();
 
         my @cmd = ( '/usr/local/bin/ea_current_to_profile', "--target-os=$ea_alias" );
 

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -35,7 +35,6 @@ sub post_leapp ($self) {
 
     $self->run_once('_restore_ea4_profile');
     $self->run_once('_restore_ea_addons');
-    $self->run_once('_restore_imunify_phps');
 
     # This needs to happen after EA4 has been reinstalled
     #
@@ -152,16 +151,6 @@ sub _restore_config_files ($self) {
         $self->rpm->restore_config_files(@config_files_to_restore);
     }
 
-    return;
-}
-
-sub _restore_imunify_phps ($self) {
-
-    my $php_pkgs = Elevate::StageFile::read_stage_file('ea4_imunify_packages');
-    return unless ref $php_pkgs eq 'ARRAY';
-    return unless scalar $php_pkgs->@*;
-
-    $self->dnf->install(@$php_pkgs);
     return;
 }
 

--- a/t/blocker-ea4.t
+++ b/t/blocker-ea4.t
@@ -155,8 +155,7 @@ Please remove these packages before continuing the update.
         }, "blocker with expected error" or diag explain $blocker;
 
         $mock_ea4->redefine(
-            _php_version_is_in_use          => 1,
-            _pkg_is_provided_by_imunify_360 => 0,
+            _php_version_is_in_use => 1,
         );
 
         $stage_ea4->{'dropped_pkgs'} = {
@@ -185,8 +184,7 @@ Please remove these packages before continuing the update.
           or diag explain $blocker;
 
         $mock_ea4->redefine(
-            _php_version_is_in_use          => 0,
-            _pkg_is_provided_by_imunify_360 => 0,
+            _php_version_is_in_use => 0,
         );
 
         $stage_ea4->{'dropped_pkgs'} = {
@@ -195,52 +193,6 @@ Please remove these packages before continuing the update.
 
         ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is an ea-php version that is not in use';
         ea_info_check($target_os);
-
-        $mock_ea4->redefine(
-            _php_version_is_in_use          => 0,
-            _pkg_is_provided_by_imunify_360 => 1,
-        );
-
-        ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is an ea-php version that is in use but provided by Imunify 360';
-        ea_info_check($target_os);
-
-        is(
-            $update_stage_file_data,
-            {},
-            'No ea-php packages need to be installed for Imunify 360 when the PHP version is not in use'
-        ) or diag explain $update_stage_file_data;
-
-        $stage_ea4->{'dropped_pkgs'} = {
-            'ea-php42'               => 'reg',
-            'ea-profiles-cloudlinux' => 'reg',
-        };
-
-        ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is "ea-profiles-cloudlinux" and provided by Imunify 360';
-        ea_info_check($target_os);
-
-        is(
-            $update_stage_file_data,
-            {
-                ea4_imunify_packages => ['ea-profiles-cloudlinux'],
-            },
-            'No blocker for ea-profiles-cloudlinux provided by Imunify 360'
-        );
-
-        $mock_ea4->redefine(
-            _php_version_is_in_use          => 1,
-            _pkg_is_provided_by_imunify_360 => 1,
-        );
-
-        ok !$ea4->_blocker_ea4_profile(), 'No blocker when dropped package is an ea-php version that is in use but provided by Imunify 360';
-        ea_info_check($target_os);
-
-        is(
-            $update_stage_file_data,
-            {
-                ea4_imunify_packages => [ 'ea-php42', 'ea-profiles-cloudlinux' ],
-            },
-            'No ea-php packages need to be installed for Imunify 360 when the PHP version is not in use'
-        ) or diag explain $update_stage_file_data;
 
         $stage_ea4 = {};
     }


### PR DESCRIPTION
Case RE-403:  In RE-313, we added support for Imunify 360's hardened PHP repo to the EA4 blocker.  Unfortunately, this improvement did not account for some packages that Imunify 360's hardened PHP repo does not provide which has resulted in some servers making it past the EA4 blocker that had packages installed that were not supported on A8/CL8. This change removes the current logic to support Imunify 360's hardened PHP repo, and replaces it by teaching
'Elevate::EA4::_backup_ea4_profile' to use the 'CloudLinux_8' target when Imunify 360 is installed with the hardened PHP feature.  We can do this since Imunify 360's hardened PHP feature is essentially just providing CloudLinux's EA4 to servers with the feature available.

Changelog: Use 'CloudLinux_8' target to backup EA4 profile on servers
 with Imunify 360 installed and providing the hardened PHP feature

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

