### PR TITLE
Create new component to handle R1Soft agent

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -62,6 +62,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Components/AutoSSL.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/DatabaseUpgrade.pm'}    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/ELS.pm'}                = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Components/R1Soft.pm'}             = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS.pm'}                            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CentOS7.pm'}                    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CloudLinux7.pm'}                = 'script/elevate-cpanel.PL.static';
@@ -117,6 +118,17 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use constant SBIN_IP => q[/sbin/ip];
 
     use constant ETH_FILE_PREFIX => q[/etc/sysconfig/network-scripts/ifcfg-];
+
+    use constant R1SOFT_REPO               => 'r1soft';
+    use constant R1SOFT_REPO_FILE          => '/etc/yum.repos.d/r1soft.repo';
+    use constant R1SOFT_MAIN_AGENT_PACKAGE => 'serverbackup-agent';
+    use constant R1SOFT_AGENT_PACKAGES => qw{
+      r1soft-getmodule
+      serverbackup-agent
+      serverbackup-async-agent-2-6
+      serverbackup-enterprise-agent
+      serverbackup-setup
+    };
 
     1;
 
@@ -2661,6 +2673,7 @@ EOS
           ssystem
           ssystem_and_die
           ssystem_capture_output
+          ssystem_hide_and_capture_output
           remove_rpms_from_repos
         };
 
@@ -5527,6 +5540,133 @@ EOS
 
 }    # --- END lib/Elevate/Components/ELS.pm
 
+{    # --- BEGIN lib/Elevate/Components/R1Soft.pm
+
+    package Elevate::Components::R1Soft;
+
+    use cPstrict;
+
+    use Elevate::Constants ();
+    use Elevate::StageFile ();
+
+    use Cpanel::Pkgr ();
+
+    use File::Slurper ();
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    # use Elevate::Components::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Components::Base); }
+
+    sub pre_leapp ($self) {
+
+        my $r1soft_agent_installed = 0;
+        my $r1soft_repo_present    = 0;
+        my $r1soft_repo_enabled    = 0;
+
+        if ( Cpanel::Pkgr::is_installed(Elevate::Constants::R1SOFT_MAIN_AGENT_PACKAGE) ) {
+            $r1soft_agent_installed = 1;
+
+            my @repo_list = $self->yum->repolist_enabled();
+
+            if ( scalar grep { index( $_, Elevate::Constants::R1SOFT_REPO ) == 0 } @repo_list ) {
+                $r1soft_repo_present = 1;
+                $r1soft_repo_enabled = 1;
+            }
+            else {
+                @repo_list = $self->yum->repolist_all();
+
+                if ( scalar grep { index( $_, Elevate::Constants::R1SOFT_REPO ) == 0 } @repo_list ) {
+                    $r1soft_repo_present = 1;
+                }
+            }
+
+            $self->yum->remove(Elevate::Constants::R1SOFT_AGENT_PACKAGES);
+        }
+
+        Elevate::StageFile::update_stage_file(
+            {
+                r1soft => {
+                    agent_installed => $r1soft_agent_installed,
+                    repo_present    => $r1soft_repo_present,
+                    repo_enabled    => $r1soft_repo_enabled,
+                }
+            }
+        );
+
+        return;
+    }
+
+    sub post_leapp ($self) {
+
+        my $r1soft_info = Elevate::StageFile::read_stage_file('r1soft');
+
+        return unless $r1soft_info->{agent_installed};
+
+        $self->yum->install('kernel-devel');
+
+        if ( !$r1soft_info->{repo_present} ) {
+
+            $self->_create_r1soft_repo();
+        }
+        else {
+            $self->_enable_r1soft_repo() unless $r1soft_info->{repo_enabled};
+        }
+
+        $self->yum->install(Elevate::Constants::R1SOFT_AGENT_PACKAGES);
+
+        if ( !$r1soft_info->{repo_present} || !$r1soft_info->{repo_enabled} ) {
+            $self->_disable_r1soft_repo();
+        }
+
+        return;
+    }
+
+    sub _enable_r1soft_repo ($self) {
+        return $self->_run_yum_config_manager( '--enable', Elevate::Constants::R1SOFT_REPO );
+    }
+
+    sub _disable_r1soft_repo ($self) {
+        return $self->_run_yum_config_manager( '--disable', Elevate::Constants::R1SOFT_REPO );
+    }
+
+    sub _run_yum_config_manager ( $self, @args ) {
+        my $yum_config = Cpanel::Binaries::path('yum-config-manager');
+
+        my $err = $self->ssystem( $yum_config, @args );
+        ERROR("Error running $yum_config: $err") if $err;
+
+        return $err;
+    }
+
+    sub _create_r1soft_repo ($self) {
+
+        my $yum_repo_contents = <<~"EOS";
+    [r1soft]
+    name=R1Soft Repository Server
+    baseurl=https://repo.r1soft.com/yum/stable/\$basearch/
+    enabled=1
+    gpgcheck=0
+    EOS
+
+        if ( -e Elevate::Constants::R1SOFT_REPO_FILE ) {
+            ERROR( "Cannot create R1Soft repo. File already exists: " . Elevate::Constants::R1SOFT_REPO_FILE );
+            return;
+        }
+
+        File::Slurper::write_binary( Elevate::Constants::R1SOFT_REPO_FILE, $yum_repo_contents );
+
+        chmod 0644, Elevate::Constants::R1SOFT_REPO_FILE;
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Components/R1Soft.pm
+
 {    # --- BEGIN lib/Elevate/OS.pm
 
     package Elevate::OS;
@@ -5786,6 +5926,7 @@ EOS
         qr/^jetapps-(?:stable|beta|edge)$/,
         'kernelcare',
         'updates',
+        'r1soft',
         qr/^wp-toolkit-(?:cpanel|thirdparties)$/,
       ),
       vetted_mysql_yum_repo_ids;
@@ -7628,6 +7769,8 @@ EOS
 
     use cPstrict;
 
+    use Elevate::Constants ();
+
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
@@ -7680,6 +7823,32 @@ EOS
         return;
     }
 
+    sub repolist_all ($self) {
+        return $self->repolist("all");
+    }
+
+    sub repolist_enabled ($self) {
+        return $self->repolist("enabled");
+    }
+
+    sub repolist ( $self, @options ) {
+        my $pkgmgr = $self->pkgmgr;
+
+        my $out   = $self->cpev->ssystem_hide_and_capture_output( $pkgmgr, '-q', 'repolist', @options );
+        my @lines = @{ $out->{stdout} };
+
+        shift @lines;
+
+        my @repos;
+        foreach my $line (@lines) {
+            my $repo = ( split( '\s+', $line ) )[0];
+
+            push @repos, $repo;
+        }
+
+        return @repos;
+    }
+
     sub get_extra_packages ($self) {
         my $pkgmgr = $self->pkgmgr;
 
@@ -7717,6 +7886,7 @@ EOS
             next if $package eq 'filesystem';
             next if $package eq 'basesystem';
             next if $package eq 'virt-what';
+            next if ( scalar grep { $_ eq $package } Elevate::Constants::R1SOFT_AGENT_PACKAGES );
 
             push @extra_packages, { package => $package, version => $version, arch => $arch };
         }
@@ -8018,6 +8188,7 @@ use Elevate::Components::SSH                ();
 use Elevate::Components::AutoSSL            ();
 use Elevate::Components::DatabaseUpgrade    ();
 use Elevate::Components::ELS                ();
+use Elevate::Components::R1Soft             ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -9050,6 +9221,7 @@ sub run_final_components_pre_leapp ($self) {
     $self->run_component_once( 'LiteSpeed'        => 'pre_leapp' );
     $self->run_component_once( 'AbsoluteSymlinks' => 'pre_leapp' );
     $self->run_component_once( 'ELS'              => 'pre_leapp' );
+    $self->run_component_once( 'R1Soft'           => 'pre_leapp' );
     $self->run_component_once( 'RpmDB'            => 'pre_leapp' );    # remove the RPMs last
 
     return;
@@ -9076,6 +9248,7 @@ sub post_leapp_update_restore ($self) {
     $self->run_component_once( 'KernelCare'    => 'post_leapp' );
     $self->run_component_once( 'NixStats'      => 'post_leapp' );
     $self->run_component_once( 'LiteSpeed'     => 'post_leapp' );
+    $self->run_component_once( 'R1Soft'        => 'post_leapp' );
 
     return;
 }

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -34,6 +34,7 @@ BEGIN {
       ssystem
       ssystem_and_die
       ssystem_capture_output
+      ssystem_hide_and_capture_output
       remove_rpms_from_repos
     };
 

--- a/lib/Elevate/Components/R1Soft.pm
+++ b/lib/Elevate/Components/R1Soft.pm
@@ -1,0 +1,151 @@
+package Elevate::Components::R1Soft;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Components::R1Soft
+
+Handle situation where the R1Soft backup agent is installed
+
+Before leapp:
+    Find out:
+        Is the R1Soft agent installed?
+        And, if so, is the R1Soft repo present and enabled?
+    And, if the agent is installed, go ahead and remove it.
+    (We'll need to reinstall it after the OS upgrade.)
+
+After leapp:
+    If the agent had been installed:
+        Re-install kernel-devel (needed by the agent install).
+        Add the repo if it wasn't present.
+        Enable the repo if it wasn't enabled.
+        Re-install the agent.
+        Disabled repo if it wasn't both present and enabled.
+
+=cut
+
+use cPstrict;
+
+use Elevate::Constants ();
+use Elevate::StageFile ();
+
+use Cpanel::Pkgr ();
+
+use File::Slurper ();
+use Log::Log4perl qw(:easy);
+
+use parent qw{Elevate::Components::Base};
+
+sub pre_leapp ($self) {
+
+    # Three pieces of information we wish to collect
+    my $r1soft_agent_installed = 0;
+    my $r1soft_repo_present    = 0;
+    my $r1soft_repo_enabled    = 0;
+
+    # We only care about the repo if the agent is installed
+    if ( Cpanel::Pkgr::is_installed(Elevate::Constants::R1SOFT_MAIN_AGENT_PACKAGE) ) {
+        $r1soft_agent_installed = 1;
+
+        my @repo_list = $self->yum->repolist_enabled();
+
+        if ( scalar grep { index( $_, Elevate::Constants::R1SOFT_REPO ) == 0 } @repo_list ) {
+            $r1soft_repo_present = 1;
+            $r1soft_repo_enabled = 1;
+        }
+        else {
+            @repo_list = $self->yum->repolist_all();
+
+            if ( scalar grep { index( $_, Elevate::Constants::R1SOFT_REPO ) == 0 } @repo_list ) {
+                $r1soft_repo_present = 1;
+            }
+        }
+
+        # Remove the agent packages; we'll need to reinstall them after the OS upgrade
+        $self->yum->remove(Elevate::Constants::R1SOFT_AGENT_PACKAGES);
+    }
+
+    Elevate::StageFile::update_stage_file(
+        {
+            r1soft => {
+                agent_installed => $r1soft_agent_installed,
+                repo_present    => $r1soft_repo_present,
+                repo_enabled    => $r1soft_repo_enabled,
+            }
+        }
+    );
+
+    return;
+}
+
+sub post_leapp ($self) {
+
+    my $r1soft_info = Elevate::StageFile::read_stage_file('r1soft');
+
+    # Nothing to do if the agent wasn't installed
+    return unless $r1soft_info->{agent_installed};
+
+    # We need kernel-devel for the agent install to work
+    $self->yum->install('kernel-devel');
+
+    # Ensure that the r1soft repo is present and enabled
+    # if it was not that way to begin with
+    if ( !$r1soft_info->{repo_present} ) {
+
+        $self->_create_r1soft_repo();
+    }
+    else {
+        $self->_enable_r1soft_repo() unless $r1soft_info->{repo_enabled};
+    }
+
+    # Now reinstall all the agent files
+    $self->yum->install(Elevate::Constants::R1SOFT_AGENT_PACKAGES);
+
+    if ( !$r1soft_info->{repo_present} || !$r1soft_info->{repo_enabled} ) {
+        $self->_disable_r1soft_repo();
+    }
+
+    return;
+}
+
+sub _enable_r1soft_repo ($self) {
+    return $self->_run_yum_config_manager( '--enable', Elevate::Constants::R1SOFT_REPO );
+}
+
+sub _disable_r1soft_repo ($self) {
+    return $self->_run_yum_config_manager( '--disable', Elevate::Constants::R1SOFT_REPO );
+}
+
+sub _run_yum_config_manager ( $self, @args ) {
+    my $yum_config = Cpanel::Binaries::path('yum-config-manager');
+
+    my $err = $self->ssystem( $yum_config, @args );
+    ERROR("Error running $yum_config: $err") if $err;
+
+    return $err;
+}
+
+sub _create_r1soft_repo ($self) {
+
+    my $yum_repo_contents = <<~"EOS";
+    [r1soft]
+    name=R1Soft Repository Server
+    baseurl=https://repo.r1soft.com/yum/stable/\$basearch/
+    enabled=1
+    gpgcheck=0
+    EOS
+
+    if ( -e Elevate::Constants::R1SOFT_REPO_FILE ) {
+        ERROR( "Cannot create R1Soft repo. File already exists: " . Elevate::Constants::R1SOFT_REPO_FILE );
+        return;
+    }
+
+    File::Slurper::write_binary( Elevate::Constants::R1SOFT_REPO_FILE, $yum_repo_contents );
+
+    chmod 0644, Elevate::Constants::R1SOFT_REPO_FILE;
+
+    return;
+}
+
+1;

--- a/lib/Elevate/Constants.pm
+++ b/lib/Elevate/Constants.pm
@@ -41,4 +41,15 @@ use constant SBIN_IP => q[/sbin/ip];
 
 use constant ETH_FILE_PREFIX => q[/etc/sysconfig/network-scripts/ifcfg-];
 
+use constant R1SOFT_REPO               => 'r1soft';
+use constant R1SOFT_REPO_FILE          => '/etc/yum.repos.d/r1soft.repo';
+use constant R1SOFT_MAIN_AGENT_PACKAGE => 'serverbackup-agent';
+use constant R1SOFT_AGENT_PACKAGES => qw{
+  r1soft-getmodule
+  serverbackup-agent
+  serverbackup-async-agent-2-6
+  serverbackup-enterprise-agent
+  serverbackup-setup
+};
+
 1;

--- a/lib/Elevate/OS/RHEL.pm
+++ b/lib/Elevate/OS/RHEL.pm
@@ -61,6 +61,7 @@ use constant vetted_yum_repo => (
     qr/^jetapps-(?:stable|beta|edge)$/,
     'kernelcare',
     'updates',
+    'r1soft',
     qr/^wp-toolkit-(?:cpanel|thirdparties)$/,
   ),
   vetted_mysql_yum_repo_ids;

--- a/lib/Elevate/YUM.pm
+++ b/lib/Elevate/YUM.pm
@@ -12,6 +12,8 @@ Logic wrapping the 'yum' system binary
 
 use cPstrict;
 
+use Elevate::Constants ();
+
 use Log::Log4perl qw(:easy);
 
 use Simple::Accessor qw{
@@ -63,6 +65,33 @@ sub install ( $self, @pkgs ) {
     return;
 }
 
+sub repolist_all ($self) {
+    return $self->repolist("all");
+}
+
+sub repolist_enabled ($self) {
+    return $self->repolist("enabled");
+}
+
+sub repolist ( $self, @options ) {
+    my $pkgmgr = $self->pkgmgr;
+
+    my $out   = $self->cpev->ssystem_hide_and_capture_output( $pkgmgr, '-q', 'repolist', @options );
+    my @lines = @{ $out->{stdout} };
+
+    # The first line is just header info
+    shift @lines;
+
+    my @repos;
+    foreach my $line (@lines) {
+        my $repo = ( split( '\s+', $line ) )[0];
+
+        push @repos, $repo;
+    }
+
+    return @repos;
+}
+
 # No cache here since this is currently only called one time from a blocker
 # Consider adding a cache if we ever call it anywhere else
 sub get_extra_packages ($self) {
@@ -107,6 +136,7 @@ sub get_extra_packages ($self) {
         next if $package eq 'filesystem';
         next if $package eq 'basesystem';
         next if $package eq 'virt-what';
+        next if ( scalar grep { $_ eq $package } Elevate::Constants::R1SOFT_AGENT_PACKAGES );
 
         push @extra_packages, { package => $package, version => $version, arch => $arch };
     }

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -288,6 +288,7 @@ use Elevate::Components::SSH                ();
 use Elevate::Components::AutoSSL            ();
 use Elevate::Components::DatabaseUpgrade    ();
 use Elevate::Components::ELS                ();
+use Elevate::Components::R1Soft             ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -1320,6 +1321,7 @@ sub run_final_components_pre_leapp ($self) {
     $self->run_component_once( 'LiteSpeed'        => 'pre_leapp' );
     $self->run_component_once( 'AbsoluteSymlinks' => 'pre_leapp' );
     $self->run_component_once( 'ELS'              => 'pre_leapp' );
+    $self->run_component_once( 'R1Soft'           => 'pre_leapp' );
     $self->run_component_once( 'RpmDB'            => 'pre_leapp' );    # remove the RPMs last
 
     return;
@@ -1346,6 +1348,7 @@ sub post_leapp_update_restore ($self) {
     $self->run_component_once( 'KernelCare'    => 'post_leapp' );
     $self->run_component_once( 'NixStats'      => 'post_leapp' );
     $self->run_component_once( 'LiteSpeed'     => 'post_leapp' );
+    $self->run_component_once( 'R1Soft'        => 'post_leapp' );
 
     return;
 }

--- a/t/components-R1Soft.t
+++ b/t/components-R1Soft.t
@@ -1,0 +1,244 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::components;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $r1soft = cpev->new->component('R1Soft');
+
+{
+    note "Checking pre_leapp";
+
+    my $stage_file_data;
+    my $is_installed;
+    my $yum_remove_called;
+    my @enabled_repos = (
+        "cpanel-plugins",
+        "base/7/x86_64",
+        "col",
+        "col-extras/7/x86_64",
+        "epel/x86_64",
+        "extras/7/x86_64",
+        "mysql-connectors-community/x86_64",
+        "mysql-tools-community/x86_64",
+        "mysql57-community/x86_64",
+        "!openSUSE_Tools",
+        "r1soft/x86_64",
+        "updates/7/x86_64",
+    );
+    my @all_repos = (
+        "base/7/x86_64",
+        "base-debuginfo/x86_64",
+        "base-source/7",
+        "c7-media",
+        "centos-kernel",
+        "centos-kernel-experimental",
+        "centos-sclo-rh/x86_64",
+        "centosplus/7/x86_64",
+        "centosplus-source/7",
+        "col",
+        "col-extras/7/x86_64",
+        "col-extras-source",
+        "col-source",
+        "cr/7/x86_64",
+        "epel/x86_64",
+        "!mysql80-community/x86_64",
+        "mysql80-community-debuginfo/x86_64",
+        "mysql80-community-source",
+        "!openSUSE_Tools",
+        "r1soft/x86_64",
+        "updates/7/x86_64",
+        "updates-source/7",
+    );
+
+    my $mock_pkgr = Test::MockModule->new('Cpanel::Pkgr');
+    $mock_pkgr->redefine(
+        is_installed => sub { return $is_installed; },
+    );
+
+    my $mock_upsf = Test::MockModule->new('Elevate::StageFile');
+    $mock_upsf->redefine(
+        update_stage_file => sub { $stage_file_data = shift; },
+    );
+
+    my $mock_yum = Test::MockModule->new('Elevate::YUM');
+    $mock_yum->redefine(
+        remove           => sub { $yum_remove_called = 1; },
+        repolist_enabled => sub { return @enabled_repos; },
+        repolist_all     => sub { return @all_repos; },
+    );
+
+    # Test when agent is not installed
+    $is_installed      = 0;
+    $yum_remove_called = 0;
+
+    $r1soft->pre_leapp();
+    is( $yum_remove_called, 0, 'Yum remove was not invoked when agent not installed' );
+    is(
+        $stage_file_data,
+        {
+            r1soft => {
+                agent_installed => 0,
+                repo_present    => 0,
+                repo_enabled    => 0,
+            }
+        },
+        'Correctly reports that the agent is not installed'
+    );
+
+    # Agent installed, repo present & enabled
+    $is_installed      = 1;
+    $yum_remove_called = 0;
+
+    $r1soft->pre_leapp();
+    is( $yum_remove_called, 1, 'Yum remove called when agent is installed' );
+    is(
+        $stage_file_data,
+        {
+            r1soft => {
+                agent_installed => 1,
+                repo_present    => 1,
+                repo_enabled    => 1,
+            }
+        },
+        'Correctly reports the installed agent and the repo is present and enabled'
+    );
+
+    # Agent installed, repo present, but not enabled
+    $yum_remove_called = 0;
+    @enabled_repos     = grep { !/^r1soft/ } @enabled_repos;
+
+    $r1soft->pre_leapp();
+    is( $yum_remove_called, 1, 'Yum remove called when agent is installed' );
+    is(
+        $stage_file_data,
+        {
+            r1soft => {
+                agent_installed => 1,
+                repo_present    => 1,
+                repo_enabled    => 0,
+            }
+        },
+        'Correctly reports the installed agent and the repo is present and not enabled'
+    );
+
+    # Agent installed, repo neither present nor enabled
+    $yum_remove_called = 0;
+    @all_repos         = grep { !/^r1soft/ } @all_repos;
+
+    $r1soft->pre_leapp();
+    is( $yum_remove_called, 1, 'Yum remove called when agent is installed' );
+    is(
+        $stage_file_data,
+        {
+            r1soft => {
+                agent_installed => 1,
+                repo_present    => 0,
+                repo_enabled    => 0,
+            }
+        },
+        'Correctly reports the installed agent and the repo is present and not enabled'
+    );
+}
+
+{
+    note "Checking post_leapp";
+
+    my $stage_file_data;
+    my $yum_install_called;
+    my $create_repo_called;
+    my $enable_repo_called;
+    my $disable_repo_called;
+
+    my $mock_upsf = Test::MockModule->new('Elevate::StageFile');
+    $mock_upsf->redefine(
+        read_stage_file => sub { return $stage_file_data; },
+    );
+
+    my $mock_yum = Test::MockModule->new('Elevate::YUM');
+    $mock_yum->redefine(
+        install => sub { $yum_install_called = 1; },
+    );
+
+    my $mock_r1soft = Test::MockModule->new('Elevate::Components::R1Soft');
+    $mock_r1soft->redefine(
+        _create_r1soft_repo  => sub { $create_repo_called  = 1 },
+        _enable_r1soft_repo  => sub { $enable_repo_called  = 1 },
+        _disable_r1soft_repo => sub { $disable_repo_called = 1 },
+    );
+
+    # Agent was not installed
+    $stage_file_data = {
+        agent_installed => 0,
+        repo_present    => 0,
+        repo_enabled    => 0,
+    };
+    ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
+
+    $r1soft->post_leapp();
+    is( $yum_install_called,  0, 'Yum install not called when agent was not installed' );
+    is( $create_repo_called,  0, 'Create repo not called when agent was not installed' );
+    is( $enable_repo_called,  0, 'Enable repo not called when agent was not installed' );
+    is( $disable_repo_called, 0, 'Disable repo not called when agent was not installed' );
+
+    # Agent installed, repo present & enabled
+    $stage_file_data = {
+        agent_installed => 1,
+        repo_present    => 1,
+        repo_enabled    => 1,
+    };
+    ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
+
+    $r1soft->post_leapp();
+    is( $yum_install_called,  1, 'Yum install called when agent was installed' );
+    is( $create_repo_called,  0, 'Create repo not called when repo present' );
+    is( $enable_repo_called,  0, 'Enable repo not called when repo already enabled' );
+    is( $disable_repo_called, 0, 'Disable repo not called when repo present and enabled' );
+
+    # Agent installed, repo present & not enabled
+    $stage_file_data = {
+        agent_installed => 1,
+        repo_present    => 1,
+        repo_enabled    => 0,
+    };
+    ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
+
+    $r1soft->post_leapp();
+    is( $yum_install_called,  1, 'Yum install called when agent was installed' );
+    is( $create_repo_called,  0, 'Create repo not called when repo present' );
+    is( $enable_repo_called,  1, 'Enable repo called when repo not already enabled' );
+    is( $disable_repo_called, 1, 'Disable repo called when repo present and not enabled' );
+
+    # Agent installed, repo not present & not enabled
+    $stage_file_data = {
+        agent_installed => 1,
+        repo_present    => 0,
+        repo_enabled    => 0,
+    };
+    ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
+
+    $r1soft->post_leapp();
+    is( $yum_install_called,  1, 'Yum install called when agent was installed' );
+    is( $create_repo_called,  1, 'Create repo called when repo not present' );
+    is( $enable_repo_called,  0, 'Enable repo not called when repo not present' );
+    is( $disable_repo_called, 1, 'Disable repo called when repo not present' );
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-502:

In cases where the R1Soft backup agent is installed, we need uninstall it.  Then after the the OS upgrade, reinstall kernel-devel, then reinstall the backup
agent.

Changelog: Enable elevate on systems with the R1Soft
  Backup Agent installed.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

