### PR TITLE
RE-404 [DNM] - this is a test

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1438,7 +1438,7 @@ EOS
         return unless -x Elevate::Constants::IMUNIFY_AGENT;
 
         my $agent_bin    = Elevate::Constants::IMUNIFY_AGENT;
-        my $out          = $self->ssystem_capture_output( $agent_bin, 'version', '--json' );
+        my $out          = $self->ssystem_hide_and_capture_output( $agent_bin, 'version', '--json' );
         my $raw_data     = join "\n", @{ $out->{stdout} };
         my $license_data = eval { Cpanel::JSON::Load($raw_data) } // {};
 

--- a/lib/Elevate/Blockers/Imunify.pm
+++ b/lib/Elevate/Blockers/Imunify.pm
@@ -28,7 +28,7 @@ sub _check_imunify_license ($self) {
     return unless -x Elevate::Constants::IMUNIFY_AGENT;
 
     my $agent_bin    = Elevate::Constants::IMUNIFY_AGENT;
-    my $out          = $self->ssystem_capture_output( $agent_bin, 'version', '--json' );
+    my $out          = $self->ssystem_hide_and_capture_output( $agent_bin, 'version', '--json' );
     my $raw_data     = join "\n", @{ $out->{stdout} };
     my $license_data = eval { Cpanel::JSON::Load($raw_data) } // {};
 

--- a/t/blocker-Imunify.t
+++ b/t/blocker-Imunify.t
@@ -36,7 +36,7 @@ my $imunify = $cpev->get_blocker('Imunify');
     my @cmds;
     my @stdout;
     $cpev_mock->redefine(
-        ssystem_capture_output => sub ( $, @args ) {
+        ssystem_hide_and_capture_output => sub ( $, @args ) {
             push @cmds, [@args];
             return { status => 0, stdout => \@stdout, stderr => [] };
         },


### PR DESCRIPTION
Case RE-404: The output of the Imunify license check could be really noisy in the output while in check mode making it more difficult to pick out if a blocker has been found.  This change makes it so that the output of this command is no longer printed to STDOUT or logged.

Changelog: Do not log output of Imunify license check

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

