### PR TITLE
Restore EA4 config files based on package prefix

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3441,8 +3441,7 @@ EOS
 
         Elevate::StageFile::remove_from_stage_file('ea4_config_files');
 
-        my $ea4_regex        = qr/^EA4(:?-c7)?/a;
-        my $ea4_config_files = $self->rpm->get_config_files_for_repo($ea4_regex);
+        my $ea4_config_files = $self->rpm->get_config_files_for_pkg_prefix('ea-');
 
         Elevate::StageFile::update_stage_file( { ea4_config_files => $ea4_config_files } );
 
@@ -7226,10 +7225,11 @@ EOS
         die q[Missing cpev];
     }
 
-    sub get_config_files_for_repo ( $self, $repo ) {
+    sub get_config_files_for_pkg_prefix ( $self, $prefix ) {
 
-        my @installed    = cpev::get_installed_rpms_in_repo($repo);
-        my $config_files = $self->_get_config_files( \@installed );
+        my @installed_rpms = $self->get_installed_rpms(q[%{NAME}\n]);
+        my @ea_rpms        = grep { $_ =~ qr/^\Q$prefix\E/ } @installed_rpms;
+        my $config_files   = $self->_get_config_files( \@ea_rpms );
 
         return $config_files;
     }
@@ -7288,8 +7288,15 @@ EOS
         return;
     }
 
-    sub get_installed_rpms ($self) {
-        my $out = $self->cpev->ssystem_capture_output( $rpm, '-qa' );
+    sub get_installed_rpms ( $self, $format = undef ) {
+        my @args = qw{-qa};
+
+        if ($format) {
+            push @args, '--queryformat';
+            push @args, $format;
+        }
+
+        my $out = $self->cpev->ssystem_capture_output( $rpm, @args );
         return @{ $out->{stdout} };
     }
 

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -118,8 +118,7 @@ sub _backup_config_files ($self) {
 
     Elevate::StageFile::remove_from_stage_file('ea4_config_files');
 
-    my $ea4_regex        = qr/^EA4(:?-c7)?/a;
-    my $ea4_config_files = $self->rpm->get_config_files_for_repo($ea4_regex);
+    my $ea4_config_files = $self->rpm->get_config_files_for_pkg_prefix('ea-');
 
     Elevate::StageFile::update_stage_file( { ea4_config_files => $ea4_config_files } );
 

--- a/lib/Elevate/RPM.pm
+++ b/lib/Elevate/RPM.pm
@@ -24,10 +24,11 @@ sub _build_cpev {
     die q[Missing cpev];
 }
 
-sub get_config_files_for_repo ( $self, $repo ) {
+sub get_config_files_for_pkg_prefix ( $self, $prefix ) {
 
-    my @installed    = cpev::get_installed_rpms_in_repo($repo);
-    my $config_files = $self->_get_config_files( \@installed );
+    my @installed_rpms = $self->get_installed_rpms(q[%{NAME}\n]);
+    my @ea_rpms        = grep { $_ =~ qr/^\Q$prefix\E/ } @installed_rpms;
+    my $config_files   = $self->_get_config_files( \@ea_rpms );
 
     return $config_files;
 }
@@ -92,8 +93,15 @@ sub remove_no_dependencies_and_justdb ( $self, $pkg ) {
     return;
 }
 
-sub get_installed_rpms ($self) {
-    my $out = $self->cpev->ssystem_capture_output( $rpm, '-qa' );
+sub get_installed_rpms ( $self, $format = undef ) {
+    my @args = qw{-qa};
+
+    if ($format) {
+        push @args, '--queryformat';
+        push @args, $format;
+    }
+
+    my $out = $self->cpev->ssystem_capture_output( $rpm, @args );
     return @{ $out->{stdout} };
 }
 

--- a/t/components-ea4.t
+++ b/t/components-ea4.t
@@ -455,8 +455,7 @@ sub test_backup_and_restore_config_files : Test(10) ($self) {
     my $cpev_mock = Test::MockModule->new('cpev');
 
     $cpev_mock->redefine(
-        get_installed_rpms_in_repo => sub { return ( 'ea-foo', 'ea-bar', 'ea-nginx' ) },
-        ssystem_capture_output     => sub ( $, @args ) {
+        ssystem_capture_output => sub ( $, @args ) {
             my $pkg         = pop @args;
             my $config_file = $pkg =~ /foo$/ ? '/tmp/foo.conf' : '/tmp/bar.conf';
             my $ret         = {
@@ -464,6 +463,13 @@ sub test_backup_and_restore_config_files : Test(10) ($self) {
                 stdout => $pkg eq 'ea-nginx' ? [ '/etc/nginx/conf.d/ea-nginx.conf', '/etc/nginx/nginx.conf' ] : [$config_file],
             };
             return $ret;
+        },
+    );
+
+    my $mock_rpm = Test::MockModule->new('Elevate::RPM');
+    $mock_rpm->redefine(
+        get_installed_rpms => sub {
+            return ( 'ea-foo', 'ea-bar', 'ea-nginx', 'not-an-ea-package' );
         },
     );
 


### PR DESCRIPTION
Case RE-499: The restore logic for EA4 config files was broken when the packages were provided by either CloudLinux's EA4 repo or Imunify's hardened PHP repo.  This was because the restore logic was gathering the EA4 packages based on the repoid that they came from, but the regex only took cPanel's version of EA4 into account.  This change makes it so that we gather these packages based on the package prefix of 'ea-' so that the config files for the installed packages are always gathered regardless of which repo provides them.

Fixes #486

Changelog: Fix restore logic for config files of packages provided by
 EA4

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

