### PR TITLE
Use croak() instead of die() in ssystem_and_die

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ cover:
 	find cover_db -type d -exec chmod 755 {} \;
 
 tags:
-	/usr/bin/ctags -R --languages=perl elevate-cpanel t
+	/usr/bin/ctags -R --languages=perl --extra=+q script lib t
 
 elevate-cpanel: $(wildcard lib/**/*) script/elevate-cpanel.PL
 	USE_CPANEL_PERL_FOR_PERLSTATIC=1 maint/perlpkg.static \

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6764,6 +6764,8 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
+    use Carp ();
+
     sub ssystem_capture_output ( $, @args ) {
 
         my %opts;
@@ -6802,7 +6804,7 @@ EOS
 
     sub ssystem_and_die ( $self, @args ) {
         $self->ssystem(@args) or return 0;
-        die "command failed. Fix it and run command.";
+        Carp::croak("command failed. Fix it and run command.");
     }
 
     sub _ssystem ( $command, %opts ) {

--- a/lib/Elevate/Roles/Run.pm
+++ b/lib/Elevate/Roles/Run.pm
@@ -27,6 +27,8 @@ use Cpanel::SafeRun::Object     ();
 
 use Log::Log4perl qw(:easy);
 
+use Carp ();
+
 sub ssystem_capture_output ( $, @args ) {
 
     my %opts;
@@ -65,7 +67,7 @@ sub ssystem ( $, @args ) {
 
 sub ssystem_and_die ( $self, @args ) {
     $self->ssystem(@args) or return 0;
-    die "command failed. Fix it and run command.";
+    Carp::croak("command failed. Fix it and run command.");
 }
 
 sub _ssystem ( $command, %opts ) {


### PR DESCRIPTION
Give better context when `ssystem_and_die` blows up as requested.

Additionally, update the tags file generation target in the Makefile to handle the now-modular nature of the project.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf