### PR TITLE
RE-113: Stop using the --noscripts flag to rpm -e on wp-toolkit-cpanel

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5316,11 +5316,11 @@ EOS
 
         INFO("Removing Wordpress Toolkit");
 
-        INFO("Removing the rpm wp-toolkit-cpanel (--noscripts)");
+        INFO("Removing the rpm wp-toolkit-cpanel");
         backup_3rdparty_file('/usr/local/cpanel/3rdparty/wp-toolkit/var/wp-toolkit.sqlite3');
         backup_3rdparty_file('/usr/local/cpanel/3rdparty/wp-toolkit/var/etc/.shadow');
 
-        my ($output) = Cpanel::SafeRun::Errors::saferunallerrors(qw{/usr/bin/rpm -e --noscripts wp-toolkit-cpanel});
+        my ($output) = Cpanel::SafeRun::Errors::saferunallerrors(qw{/usr/bin/rpm -e wp-toolkit-cpanel});
         DEBUG($output) if $output;
 
         cpev::yum_list(1);    # Invalidate the cache since we just ran an rpm -e by hand.

--- a/lib/Elevate/Components/WPToolkit.pm
+++ b/lib/Elevate/Components/WPToolkit.pm
@@ -42,11 +42,11 @@ sub _remove_wordpress_toolkit ($self) {
 
     INFO("Removing Wordpress Toolkit");
 
-    INFO("Removing the rpm wp-toolkit-cpanel (--noscripts)");
+    INFO("Removing the rpm wp-toolkit-cpanel");
     backup_3rdparty_file('/usr/local/cpanel/3rdparty/wp-toolkit/var/wp-toolkit.sqlite3');
     backup_3rdparty_file('/usr/local/cpanel/3rdparty/wp-toolkit/var/etc/.shadow');
 
-    my ($output) = Cpanel::SafeRun::Errors::saferunallerrors(qw{/usr/bin/rpm -e --noscripts wp-toolkit-cpanel});
+    my ($output) = Cpanel::SafeRun::Errors::saferunallerrors(qw{/usr/bin/rpm -e wp-toolkit-cpanel});
     DEBUG($output) if $output;
 
     cpev::yum_list(1);    # Invalidate the cache since we just ran an rpm -e by hand.


### PR DESCRIPTION
Apparently this is no longer required.

Changelog: Stop using the --noscripts flag when erasing wp-toolkit-cpanel
  in pre-leapp stage.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

