### PR TITLE
Have ELS component always remove the ELS repo files if they exist

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5441,8 +5441,6 @@ EOS
 
         return unless Elevate::OS::remove_els();
 
-        return unless Cpanel::Pkgr::is_installed(ELS_PACKAGE);
-
         my @files_to_remove = qw{
           /etc/yum.repos.d/centos7-els.repo
           /etc/yum.repos.d/centos7-els-rollout.repo
@@ -5454,7 +5452,7 @@ EOS
             }
         }
 
-        $self->yum->remove(ELS_PACKAGE);
+        $self->yum->remove(ELS_PACKAGE) if Cpanel::Pkgr::is_installed(ELS_PACKAGE);
 
         return;
     }

--- a/lib/Elevate/Components/ELS.pm
+++ b/lib/Elevate/Components/ELS.pm
@@ -25,8 +25,6 @@ sub pre_leapp ($self) {
 
     return unless Elevate::OS::remove_els();
 
-    return unless Cpanel::Pkgr::is_installed(ELS_PACKAGE);
-
     my @files_to_remove = qw{
       /etc/yum.repos.d/centos7-els.repo
       /etc/yum.repos.d/centos7-els-rollout.repo
@@ -38,7 +36,7 @@ sub pre_leapp ($self) {
         }
     }
 
-    $self->yum->remove(ELS_PACKAGE);
+    $self->yum->remove(ELS_PACKAGE) if Cpanel::Pkgr::is_installed(ELS_PACKAGE);
 
     return;
 }


### PR DESCRIPTION
Case RE-538:  Previously, we would check to see if the 'els-define' package was installed and return early in this pre_leapp component. However, due to the CentOS 7 base repo moving to vault, it was found that ELS was installed while yum was in a broken state which resulted in the 'els-define' package not getting installed.  As such, this change makes it so that we always remove the ELS repo files if they exist since we can not rely on the 'els-define' package being installed.

Changelog: Have ELS component always remove the ELS repo files if they
 exist

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

