### PR TITLE
Add jetapps-* to the list of vetted repos

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5723,6 +5723,8 @@ EOS
         'imunify360-ea-php-hardened',
         qr/^imunify360-rollout-[0-9]+$/,
         'influxdb',
+        'jetapps',
+        qr/^jetapps-(?:stable|beta|edge)$/,
         'kernelcare',
         'updates',
         qr/^wp-toolkit-(?:cpanel|thirdparties)$/,

--- a/lib/Elevate/OS/RHEL.pm
+++ b/lib/Elevate/OS/RHEL.pm
@@ -57,6 +57,8 @@ use constant vetted_yum_repo => (
     'imunify360-ea-php-hardened',
     qr/^imunify360-rollout-[0-9]+$/,
     'influxdb',
+    'jetapps',
+    qr/^jetapps-(?:stable|beta|edge)$/,
     'kernelcare',
     'updates',
     qr/^wp-toolkit-(?:cpanel|thirdparties)$/,


### PR DESCRIPTION
Case RE-542: In RE-420, we updated the Repository blocker to check for packages installed from repositories that are no longer enabled.  This resulted in jetapps support being broken since the jetapps repositories were not in the list of vetted repositories.  This change reinstates jetapps support.

Changelog:  Add jetapps-* to the list of vetted repos

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

