### PR TITLE
Do not cleanup database packages if the database is provided by CL

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4231,11 +4231,9 @@ EOS
     my $cnf_file = '/etc/my.cnf';
 
     sub pre_leapp ($self) {
+        return if Elevate::Database::is_database_provided_by_cloudlinux();
 
-        Elevate::Database::is_database_provided_by_cloudlinux()
-          ? $self->run_once('_remove_cpanel_mysql_packages')
-          : $self->run_once("_cleanup_mysql_packages");
-
+        $self->run_once("_cleanup_mysql_packages");
         return;
     }
 

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -24,11 +24,9 @@ use parent qw{Elevate::Components::Base};
 my $cnf_file = '/etc/my.cnf';
 
 sub pre_leapp ($self) {
+    return if Elevate::Database::is_database_provided_by_cloudlinux();
 
-    Elevate::Database::is_database_provided_by_cloudlinux()
-      ? $self->run_once('_remove_cpanel_mysql_packages')
-      : $self->run_once("_cleanup_mysql_packages");
-
+    $self->run_once("_cleanup_mysql_packages");
     return;
 }
 


### PR DESCRIPTION
Case RE-544: When MySQL governor takes over the MySQL install, it can leave a mix of packages from the MariaDB/MySQL upstream and MySQL/MariaDB CloudLinux repos in place.  After discussing this with CloudLinux's developers, it was determined that CloudLinux's version of leapp is able to handle this situation and that elevate should NOT remove these packages as it result in a situation where the database is NOT installed.  This change makes it so that elevate does NOT remove any database packages if it determines that the database server is provided by CloudLinux.

Changelog: Do not cleanup database packages if the database is provided
 by CloudLinux

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

