### PR TITLE
Update PECL checks

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4664,6 +4664,9 @@ EOS
     use Elevate::Constants ();
     use Elevate::StageFile ();
 
+    use Cpanel::JSON            ();
+    use Cpanel::SafeRun::Simple ();
+
     use Cwd ();
 
     # use Log::Log4perl qw(:easy);
@@ -4688,9 +4691,19 @@ EOS
     }
 
     sub _backup_pecl_packages ($self) {
-        my @ea_versions = qw{ea-php70 ea-php71 ea-php72 ea-php73 ea-php74 ea-php80};
+        my $out    = Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 --output=json php_get_installed_versions});
+        my $result = eval { Cpanel::JSON::Load($out); } // {};
 
-        foreach my $v (@ea_versions) {
+        unless ( $result->{metadata}{result} ) {
+            WARN( <<~"EOS" );
+        Unable to determine the installed PHP versions.
+        Assuming that backing up PECL packages is not relevant as such.
+
+        EOS
+            return;
+        }
+
+        foreach my $v ( @{ $result->{'data'}{'versions'} } ) {
             _store_pecl_for( qq[/opt/cpanel/$v/root/usr/bin/pecl], $v );
         }
 
@@ -8978,8 +8991,8 @@ sub run_final_components_pre_leapp ($self) {
     # order matters
     $self->run_component_once( 'RmMod'            => 'pre_leapp' );
     $self->run_component_once( 'Imunify'          => 'pre_leapp' );
-    $self->run_component_once( 'EA4'              => 'pre_leapp' );
     $self->run_component_once( 'PECL'             => 'pre_leapp' );
+    $self->run_component_once( 'EA4'              => 'pre_leapp' );
     $self->run_component_once( 'MySQL'            => 'pre_leapp' );
     $self->run_component_once( 'Repositories'     => 'pre_leapp' );
     $self->run_component_once( 'cPanelPlugins'    => 'pre_leapp' );

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -1307,8 +1307,8 @@ sub run_final_components_pre_leapp ($self) {
     # order matters
     $self->run_component_once( 'RmMod'            => 'pre_leapp' );
     $self->run_component_once( 'Imunify'          => 'pre_leapp' );
-    $self->run_component_once( 'EA4'              => 'pre_leapp' );
     $self->run_component_once( 'PECL'             => 'pre_leapp' );
+    $self->run_component_once( 'EA4'              => 'pre_leapp' );
     $self->run_component_once( 'MySQL'            => 'pre_leapp' );
     $self->run_component_once( 'Repositories'     => 'pre_leapp' );
     $self->run_component_once( 'cPanelPlugins'    => 'pre_leapp' );

--- a/t/pecl.t
+++ b/t/pecl.t
@@ -157,4 +157,14 @@ EOS
 
 }
 
+# Test _backup_pecl_packages
+$list_output = '{"metadata":{"reason":"OK","result":1,"command":"php_get_installed_versions","version":1},"data":{"versions":["ea-php80","ea-php81","ea-php82"]}}';
+my @stored;
+$mock_pecl->redefine(
+    _store_pecl_for => sub { push @stored, $_[1] },
+);
+
+$pecl->_backup_pecl_packages();
+is \@stored, [qw{ea-php80 ea-php81 ea-php82 cpanel}], "Got the expeced versions to store in _backup_pecl_packages";
+
 done_testing;


### PR DESCRIPTION
case RE-72: Also updates pecl.t, should pick up a bit more cover

Changelog: Update PECL check to run before EA in pre_leapp phase; use
  php_get_installed_versions to determine EA PHP package versions.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

