### PR TITLE
Block when packages are installed from a disabled repo

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -133,6 +133,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     use Simple::Accessor qw(
       blockers
+      yum
     );
 
     # use Log::Log4perl qw(:easy);
@@ -147,6 +148,10 @@ BEGIN {    # Suppress load of all of these at earliest point.
         Carp::confess(q[Missing blockers]);
     }
 
+    sub _build_yum ($self) {
+        return Elevate::YUM->new( cpev => $self );
+    }
+
     sub cpev ($self) {
         return $self->blockers->cpev;
     }
@@ -158,6 +163,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
           should_run_leapp
           ssystem
           ssystem_capture_output
+          ssystem_hide_and_capture_output
         };
 
         foreach my $subname (@_DELEGATE_TO_CPEV) {
@@ -1919,10 +1925,24 @@ EOS
 
     sub check ($self) {
         my $ok = 1;
+        $ok = 0 if $self->_blocker_packages_installed_without_associated_repo;
         $ok = 0 if $self->_blocker_invalid_yum_repos;
         $ok = 0 if $self->_yum_is_stable();
 
         return $ok;
+    }
+
+    sub _blocker_packages_installed_without_associated_repo ($self) {
+        my @extra_packages = $self->yum->get_extra_packages();
+        return unless scalar @extra_packages;
+
+        my @packages   = map { $_->{package} } @extra_packages;
+        my $pkg_string = join "\n", @packages;
+        return $self->has_blocker( <<~EOS );
+    There are packages installed that do not have associated repositories:
+
+    $pkg_string
+    EOS
     }
 
     sub _blocker_invalid_yum_repos ($self) {
@@ -2090,7 +2110,6 @@ EOS
 
             my $check_last_known_repo = sub {
                 return unless length $current_repo_name;
-                return unless $current_repo_enabled;
 
                 my $is_vetted = grep { $current_repo_name =~ m/$_/ } @vetted_repos;
 
@@ -2120,6 +2139,8 @@ EOS
                         $status{'USE_RPMS_FROM_UNVETTED_REPO'} = 1;
                     }
                     else {
+                        return unless $current_repo_enabled;
+
                         INFO( sprintf( "Unsupported YUM repo enabled '%s' without packages installed from %s, these will be disabled before ELevation", $current_repo_name, $path ) );
 
                         push( $self->{_yum_repos_to_disable}->@*, $current_repo_name );
@@ -2127,6 +2148,8 @@ EOS
                     }
                 }
                 elsif ( !$current_repo_use_valid_syntax ) {
+                    return unless $current_repo_enabled;
+
                     WARN( sprintf( "YUM repo '%s' is using unsupported '\\\$' syntax in %s", $current_repo_name, $path ) );
                     unless ( grep { $_ eq $path } $self->{_yum_repos_path_using_invalid_syntax}->@* ) {
                         my $blocker_id = ref($self) . '::YumRepoConfigInvalidSyntax';
@@ -7570,6 +7593,50 @@ EOS
         $self->cpev->ssystem_and_die( $pkgmgr, '-y', 'install', @pkgs );
 
         return;
+    }
+
+    sub get_extra_packages ($self) {
+        my $pkgmgr = $self->pkgmgr;
+
+        my $out   = $self->cpev->ssystem_hide_and_capture_output( $pkgmgr, 'list', 'extras' );
+        my @lines = @{ $out->{stdout} };
+        while ( my $line = shift @lines ) {
+            last if $line && $line =~ m/^Extra Packages/;
+        }
+
+        my @extra_packages;
+        while ( my $line = shift @lines ) {
+            chomp $line;
+            my ( $package, $version, $repo ) = split( qr{\s+}, $line );
+
+            if ( !length $version ) {
+                my $extra_line = shift @lines;
+                chomp $extra_line;
+                $extra_line =~ s/^\s+//;
+                ( $version, $repo ) = split( ' ', $extra_line );
+            }
+            if ( !length $repo ) {
+                $repo = shift @lines;
+                chomp $repo;
+                $repo =~ s/\s+//g;
+            }
+            length $repo or next;    # We screwed up the parse. move on.
+
+            $repo eq 'installed' or next;
+
+            $package =~ s/\.(noarch|x86_64)$//;
+            my $arch = $1 // '?';
+
+            next if $package =~ m/^cpanel-/;
+            next if $package =~ m/^kernel/;
+            next if $package eq 'filesystem';
+            next if $package eq 'basesystem';
+            next if $package eq 'virt-what';
+
+            push @extra_packages, { package => $package, version => $version, arch => $arch };
+        }
+
+        return @extra_packages;
     }
 
     1;

--- a/lib/Elevate/Blockers/Base.pm
+++ b/lib/Elevate/Blockers/Base.pm
@@ -17,6 +17,7 @@ use Cpanel::JSON ();
 
 use Simple::Accessor qw(
   blockers
+  yum
 );
 
 use Log::Log4perl qw(:easy);
@@ -32,6 +33,10 @@ sub _build_blockers {
     Carp::confess(q[Missing blockers]);
 }
 
+sub _build_yum ($self) {
+    return Elevate::YUM->new( cpev => $self );
+}
+
 sub cpev ($self) {
     return $self->blockers->cpev;
 }
@@ -44,6 +49,7 @@ BEGIN {
       should_run_leapp
       ssystem
       ssystem_capture_output
+      ssystem_hide_and_capture_output
     };
 
     foreach my $subname (@_DELEGATE_TO_CPEV) {

--- a/lib/Elevate/YUM.pm
+++ b/lib/Elevate/YUM.pm
@@ -63,4 +63,55 @@ sub install ( $self, @pkgs ) {
     return;
 }
 
+# No cache here since this is currently only called one time from a blocker
+# Consider adding a cache if we ever call it anywhere else
+sub get_extra_packages ($self) {
+    my $pkgmgr = $self->pkgmgr;
+
+    # From the yum man page
+    # yum list extras [glob_exp1] [...]
+    #     List the packages installed on the system that are not available
+    #     in any yum repository listed in the config file.
+    my $out   = $self->cpev->ssystem_hide_and_capture_output( $pkgmgr, 'list', 'extras' );
+    my @lines = @{ $out->{stdout} };
+    while ( my $line = shift @lines ) {
+        last if $line && $line =~ m/^Extra Packages/;
+    }
+
+    my @extra_packages;
+    while ( my $line = shift @lines ) {
+        chomp $line;
+        my ( $package, $version, $repo ) = split( qr{\s+}, $line );
+
+        if ( !length $version ) {
+            my $extra_line = shift @lines;
+            chomp $extra_line;
+            $extra_line =~ s/^\s+//;
+            ( $version, $repo ) = split( ' ', $extra_line );
+        }
+        if ( !length $repo ) {
+            $repo = shift @lines;
+            chomp $repo;
+            $repo =~ s/\s+//g;
+        }
+        length $repo or next;    # We screwed up the parse. move on.
+
+        # We only care about installed packages not associated with repos here
+        $repo eq 'installed' or next;
+
+        $package =~ s/\.(noarch|x86_64)$//;
+        my $arch = $1 // '?';
+
+        next if $package =~ m/^cpanel-/;
+        next if $package =~ m/^kernel/;
+        next if $package eq 'filesystem';
+        next if $package eq 'basesystem';
+        next if $package eq 'virt-what';
+
+        push @extra_packages, { package => $package, version => $version, arch => $arch };
+    }
+
+    return @extra_packages;
+}
+
 1;


### PR DESCRIPTION
Case RE-420:  Previously, we ignored packages that were installed directly via the RPM binary or packages that were installed from repositories that had since been disabled.  This led to elevations being allowed to continue when they should have been blocked due to packages being installed from unvetted sources.  This could lead to services or other things being broken on the server after the elevation has completed.  This change makes it so that we detect when packages are installed from disabled repositories and when packages are installed directly via the RPM binary.

Changelog:  Block when packages are installed from a disabled repo

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

