### PR TITLE
Do not allow check to run in the middle of an elevation

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -309,6 +309,17 @@ BEGIN {    # Suppress load of all of these at earliest point.
             return 1;
         }
 
+        my $stage = Elevate::Stages::get_stage();
+        if ( $stage != 0 && $stage <= cpev::VALID_STAGES() ) {
+            die <<~"EOS";
+        An elevation process is currently in progress: running stage $stage
+        You can check the log by running:
+            /scripts/elevate-cpanel --log
+        or check the elevation status:
+            /scripts/elevate-cpanel --status
+        EOS
+        }
+
         Elevate::Blockers::Distros::bail_out_on_inappropriate_distro();
 
         my $blocker_file = $self->cpev->getopt('check') || ELEVATE_BLOCKER_FILE;
@@ -5423,6 +5434,9 @@ EOS
         $OS = eval { factory(); };
 
         if ( !$OS ) {
+
+            DEBUG("Unable to acquire Elevate::OS instance, dying") unless -t STDOUT;
+
             my $supported_distros = join( "\n", SUPPORTED_DISTROS() );
             die "This script is only designed to upgrade the following OSs:\n\n$supported_distros\n";
         }
@@ -8041,7 +8055,7 @@ sub start ($self) {
         You can check the log by running:
             /scripts/elevate-cpanel --log
         or check the elevation status:
-            /scripts/elevate-cpanel --check
+            /scripts/elevate-cpanel --status
         EOS
 
     }

--- a/lib/Elevate/Blockers.pm
+++ b/lib/Elevate/Blockers.pm
@@ -90,6 +90,17 @@ sub check ($self) {    # do_check - main  entry point
         return 1;
     }
 
+    my $stage = Elevate::Stages::get_stage();
+    if ( $stage != 0 && $stage <= cpev::VALID_STAGES() ) {
+        die <<~"EOS";
+        An elevation process is currently in progress: running stage $stage
+        You can check the log by running:
+            /scripts/elevate-cpanel --log
+        or check the elevation status:
+            /scripts/elevate-cpanel --status
+        EOS
+    }
+
     Elevate::Blockers::Distros::bail_out_on_inappropriate_distro();
 
     # If no argument passed to --check, use default path:

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -55,6 +55,11 @@ sub instance {
     $OS = eval { factory(); };
 
     if ( !$OS ) {
+
+        # Ensure that we don't just fail silently if we hit this while tailing
+        # the elevate log
+        DEBUG("Unable to acquire Elevate::OS instance, dying") unless -t STDOUT;
+
         my $supported_distros = join( "\n", SUPPORTED_DISTROS() );
         die "This script is only designed to upgrade the following OSs:\n\n$supported_distros\n";
     }

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -525,7 +525,7 @@ sub start ($self) {
         You can check the log by running:
             /scripts/elevate-cpanel --log
         or check the elevation status:
-            /scripts/elevate-cpanel --check
+            /scripts/elevate-cpanel --status
         EOS
 
     }


### PR DESCRIPTION
Case RE-505:  Previously, a user or security advisor could execute --check in the middle of a failed elevation.  It does not make sense for this to be allowed since the elevation attempt has already made it past the blocker stage.  At this point, it is far more appropriate for the user to execute --continue in order to complete the elevation.

Of note, one of the side affects of this is that --check will clear the Elevate::OS cache which will cause failures if the elevation attempt has already made it to stage 4 or 5 and the OS has been upgraded, but cPanel services and friends have not been restored.

Changelog:  Do not allow check to run in the middle of an elevation

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

