### PR TITLE
Do not block on Panopta or FortiMonitor

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -63,6 +63,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Components/DatabaseUpgrade.pm'}    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/ELS.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/R1Soft.pm'}             = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Components/Panopta.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS.pm'}                            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CentOS7.pm'}                    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CloudLinux7.pm'}                = 'script/elevate-cpanel.PL.static';
@@ -5915,6 +5916,37 @@ EOS
 
 }    # --- END lib/Elevate/Components/R1Soft.pm
 
+{    # --- BEGIN lib/Elevate/Components/Panopta.pm
+
+    package Elevate::Components::Panopta;
+
+    use cPstrict;
+
+    use Cpanel::Pkgr ();
+
+    # use Elevate::Components::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Components::Base); }
+
+    sub pre_leapp ($self) {
+
+        if ( Cpanel::Pkgr::is_installed('panopta-agent') ) {
+
+            $self->yum->remove('panopta-agent');
+        }
+
+        return;
+    }
+
+    sub post_leapp ($self) {
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Components/Panopta.pm
+
 {    # --- BEGIN lib/Elevate/OS.pm
 
     package Elevate::OS;
@@ -6175,6 +6207,8 @@ EOS
         'kernelcare',
         'updates',
         'r1soft',
+        qr/^panopta(?:\.repo)?$/,
+        qr/^fortimonitor(?:\.repo)?$/,
         qr/^wp-toolkit-(?:cpanel|thirdparties)$/,
       ),
       vetted_mysql_yum_repo_ids;
@@ -8472,6 +8506,7 @@ use Elevate::Components::AutoSSL            ();
 use Elevate::Components::DatabaseUpgrade    ();
 use Elevate::Components::ELS                ();
 use Elevate::Components::R1Soft             ();
+use Elevate::Components::Panopta            ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -9514,6 +9549,7 @@ sub run_final_components_pre_leapp ($self) {
     $self->run_component_once( 'AbsoluteSymlinks' => 'pre_leapp' );
     $self->run_component_once( 'ELS'              => 'pre_leapp' );
     $self->run_component_once( 'R1Soft'           => 'pre_leapp' );
+    $self->run_component_once( 'Panopta'          => 'pre_leapp' );
     $self->run_component_once( 'RpmDB'            => 'pre_leapp' );    # remove the RPMs last
 
     return;

--- a/lib/Elevate/Components/Panopta.pm
+++ b/lib/Elevate/Components/Panopta.pm
@@ -1,0 +1,38 @@
+package Elevate::Components::Panopta;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Components::Panopta
+
+Handle situation where the Panopta agent is installed
+
+Before leapp:
+    Uninstall the Panopta agent since it is deprecated and
+    not compatible with Elevate
+
+=cut
+
+use cPstrict;
+
+use Cpanel::Pkgr ();
+
+use parent qw{Elevate::Components::Base};
+
+sub pre_leapp ($self) {
+
+    if ( Cpanel::Pkgr::is_installed('panopta-agent') ) {
+
+        $self->yum->remove('panopta-agent');
+    }
+
+    return;
+}
+
+sub post_leapp ($self) {
+
+    return;
+}
+
+1;

--- a/lib/Elevate/OS/RHEL.pm
+++ b/lib/Elevate/OS/RHEL.pm
@@ -62,6 +62,8 @@ use constant vetted_yum_repo => (
     'kernelcare',
     'updates',
     'r1soft',
+    qr/^panopta(?:\.repo)?$/,
+    qr/^fortimonitor(?:\.repo)?$/,
     qr/^wp-toolkit-(?:cpanel|thirdparties)$/,
   ),
   vetted_mysql_yum_repo_ids;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -289,6 +289,7 @@ use Elevate::Components::AutoSSL            ();
 use Elevate::Components::DatabaseUpgrade    ();
 use Elevate::Components::ELS                ();
 use Elevate::Components::R1Soft             ();
+use Elevate::Components::Panopta            ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -1331,6 +1332,7 @@ sub run_final_components_pre_leapp ($self) {
     $self->run_component_once( 'AbsoluteSymlinks' => 'pre_leapp' );
     $self->run_component_once( 'ELS'              => 'pre_leapp' );
     $self->run_component_once( 'R1Soft'           => 'pre_leapp' );
+    $self->run_component_once( 'Panopta'          => 'pre_leapp' );
     $self->run_component_once( 'RpmDB'            => 'pre_leapp' );    # remove the RPMs last
 
     return;


### PR DESCRIPTION
Case RE-43:

If they have the Panopta agent installed, simply remove it since it is deprecated and will be incompatible with Elevate. Do not block if the FortiMonitor repo is present.

Changelog: No longer block on Panopta or FortiMonitor

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

