### PR TITLE
Set locale environment variables to “C” in BEGIN block

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -7563,6 +7563,12 @@ BEGIN {
         warn(qq[This script is designed to only run on cPanel servers.\n]);
         exit 1;    ## no critic(Cpanel::NoExitsFromSubroutines)
     };
+
+    $ENV{LANG}        = "C";
+    $ENV{LANGUAGE}    = "C";
+    $ENV{LC_ALL}      = "C";
+    $ENV{LC_MESSAGES} = "C";
+    $ENV{LC_CTYPE}    = "C";
 }
 
 use Log::Log4perl qw(:easy);

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -194,6 +194,12 @@ BEGIN {
         warn(qq[This script is designed to only run on cPanel servers.\n]);
         exit 1;    ## no critic(Cpanel::NoExitsFromSubroutines)
     };
+
+    $ENV{LANG}        = "C";
+    $ENV{LANGUAGE}    = "C";
+    $ENV{LC_ALL}      = "C";
+    $ENV{LC_MESSAGES} = "C";
+    $ENV{LC_CTYPE}    = "C";
 }
 
 use Log::Log4perl qw(:easy);


### PR DESCRIPTION
Case RE-450: Ensure the environment is setup for the default POSIX locale before elevating.

Changelog: Set locale environment variables to “C” before elevating.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

