### PR TITLE
Add blocker for duplicate repo IDs

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1917,6 +1917,8 @@ EOS
 
     use cPstrict;
 
+    use File::Copy ();
+
     use Cpanel::OS             ();
     use Cpanel::JSON           ();
     use Cpanel::Update::Config ();
@@ -1979,11 +1981,31 @@ EOS
 
             if ( !$self->is_check_mode() ) {    # autofix when --check is not used
                 $self->_autofix_yum_repos();
+                $self->_autofix_duplicate_repoids();
 
                 $status_hr = $self->_check_yum_repos();
             }
 
             return 0 unless _yum_status_hr_contains_blocker($status_hr);
+
+            if ( $status_hr->{DUPLICATE_IDS} ) {
+                my $duplicate_ids = join "\n", keys $self->{_duplicate_repoids}->%*;
+                my $dupe_id_msg   = <<~"EOS";
+            One or more enable YUM repo have repositories defined multiple times:
+
+            $duplicate_ids
+
+            A possible resolution for this issue is to either remove the duplicate
+            repository definitions or change the repoids of the conflicting
+            repositories on the system to prevent the conflict.
+            EOS
+
+                my $blocker_id = ref($self) . '::' . 'DuplicateRepoIds';
+                $self->has_blocker(
+                    $dupe_id_msg,
+                    blocker_id => $blocker_id,
+                );
+            }
 
             for my $unsupported_repo ( @{ $self->{_yum_repos_unsupported_with_packages} } ) {
                 my $blocker_id = ref($self) . '::' . $unsupported_repo->{'name'};
@@ -1997,13 +2019,13 @@ EOS
             }
         }
 
-        return 0;
+        return 1;
     }
 
     sub _yum_status_hr_contains_blocker ($status_hr) {
         return 0 if ref $status_hr ne 'HASH' || !scalar keys( %{$status_hr} );
 
-        my @blockers = qw{INVALID_SYNTAX USE_RPMS_FROM_UNVETTED_REPO};
+        my @blockers = qw{INVALID_SYNTAX USE_RPMS_FROM_UNVETTED_REPO DUPLICATE_IDS};
         foreach my $blocked (@blockers) {
             return 1 if $status_hr->{$blocked};
         }
@@ -2103,12 +2125,15 @@ EOS
         $self->{_yum_repos_path_using_invalid_syntax} = [];
         $self->{_yum_repos_to_disable}                = [];
         $self->{_yum_repos_unsupported_with_packages} = [];
+        $self->{_duplicate_repoids}                   = [];
 
         my @vetted_repos = Elevate::OS::vetted_yum_repo();
 
         my $repo_dir = Elevate::Constants::YUM_REPOS_D;
 
         my %status;
+        my %repoids;
+        my %duplicate_repoids;
         opendir( my $dh, $repo_dir ) or do {
             ERROR("Cannot read directory $repo_dir - $!");
             return;
@@ -2202,6 +2227,11 @@ EOS
                     $current_repo_enabled          = 1;    # assume enabled unless explicitely disabled
                     $current_repo_use_valid_syntax = 1;
 
+                    if ( $repoids{$current_repo_name} ) {
+                        $duplicate_repoids{$current_repo_name} = $path;
+                    }
+                    $repoids{$current_repo_name} = 1;
+
                     next;
                 }
                 next unless defined $current_repo_name;
@@ -2213,7 +2243,25 @@ EOS
 
             $check_last_known_repo->();
         }
+
+        if ( scalar keys %duplicate_repoids ) {
+            $status{DUPLICATE_IDS} = 1;
+            $self->{_duplicate_repoids} = \%duplicate_repoids;
+        }
+
         return \%status;
+    }
+
+    sub _autofix_duplicate_repoids ($self) {
+        my %duplicate_ids = $self->{_duplicate_repoids}->%*;
+        foreach my $id ( keys %duplicate_ids ) {
+            if ( $id =~ m/^MariaDB[0-9]+/ ) {
+                my $path = $duplicate_ids{$id};
+                File::Copy::move( $path, "$path.disabled_by_elevate" );
+            }
+        }
+
+        return;
     }
 
     sub _autofix_yum_repos ($self) {


### PR DESCRIPTION
Case RE-452: leapp has an inhibitor in place to check for any repositories that duplicate repo IDs.  This can lead to a situation where --check recommends that a server is ready for elevation, and --start blocks since it 'leapp preupgrade' is only executed during --start.  This change adds a blocker to perform the same check the leapp performs so that we can block and advise the customer how to remove the blocker during --check.  Additionally, one of the things that is triggering this issue on customer server appears to be repo files that are put in place by the product during MariaDB upgrades.  As such, this change also adds in an autofix if the duplicate repo ID matches MariaDBXX since it was likely put in place by the product and will be removed as part of the pre_leapp component for the databases.

Chagnelog:  Add blocker for duplicate repo IDs

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

