### PR TITLE
Fix text in failure advice when MySQL restore fails

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4452,7 +4452,7 @@ EOS
         Unable to install $upgrade_dbtype_name $upgrade_version.  To attempt to
         install the database server manually, execute:
 
-        /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade veresion=$upgrade_version
+        /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade version=$upgrade_version
 
         To have this script attempt to install $upgrade_dbtype_name $upgrade_version
         for you, execute this script again with the continue flag

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -108,7 +108,7 @@ sub _reinstall_mysql_packages {
         Unable to install $upgrade_dbtype_name $upgrade_version.  To attempt to
         install the database server manually, execute:
 
-        /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade veresion=$upgrade_version
+        /usr/local/cpanel/bin/whmapi1 start_background_mysql_upgrade version=$upgrade_version
 
         To have this script attempt to install $upgrade_dbtype_name $upgrade_version
         for you, execute this script again with the continue flag


### PR DESCRIPTION
Case RE-662

Changelog: Fix text in failure advice when MySQL restore fails

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

