### PR TITLE
Teach wait_for_leapp_completion() about the no-leapp option

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6081,6 +6081,9 @@ EOS
     }
 
     sub wait_for_leapp_completion ($self) {
+
+        return 1 unless $self->cpev->should_run_leapp();
+
         my $upgrade_log = LEAPP_UPGRADE_LOG;
 
         if ( !-e $upgrade_log ) {

--- a/lib/Elevate/Leapp.pm
+++ b/lib/Elevate/Leapp.pm
@@ -242,6 +242,10 @@ sub extract_error_block_from_output ( $self, $text_ar ) {
 # Returns 0 on failure.
 
 sub wait_for_leapp_completion ($self) {
+
+    # No use waiting for leapp to complete if we did not run leapp
+    return 1 unless $self->cpev->should_run_leapp();
+
     my $upgrade_log = LEAPP_UPGRADE_LOG;
 
     if ( !-e $upgrade_log ) {

--- a/t/leapp_upgrade.t
+++ b/t/leapp_upgrade.t
@@ -313,6 +313,16 @@ note 'LEAPP upgrade log failure checks';
 {
     $mock_leapp_upgrade_log->unlink;
 
+    $mock_elevate->redefine(
+        should_run_leapp => 0,
+    );
+
+    is( cpev->leapp->wait_for_leapp_completion, 1, 'wait_for_leapp_completion returns early when it should NOT run leapp' );
+
+    $mock_elevate->redefine(
+        should_run_leapp => 1,
+    );
+
     is( cpev->leapp->wait_for_leapp_completion, 0, "wait_for_leapp_completion fails when the upgrade log is missing." );
 
     $mock_leapp_upgrade_log->contents("magic string is missing");


### PR DESCRIPTION
Case RE-475:  In case RE-224, we added a check to ensure that leapp has completed before continuing with stage 4 / starting the post leapp components.  Unfortunately, this check did not account for the no-leapp option that the script provides for those who want to perform the upgrade from C7->C8 without using the leapp utility, but still want the script to handle the cPanel specific potions of the upgrade.  This resulted in upgrades using the no-leapp option to fail in stage 4 while waiting on leapp to complete.  This change teaches this check about the no-leapp option which allows for upgrades using this option to skip past this check.

Changelog: Teach wait_for_leapp_completion() about the no-leapp option

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

