### PR TITLE
Check whether leapp can control the boot process

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3524,6 +3524,7 @@ EOS
     use Cpanel::JSON            ();
     use Cpanel::Pkgr            ();
     use Cpanel::SafeRun::Simple ();
+    use Cpanel::SafeRun::Object ();
 
     # use Elevate::Components::Base();
     our @ISA;
@@ -3533,6 +3534,118 @@ EOS
 
     use constant GRUB_EDITENV  => '/usr/bin/grub2-editenv';
     use constant GRUB_ENV_FILE => '/boot/grub2/grubenv';
+
+    use constant GRUBBY_PATH  => '/usr/sbin/grubby';
+    use constant CMDLINE_PATH => '/proc/cmdline';
+
+    use constant EX_UNAVAILABLE => 69;
+
+    sub _call_grubby ( $self, @args ) {
+
+        my %opts = (
+            should_capture_output => 0,
+            should_hide_output    => 0,
+            die_on_error          => 0,
+        );
+
+        if ( ref $args[0] eq 'HASH' ) {
+            my %opt_args = %{ shift @args };
+            foreach my $key ( keys %opt_args ) {
+                $opts{$key} = $opt_args{$key};
+            }
+        }
+
+        unshift @args, GRUBBY_PATH;
+
+        return $opts{die_on_error} ? $self->ssystem_and_die(@args) : $self->ssystem( \%opts, @args );
+    }
+
+    sub _default_kernel ($self) {
+        return $self->_call_grubby( { should_capture_output => 1, should_hide_output => 1 }, '--default-kernel' )->{'stdout'}->[0] // '';
+    }
+
+    sub _persistent_id {
+        my $id = Elevate::StageFile::read_stage_file( 'bootloader_random_tag', '' );
+        return $id if $id;
+
+        $id = int( rand(100000) );
+        Elevate::StageFile::update_stage_file( { 'bootloader_random_tag', $id } );
+        return $id;
+    }
+
+    sub mark_cmdline ($self) {
+        my $arg = "elevate-" . _persistent_id;
+        INFO("Marking default boot entry with additional parameter \"$arg\".");
+
+        my $kernel_path = $self->_default_kernel;
+        $self->_call_grubby( { die_on_error => 1 }, "--update-kernel=$kernel_path", "--args=$arg" );
+
+        return;
+    }
+
+    sub _remove_but_dont_stop_service ($self) {
+
+        $self->cpev->service->disable();
+        $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
+
+        return;
+    }
+
+    sub verify_cmdline ($self) {
+        if ( $self->cpev->should_run_leapp() ) {
+            my $arg = "elevate-" . _persistent_id;
+            INFO("Checking for \"$arg\" in booted kernel's command line...");
+
+            my $kernel_cmdline = eval { File::Slurper::read_binary(CMDLINE_PATH) } // '';
+            DEBUG( CMDLINE_PATH . " contains: $kernel_cmdline" );
+
+            my $detected = scalar grep { $_ eq $arg } split( ' ', $kernel_cmdline );
+            if ($detected) {
+                INFO("Parameter detected; restoring entry to original state.");
+            }
+            else {
+                ERROR("Parameter not detected. Attempt to upgrade is being aborted.");
+            }
+
+            my $kernel_path = $self->_default_kernel;
+            my $result      = $self->_call_grubby( "--update-kernel=$kernel_path", "--remove-args=$arg" );
+            WARN("Unable to restore original command line. This should not cause problems but is unusual.") if $result != 0;
+
+            if ( !$detected ) {
+
+                my $stage              = Elevate::Stages::get_stage();
+                my $pretty_distro_name = $self->cpev->upgrade_to_pretty_name();
+                my $msg                = <<"EOS";
+The elevation process failed during stage $stage.
+
+Specifically, the script could not prove that the system has control over its
+own boot process using the utilities the operating system provides.
+
+For this reason, the elevation process has terminated before making any
+irreversible changes.
+
+You can check the error log by running:
+
+    $0
+
+Before you can run the elevation process, you must provide for the ability for
+the system to manipulate its own boot process. Then you can start the elevation
+process anew:
+
+    $0 --start
+
+EOS
+                Elevate::Notify::send_notification( qq[Failed to update to $pretty_distro_name] => $msg );
+
+                $self->cpev->do_cleanup(1);
+                $self->_remove_but_dont_stop_service();
+
+                exit EX_UNAVAILABLE;    ## no critic(Cpanel::NoExitsFromSubroutines)
+            }
+        }
+
+        return;
+    }
 
     sub pre_leapp ($self) {
 
@@ -6935,9 +7048,9 @@ EOS
             keep_env     => $opts{keep_env} // 0,
             read_timeout => 0,
         );
-        INFO();    # Buffer so they can more easily read the output.
+        INFO() unless $opts{should_hide_output};    # Buffer so they can more easily read the output.
 
-        $? = $sr->CHILD_ERROR;    ## no critic qw(Variables::RequireLocalizedPunctuationVars) -- emulate return behavior of system()
+        $? = $sr->CHILD_ERROR;                      ## no critic qw(Variables::RequireLocalizedPunctuationVars) -- emulate return behavior of system()
 
         if ( $opts{should_capture_output} ) {
             $capture_output->{status} = $?;
@@ -8058,6 +8171,7 @@ use constant NOC_RECOMMENDATIONS_TOUCH_FILE => q[/var/cpanel/elevate-noc-recomme
 
 use constant ACTION_REBOOT_NEEDED   => 4242;    # just one unique id
 use constant ACTION_PAUSE_REQUESTED => 4243;
+use constant ACTION_CONTINUE        => 4244;
 
 use constant PAUSE_ELEVATE_TOUCHFILE => q[/waiting_for_distro_upgrade];
 
@@ -8241,6 +8355,9 @@ sub monitor_upgrade ($self) {
 }
 
 sub start ($self) {
+
+    return 1 unless _sanity_check();
+
     my $stage = Elevate::Stages::get_stage();
     if ( $stage != 0 ) {
         my $header;
@@ -8268,8 +8385,6 @@ sub start ($self) {
 
     system touch => Elevate::Constants::LOG_FILE;
 
-    Elevate::Stages::bump_stage();    # init stage number to 1
-
     # store the manual reboots flag
     if ( $self->getopt('manual-reboots') ) {
         WARN('Manual Reboot would be required between each stages');
@@ -8291,8 +8406,8 @@ sub start ($self) {
         Elevate::StageFile::update_stage_file( { no_leapp => 1 } );
     }
 
-    # prefer over running step1: so status and notifications are enabled
-    return $self->run_service_and_notify();
+    # This starts the service for us:
+    return $self->service->install();
 }
 
 sub _capture_env_variables ($self) {
@@ -8379,11 +8494,6 @@ sub continue_elevation ($self) {
         Elevate::Logger::ERROR_nolog("Looks like no elevate process was started. Please consider running: /scripts/elevate-cpanel --start");
         return;
     }
-    elsif ( $stage == 1 ) {
-        Elevate::Logger::INFO_nolog("Continuing elevate process from stage 1 (service not setup yet)");
-        $self->run_stage_1();
-        return;
-    }
 
     $self->_capture_env_variables();    # capture env before restart
 
@@ -8401,11 +8511,13 @@ sub continue_elevation ($self) {
     }
 }
 
-sub do_cleanup ($self) {
+sub do_cleanup ( $self, $handle_service_manually = 0 ) {
 
-    $self->service->remove;
+    if ( !$handle_service_manually ) {
+        $self->service->remove;
+        $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
+    }
 
-    $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
     Elevate::StageFile::remove_stage_file();
     unlink Elevate::Constants::PID_FILE;
 
@@ -8429,37 +8541,40 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
     }
 
     my $action_todo;
-    my $ok = eval {
-        $action_todo = $self->_run_service();
-        1;
-    };
+    do {
+        my $ok = eval {
+            $action_todo = $self->_run_service();
+            1;
+        };
 
-    $action_todo //= 0;
+        $action_todo //= 0;
 
-    if ($ok) {
+        if ($ok) {
 
-        # only notify a success when reaching the last stage
-        if ( $stage == VALID_STAGES ) {
-            Elevate::StageFile::update_stage_file( { status => q[success] } );
-            $self->_notify_success();
-            Elevate::StageFile::create_success_file();
+            # only notify a success when reaching the last stage
+            if ( $stage == VALID_STAGES ) {
+                Elevate::StageFile::update_stage_file( { status => q[success] } );
+                $self->_notify_success();
+                Elevate::StageFile::create_success_file();
+            }
+
+            if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
+                Elevate::StageFile::update_stage_file( { status => q[paused] } );
+            }
+            elsif ( $action_todo == ACTION_REBOOT_NEEDED ) {
+                $self->reboot();
+            }
+
         }
+        else {
+            my $error = $@ // q[Unknown error];
 
-        if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
-            Elevate::StageFile::update_stage_file( { status => q[paused] } );
+            Elevate::StageFile::update_stage_file( { status => q[failed] } );
+            $self->_notify_error($error);
+
+            LOGDIE($error);
         }
-        elsif ( $action_todo == ACTION_REBOOT_NEEDED ) {
-            $self->reboot();
-        }
-    }
-    else {
-        my $error = $@ // q[Unknown error];
-
-        Elevate::StageFile::update_stage_file( { status => q[failed] } );
-        $self->_notify_error($error);
-
-        LOGDIE($error);
-    }
+    } while ( $action_todo == ACTION_CONTINUE );
 
     return $action_todo;
 }
@@ -8562,7 +8677,7 @@ sub _run_service ($self) {
 
     my $stage = Elevate::Stages::get_stage();
 
-    print_box( "Starting stage $stage of " . VALID_STAGES ) if $stage > 1;
+    print_box( "Starting stage $stage of " . VALID_STAGES );
 
     $self->_wait_on_pause();    # handle pause when requested
 
@@ -8658,20 +8773,18 @@ responsible of the multiple reboots.
 
 sub run_stage_1 ($self) {
 
-    # do not leave cruft behing when aborting
-    my $abort = sub {
-        $self->do_cleanup();
-        exit 42;    ## no critic(Cpanel::NoExitsFromSubroutines) catching signals
-    };
+    Elevate::Marker::startup();
 
-    local $SIG{'INT'} = $abort;
-    local $SIG{'HUP'} = $abort;
+    Elevate::Motd->setup();
 
-    return 1 unless _sanity_check();
+    if ( !$self->should_run_leapp() ) {
+        Elevate::Stages::bump_stage();
+        return ACTION_CONTINUE;
+    }
 
-    print_box( "Starting stage 1 of " . VALID_STAGES . ": Installing " . $self->service->name . " service" );
+    $self->run_component_once( 'Grub2' => 'mark_cmdline' );
 
-    return $self->service->install();
+    return ACTION_REBOOT_NEEDED;
 }
 
 =head2 run_stage_2
@@ -8682,9 +8795,7 @@ Update the current distro packages then reboot.
 
 sub run_stage_2 ($self) {
 
-    Elevate::Marker::startup();
-
-    Elevate::Motd->setup();
+    $self->run_component_once( 'Grub2' => 'verify_cmdline' );
 
     $self->ssystem(qw{/usr/bin/yum clean all});
     $self->ssystem_and_die(qw{/scripts/update-packages});

--- a/lib/Elevate/Components/Grub2.pm
+++ b/lib/Elevate/Components/Grub2.pm
@@ -21,6 +21,7 @@ use Log::Log4perl qw(:easy);
 use Cpanel::JSON            ();
 use Cpanel::Pkgr            ();
 use Cpanel::SafeRun::Simple ();
+use Cpanel::SafeRun::Object ();
 
 use parent qw{Elevate::Components::Base};
 
@@ -28,6 +29,122 @@ use Elevate::Blockers ();
 
 use constant GRUB_EDITENV  => '/usr/bin/grub2-editenv';
 use constant GRUB_ENV_FILE => '/boot/grub2/grubenv';
+
+use constant GRUBBY_PATH  => '/usr/sbin/grubby';
+use constant CMDLINE_PATH => '/proc/cmdline';
+
+# In place of Unix::Sysexits:
+use constant EX_UNAVAILABLE => 69;
+
+sub _call_grubby ( $self, @args ) {
+
+    my %opts = (
+        should_capture_output => 0,
+        should_hide_output    => 0,
+        die_on_error          => 0,
+    );
+
+    if ( ref $args[0] eq 'HASH' ) {
+        my %opt_args = %{ shift @args };
+        foreach my $key ( keys %opt_args ) {
+            $opts{$key} = $opt_args{$key};
+        }
+    }
+
+    unshift @args, GRUBBY_PATH;
+
+    return $opts{die_on_error} ? $self->ssystem_and_die(@args) : $self->ssystem( \%opts, @args );
+}
+
+sub _default_kernel ($self) {
+    return $self->_call_grubby( { should_capture_output => 1, should_hide_output => 1 }, '--default-kernel' )->{'stdout'}->[0] // '';
+}
+
+sub _persistent_id {
+    my $id = Elevate::StageFile::read_stage_file( 'bootloader_random_tag', '' );
+    return $id if $id;
+
+    $id = int( rand(100000) );
+    Elevate::StageFile::update_stage_file( { 'bootloader_random_tag', $id } );
+    return $id;
+}
+
+sub mark_cmdline ($self) {
+    my $arg = "elevate-" . _persistent_id;
+    INFO("Marking default boot entry with additional parameter \"$arg\".");
+
+    my $kernel_path = $self->_default_kernel;
+    $self->_call_grubby( { die_on_error => 1 }, "--update-kernel=$kernel_path", "--args=$arg" );
+
+    return;
+}
+
+sub _remove_but_dont_stop_service ($self) {
+
+    $self->cpev->service->disable();
+    $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
+
+    return;
+}
+
+sub verify_cmdline ($self) {
+    if ( $self->cpev->should_run_leapp() ) {
+        my $arg = "elevate-" . _persistent_id;
+        INFO("Checking for \"$arg\" in booted kernel's command line...");
+
+        my $kernel_cmdline = eval { File::Slurper::read_binary(CMDLINE_PATH) } // '';
+        DEBUG( CMDLINE_PATH . " contains: $kernel_cmdline" );
+
+        my $detected = scalar grep { $_ eq $arg } split( ' ', $kernel_cmdline );
+        if ($detected) {
+            INFO("Parameter detected; restoring entry to original state.");
+        }
+        else {
+            ERROR("Parameter not detected. Attempt to upgrade is being aborted.");
+        }
+
+        my $kernel_path = $self->_default_kernel;
+        my $result      = $self->_call_grubby( "--update-kernel=$kernel_path", "--remove-args=$arg" );
+        WARN("Unable to restore original command line. This should not cause problems but is unusual.") if $result != 0;
+
+        if ( !$detected ) {
+
+            # Can't use _notify_error as in run_service_and_notify, because that
+            # tells you to use --continue, which won't work here due to the
+            # do_cleanup invocation:
+            my $stage              = Elevate::Stages::get_stage();
+            my $pretty_distro_name = $self->cpev->upgrade_to_pretty_name();
+            my $msg                = <<"EOS";
+The elevation process failed during stage $stage.
+
+Specifically, the script could not prove that the system has control over its
+own boot process using the utilities the operating system provides.
+
+For this reason, the elevation process has terminated before making any
+irreversible changes.
+
+You can check the error log by running:
+
+    $0
+
+Before you can run the elevation process, you must provide for the ability for
+the system to manipulate its own boot process. Then you can start the elevation
+process anew:
+
+    $0 --start
+
+EOS
+            Elevate::Notify::send_notification( qq[Failed to update to $pretty_distro_name] => $msg );
+
+            $self->cpev->do_cleanup(1);
+            $self->_remove_but_dont_stop_service();
+
+            exit EX_UNAVAILABLE;    ## no critic(Cpanel::NoExitsFromSubroutines)
+        }
+    }
+
+    return;
+}
 
 sub pre_leapp ($self) {
 

--- a/lib/Elevate/Notify.pm
+++ b/lib/Elevate/Notify.pm
@@ -50,6 +50,7 @@ sub send_notification ( $subject, $msg, %opts ) {
     return;
 }
 
+# NOTE: change notification capturing in Test::Elevate if sub signature changes
 sub _send_notification ( $subject, $msg, %opts ) {
 
     my $is_success = delete $opts{is_success};

--- a/lib/Elevate/Roles/Run.pm
+++ b/lib/Elevate/Roles/Run.pm
@@ -108,9 +108,9 @@ sub _ssystem ( $command, %opts ) {
         keep_env     => $opts{keep_env} // 0,
         read_timeout => 0,
     );
-    INFO();    # Buffer so they can more easily read the output.
+    INFO() unless $opts{should_hide_output};    # Buffer so they can more easily read the output.
 
-    $? = $sr->CHILD_ERROR;    ## no critic qw(Variables::RequireLocalizedPunctuationVars) -- emulate return behavior of system()
+    $? = $sr->CHILD_ERROR;                      ## no critic qw(Variables::RequireLocalizedPunctuationVars) -- emulate return behavior of system()
 
     if ( $opts{should_capture_output} ) {
         $capture_output->{status} = $?;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -328,6 +328,7 @@ use constant NOC_RECOMMENDATIONS_TOUCH_FILE => q[/var/cpanel/elevate-noc-recomme
 
 use constant ACTION_REBOOT_NEEDED   => 4242;    # just one unique id
 use constant ACTION_PAUSE_REQUESTED => 4243;
+use constant ACTION_CONTINUE        => 4244;
 
 use constant PAUSE_ELEVATE_TOUCHFILE => q[/waiting_for_distro_upgrade];
 
@@ -511,6 +512,9 @@ sub monitor_upgrade ($self) {
 }
 
 sub start ($self) {
+
+    return 1 unless _sanity_check();
+
     my $stage = Elevate::Stages::get_stage();
     if ( $stage != 0 ) {
         my $header;
@@ -538,8 +542,6 @@ sub start ($self) {
 
     system touch => Elevate::Constants::LOG_FILE;
 
-    Elevate::Stages::bump_stage();    # init stage number to 1
-
     # store the manual reboots flag
     if ( $self->getopt('manual-reboots') ) {
         WARN('Manual Reboot would be required between each stages');
@@ -561,8 +563,8 @@ sub start ($self) {
         Elevate::StageFile::update_stage_file( { no_leapp => 1 } );
     }
 
-    # prefer over running step1: so status and notifications are enabled
-    return $self->run_service_and_notify();
+    # This starts the service for us:
+    return $self->service->install();
 }
 
 sub _capture_env_variables ($self) {
@@ -649,11 +651,6 @@ sub continue_elevation ($self) {
         Elevate::Logger::ERROR_nolog("Looks like no elevate process was started. Please consider running: /scripts/elevate-cpanel --start");
         return;
     }
-    elsif ( $stage == 1 ) {
-        Elevate::Logger::INFO_nolog("Continuing elevate process from stage 1 (service not setup yet)");
-        $self->run_stage_1();
-        return;
-    }
 
     $self->_capture_env_variables();    # capture env before restart
 
@@ -671,11 +668,13 @@ sub continue_elevation ($self) {
     }
 }
 
-sub do_cleanup ($self) {
+sub do_cleanup ( $self, $handle_service_manually = 0 ) {
 
-    $self->service->remove;
+    if ( !$handle_service_manually ) {
+        $self->service->remove;
+        $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
+    }
 
-    $self->ssystem( '/usr/bin/systemctl', 'daemon-reload' );
     Elevate::StageFile::remove_stage_file();
     unlink Elevate::Constants::PID_FILE;
 
@@ -699,37 +698,40 @@ sub run_service_and_notify ($self) {    # FIXME: move to Elevate::Service - need
     }
 
     my $action_todo;
-    my $ok = eval {
-        $action_todo = $self->_run_service();
-        1;
-    };
+    do {
+        my $ok = eval {
+            $action_todo = $self->_run_service();
+            1;
+        };
 
-    $action_todo //= 0;
+        $action_todo //= 0;
 
-    if ($ok) {
+        if ($ok) {
 
-        # only notify a success when reaching the last stage
-        if ( $stage == VALID_STAGES ) {
-            Elevate::StageFile::update_stage_file( { status => q[success] } );
-            $self->_notify_success();
-            Elevate::StageFile::create_success_file();
+            # only notify a success when reaching the last stage
+            if ( $stage == VALID_STAGES ) {
+                Elevate::StageFile::update_stage_file( { status => q[success] } );
+                $self->_notify_success();
+                Elevate::StageFile::create_success_file();
+            }
+
+            if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
+                Elevate::StageFile::update_stage_file( { status => q[paused] } );
+            }
+            elsif ( $action_todo == ACTION_REBOOT_NEEDED ) {
+                $self->reboot();
+            }
+
         }
+        else {
+            my $error = $@ // q[Unknown error];
 
-        if ( $action_todo == ACTION_PAUSE_REQUESTED ) {
-            Elevate::StageFile::update_stage_file( { status => q[paused] } );
+            Elevate::StageFile::update_stage_file( { status => q[failed] } );
+            $self->_notify_error($error);
+
+            LOGDIE($error);
         }
-        elsif ( $action_todo == ACTION_REBOOT_NEEDED ) {
-            $self->reboot();
-        }
-    }
-    else {
-        my $error = $@ // q[Unknown error];
-
-        Elevate::StageFile::update_stage_file( { status => q[failed] } );
-        $self->_notify_error($error);
-
-        LOGDIE($error);
-    }
+    } while ( $action_todo == ACTION_CONTINUE );
 
     return $action_todo;
 }
@@ -832,7 +834,7 @@ sub _run_service ($self) {
 
     my $stage = Elevate::Stages::get_stage();
 
-    print_box( "Starting stage $stage of " . VALID_STAGES ) if $stage > 1;
+    print_box( "Starting stage $stage of " . VALID_STAGES );
 
     $self->_wait_on_pause();    # handle pause when requested
 
@@ -928,20 +930,18 @@ responsible of the multiple reboots.
 
 sub run_stage_1 ($self) {
 
-    # do not leave cruft behing when aborting
-    my $abort = sub {
-        $self->do_cleanup();
-        exit 42;    ## no critic(Cpanel::NoExitsFromSubroutines) catching signals
-    };
+    Elevate::Marker::startup();
 
-    local $SIG{'INT'} = $abort;
-    local $SIG{'HUP'} = $abort;
+    Elevate::Motd->setup();
 
-    return 1 unless _sanity_check();
+    if ( !$self->should_run_leapp() ) {
+        Elevate::Stages::bump_stage();
+        return ACTION_CONTINUE;
+    }
 
-    print_box( "Starting stage 1 of " . VALID_STAGES . ": Installing " . $self->service->name . " service" );
+    $self->run_component_once( 'Grub2' => 'mark_cmdline' );
 
-    return $self->service->install();
+    return ACTION_REBOOT_NEEDED;
 }
 
 =head2 run_stage_2
@@ -952,9 +952,7 @@ Update the current distro packages then reboot.
 
 sub run_stage_2 ($self) {
 
-    Elevate::Marker::startup();
-
-    Elevate::Motd->setup();
+    $self->run_component_once( 'Grub2' => 'verify_cmdline' );
 
     $self->ssystem(qw{/usr/bin/yum clean all});
     $self->ssystem_and_die(qw{/scripts/update-packages});

--- a/t/components-Grub2.t
+++ b/t/components-Grub2.t
@@ -1,0 +1,91 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::components;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockFile 0.032;
+use Test::MockModule qw/strict/;
+use Test::Trap       qw/:output(perlio) :exit/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $mock_cpev = Test::MockModule->new('cpev');
+
+my $grub2_comp = cpev->new->component('Grub2');
+
+my $mock_stage_file = Test::MockModule->new('Elevate::StageFile');
+my $stage_data;
+$mock_stage_file->redefine( _read_stage_file => sub { return $stage_data } );
+$mock_stage_file->redefine( _save_stage_file => sub { $stage_data = $_[0]; return 1 } );
+
+{
+    note "Checking mark_cmdline";
+
+    $stage_data = undef;
+
+    my $mock_comp = Test::MockModule->new('Elevate::Components::Grub2');
+    $mock_comp->redefine( _call_grubby    => 0 );
+    $mock_comp->redefine( _default_kernel => "doesn't matter" );
+
+    $grub2_comp->mark_cmdline();
+    my $tag = $stage_data->{bootloader_random_tag};
+    ok( 0 <= $tag && $tag < 100000, "tag value created as expected" );
+    message_seen( 'INFO' => qq[Marking default boot entry with additional parameter "elevate-$tag".] );
+    no_messages_seen();
+}
+
+{
+    note "Checking verify_cmdline";
+
+    my $mock_slurp = Test::MockModule->new('File::Slurper');
+    my $cmdline;
+    $mock_slurp->redefine( read_binary => sub { return $cmdline } );
+
+    $mock_cpev->redefine( should_run_leapp => 1 );
+    $mock_cpev->redefine( do_cleanup       => sub { $stage_data = undef; return; } );
+
+    my $mock_comp = Test::MockModule->new('Elevate::Components::Grub2');
+    $mock_comp->redefine( _default_kernel               => "kernel-image" );
+    $mock_comp->redefine( _call_grubby                  => 0 );
+    $mock_comp->redefine( _remove_but_dont_stop_service => 0 );
+
+    $cmdline    = 'BOOT_IMAGE=(hd0,gpt2)/boot/vmlinuz-4.18.0-513.11.1.el8_9.x86_64 root=UUID=cc6b4037-0469-45b1-9b87-e5d2c3bb1654 ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0 crashkernel=no nosplash net.ifnames=0 nomodeset rootflags=uquota';
+    $stage_data = { stage_number => 2 };
+    trap { $grub2_comp->verify_cmdline() };
+    is( $trap->exit, 69, "verify_cmdline exited with EX_UNAVAILABLE" );
+
+    message_seen( 'INFO'  => qr/^Checking for "elevate-[0-9]{1,5}" in booted kernel's command line...$/ );
+    message_seen( 'DEBUG' => "/proc/cmdline contains: $cmdline" );
+    message_seen( 'ERROR' => "Parameter not detected. Attempt to upgrade is being aborted." );
+    no_messages_seen();
+
+    notification_seen( qr/^Failed to update to/, qr/the system has control over/ );
+    no_notifications_seen();
+
+    $cmdline    = 'BOOT_IMAGE=(hd0,gpt2)/boot/vmlinuz-4.18.0-513.11.1.el8_9.x86_64 root=UUID=cc6b4037-0469-45b1-9b87-e5d2c3bb1654 ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0 crashkernel=no nosplash net.ifnames=0 nomodeset rootflags=uquota elevate-9001';
+    $stage_data = { stage_number => 2, bootloader_random_tag => 9001 };
+    ok( lives { $grub2_comp->verify_cmdline() }, "verify_cmdline doesn't die" );
+
+    message_seen( 'INFO'  => qq[Checking for "elevate-9001" in booted kernel's command line...] );
+    message_seen( 'DEBUG' => "/proc/cmdline contains: $cmdline" );
+    message_seen( 'INFO'  => "Parameter detected; restoring entry to original state." );
+    no_messages_seen();
+
+    no_notifications_seen();
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-514: Currently, the script assumes that leapp will have sufficient control over the boot process via GRUB2 configuration. This can result in upgrades making it all the way to leapp only to discover that leapp cannot boot into the custom environment leapp uses to carry out the upgrade, leading to a system that largely cannot be restored into a fully functional state.

It is possible to check that changes made to the bootloader are reflected in the behavior of the boot process, but this requires doing work prior to any major changes to the system. Stage 1 is an ideal time for this, but also stage 1 was not designed to result in a reboot, unlike every other stage. To make this work, the bootstraping of the elevate-cpanel service has been moved to a pre-stage, and the start and continuation entry points have been changed not to call stage 1 directly. This allows the stage 1 subroutine to return a signal to reboot like all the other stages, though it also results in some cosmetic and (hopefully) minor changes to user-facing behavior, some of which can be mitigated.

In particular, the check being done is to use the `grubby` utility to add and later remove a kernel argument in the default boot entry. The argument is designed to be exceedingly unlikely to ever be something that the kernel or PID 1 would recognize, and thus they ignore it; the script then checks for the argument via `/proc/cmdline` at the very start of stage 2. If found, the rest of stage 2 proceeds as normal; if not, the entire ELevate process is reset as if `--start` had never been passed to the script, and a custom failure notification is emitted.

Changelog: Check whether leapp can control the boot process before
 significant and irreversable changes are applied to the system.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

