### PR TITLE
Restore my.cnf after installing the database server during post_leapp

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4369,10 +4369,14 @@ EOS
 
     use cPstrict;
 
+    use Try::Tiny;
+
     use File::Copy ();
 
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
+
+    use Cpanel::JSON ();
 
     use Elevate::Database  ();
     use Elevate::Notify    ();
@@ -4428,82 +4432,78 @@ EOS
 
     sub _reinstall_mysql_packages {
 
-        my $mysql_version = Elevate::StageFile::read_stage_file( 'mysql-version', '' ) or return;
-        my $enabled       = Elevate::StageFile::read_stage_file( 'mysql-enabled', '' ) or return;
+        my $upgrade_version     = Elevate::StageFile::read_stage_file( 'mysql-version', '' ) or return;
+        my $upgrade_dbtype_name = Elevate::Database::get_database_type_name_from_version($upgrade_version);
+        my $enabled             = Elevate::StageFile::read_stage_file( 'mysql-enabled', '' ) or return;
 
-        INFO("Restoring MySQL $mysql_version");
-
-        my ( $major, $minor ) = split( /\./, $mysql_version );
-
-        INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
-        File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file ) or WARN("Couldn't restore $cnf_file.rpmsave: $!");
+        INFO("Restoring $upgrade_dbtype_name $upgrade_version");
 
         if ( !$enabled ) {
-            INFO("MySQL is not enabled. This will cause the MySQL upgrade tool to fail. Temporarily enabling it to ensure the upgrade succeeds.");
+            INFO("$upgrade_dbtype_name is not enabled. This will cause the $upgrade_dbtype_name upgrade tool to fail. Temporarily enabling it to ensure the upgrade succeeds.");
             Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=1});
 
         }
 
-        my $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade}, "version=$mysql_version" );
-        die qq[Failed to restore MySQL $mysql_version] if $?;
-
-        if ( $out =~ m{\supgrade_id:\s*(\S+)} ) {
-            my $id = $1;
-
-            INFO("Restoring MySQL via upgrade_id $id");
-            INFO('Waiting for MySQL installation');
-
-            my $status = '';
-
-            my $c = 0;
-
-            my $wait_more = 30;
-            while (1) {
-                $c   = ( $c + 1 ) % 10;
-                $out = Cpanel::SafeRun::Simple::saferunnoerror( qw{/usr/local/cpanel/bin/whmapi1 background_mysql_upgrade_status }, "upgrade_id=$id" );
-                if ($?) {
-                    last if !$enabled;
-                    die qq[Failed to restore MySQL $mysql_version: cannot check upgrade_id=$id];
-                }
-
-                if ( $out =~ m{\sstate:\s*inprogress} ) {
-                    print ".";
-                    print "\n" if $c == 0;
-                    sleep 5;
-                    next;
-                }
-
-                if ( $out =~ m{\sstate:\s*(\w+)} ) {
-                    $status = $1;
-                }
-
-                if ( $status ne 'success' && --$wait_more > 0 ) {
-                    sleep 1;
-                    next;
-                }
-
-                last;
-            }
-
-            print "\n"                                                                                                          if $c;          # clear the last "." from above
-            Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0}) if !$enabled;
-
-            if ( $status eq 'success' ) {
-                INFO("MySQL $mysql_version restored");
-            }
-            else {
-                my $msg = "Failed to restore MySQL $mysql_version: upgrade $id status '$status'";
-
-                FATAL($msg);
-                FATAL("$out");
-
-                Elevate::Notify::add_final_notification($msg);
-                return;
-            }
+        try {
+            Elevate::Database::upgrade_database_server();
         }
-        else {
-            die qq[Cannot find upgrade_id from start_background_mysql_upgrade:\n$out];
+        catch {
+            LOGDIE( <<~"EOS" );
+        Unable to install $upgrade_dbtype_name $upgrade_version.  To attempt to
+        install the database server manually, execute:
+
+        /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade veresion=$upgrade_version
+
+        To have this script attempt to install $upgrade_dbtype_name $upgrade_version
+        for you, execute this script again with the continue flag
+
+        /scripts/elevate-cpanel --continue
+
+        Or once the issue has been resolved manually, execute
+
+        /scripts/elevate-cpanel --continue
+
+        to complete the ELevation process.
+        EOS
+        };
+
+        if ( !$enabled ) {
+            Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/local/cpanel/bin/whmapi1 configureservice service=mysql enabled=0});
+            return;
         }
+
+        File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_leapp_orig" );
+
+        INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
+        File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file );
+
+        my $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
+        my @restart_lines = split "\n", $restart_out;
+
+        DEBUG('Restarting Database server with restored my.cnf in place');
+        DEBUG($restart_out);
+        return if grep { $_ =~ m{mysql (?:re)?started successfully} } @restart_lines;
+
+        INFO('The database server failed to start.  Restoring my.cnf to default.');
+        File::Copy::copy( "$cnf_file.elevate_post_leapp_orig", $cnf_file );
+
+        $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
+        @restart_lines = split "\n", $restart_out;
+
+        DEBUG('Restarting Database server with original my.cnf in place');
+        DEBUG($restart_out);
+        return if grep { $_ =~ m{mysql (?:re)?started successfully} } @restart_lines;
+
+        LOGDIE( <<~'EOS' );
+    The database server was unable to start after the attempted restoration.
+
+    Check the elevate log located at '/var/log/elevate-cpanel.log' for further
+    details.
+
+    Additionally, you may wish to inspect the database error log for further
+    details.  This log is located at '/var/lib/mysql/$HOSTNAME.err' where
+    $HOSTNAME is the hostname of your server by default.
+    EOS
 
         return;
     }
@@ -6326,7 +6326,7 @@ EOS
         );
 
         if ($failed_step) {
-            FATAL("FAILED to upgrade to $upgrade_dbtype_name $upgrade_version");
+            LOGDIE("FAILED to upgrade to $upgrade_dbtype_name $upgrade_version");
         }
         else {
             INFO("Finished upgrade to $upgrade_dbtype_name $upgrade_version");

--- a/lib/Elevate/Database.pm
+++ b/lib/Elevate/Database.pm
@@ -141,7 +141,7 @@ sub upgrade_database_server () {
     );
 
     if ($failed_step) {
-        FATAL("FAILED to upgrade to $upgrade_dbtype_name $upgrade_version");
+        LOGDIE("FAILED to upgrade to $upgrade_dbtype_name $upgrade_version");
     }
     else {
         INFO("Finished upgrade to $upgrade_dbtype_name $upgrade_version");


### PR DESCRIPTION
Case RE-543: The contents of my.cnf have the potential to cause the restoration of the database server to fail.  As such, we need to restore the original my.cnf from pre_leapp after restoring the database server in post_leapp.  Once the custom my.cnf is restored, we should attempt to restart the database service to make sure that it starts with the original my.cnf from before elevate began in place.  If it does, then we can move on.  If it does not, then we need to put the default my.cnf that is generated by the installation process of the database restore back in place and make sure that the database service starts with it in place.  This change makes it so that it is more likely for the database service to be installed and running after post_leapp component for it has completed.

Fixes #469

Changelog: Restore my.cnf after installing the database server during
 post_leapp

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

