### PR TITLE
Have Imunify 360 check ensure ea-cpanel-tools is provided by CL

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5963,7 +5963,11 @@ EOS
             } grep { m/\S/ } split( "\n", $output );
 
             foreach my $feature (@features) {
-                return 1 if $feature eq 'hardened-php';
+
+                if ( $feature eq 'hardened-php' ) {
+                    my $version = Cpanel::Pkgr::get_package_version('ea-cpanel-tools');
+                    return $version =~ m{cloudlinux} ? 1 : 0;
+                }
             }
         }
 

--- a/lib/Elevate/EA4.pm
+++ b/lib/Elevate/EA4.pm
@@ -78,7 +78,15 @@ sub _imunify360_is_installed_and_provides_hardened_php () {
         } grep { m/\S/ } split( "\n", $output );
 
         foreach my $feature (@features) {
-            return 1 if $feature eq 'hardened-php';
+
+            # If Imunify 360 provides hardened PHP and
+            # the ea-cpanel-tools has been updated to the
+            # CL version, then we can assume that this system
+            # is using CL EA4
+            if ( $feature eq 'hardened-php' ) {
+                my $version = Cpanel::Pkgr::get_package_version('ea-cpanel-tools');
+                return $version =~ m{cloudlinux} ? 1 : 0;
+            }
         }
     }
 


### PR DESCRIPTION
Case RE-535: A server with Imunify 360 installed could report that it had the hardened PHP feature, but either have the repo disabled or not have updated the ea-cpanel-tools package to be provided by CloudLinux. This would result in the EA4 blocker check failing because it would attempt give the EA4 backup script
(/usr/local/bin/ea_current_to_profile) the 'CloudLinux_8' target which the cPanel version of ea-cpanel-tools does not provide.  This would result in the command failing due to an invalid target.  This change makes it so that we verify that ea-cpanel-tools is being provided by CloudLinux before assuming that Imunify 360 provides hardened PHP.

Changelog: Have check that Imunify 360 provides hardened PHP ensure that
 the 'ea-cpanel-tools' package is provided by the CloudLinux repository

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

