### PR TITLE
Add 'check_detected_devices_and_drivers' to list of inhibitors to ignore

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2570,6 +2570,7 @@ EOS
 
         my $inhibitors = $self->cpev->leapp->search_report_file_for_inhibitors(
             qw(
+              check_detected_devices_and_drivers
               check_installed_devel_kernels
               cl_mysql_repository_setup
               persistentnetnamesdisable

--- a/lib/Elevate/Blockers/Leapp.pm
+++ b/lib/Elevate/Blockers/Leapp.pm
@@ -57,6 +57,7 @@ sub _check_for_inhibitors ($self) {
 
     my $inhibitors = $self->cpev->leapp->search_report_file_for_inhibitors(
         qw(
+          check_detected_devices_and_drivers
           check_installed_devel_kernels
           cl_mysql_repository_setup
           persistentnetnamesdisable


### PR DESCRIPTION
Case RE-614: Upstream leapp version 0.19.0 is currently in testing but pending being released to stable sometime this month.  One of the changes in this version is the name of the inhibitor that checks the loaded kernel modules.  It changes from 'check_installed_devel_kernels' in version 0.16.0 to 'check_detected_devices_and_drivers' in version 0.19.0.  In order to ensure elevate-cpanel supports both versions of upstream leapp, we simply add 'check_detected_devices_and_drivers' to the list of inhibitors to ignore so that it is ignored under both names.

Changelog: Add 'check_detected_devices_and_drivers' to list of
 inhibitors to ignore in the leapp preupgrade check to prepare for
 upstream leapp version 0.19.0

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

