### PR TITLE
Remove our handling of EPEL in favor of leapp's

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5203,7 +5203,6 @@ EOS
 
     sub pre_leapp ($self) {
 
-        $self->run_once("_disable_epel");
         $self->run_once("_disable_yum_plugin_fastestmirror");
         $self->run_once("_disable_known_yum_repositories");
 
@@ -5231,15 +5230,6 @@ EOS
 
     sub _disable_yum_plugin_fastestmirror ($self) {
         my $pkg = 'yum-plugin-fastestmirror';
-        $self->_erase_package($pkg);
-        return;
-    }
-
-    sub _disable_epel ($self) {
-
-        return if Elevate::OS::leapp_can_handle_epel();
-
-        my $pkg = 'epel-release';
         $self->_erase_package($pkg);
         return;
     }
@@ -5987,7 +5977,6 @@ EOS
             'leapp_repo_prod',                    # This is the repo name for the production repo.
             'leapp_repo_beta',                    # This is the repo name for the beta repo. The OS might not provide a beta repo in which case it'll be blank.
             'is_supported',                       # This is used to determine if the OS is supported or not
-            'leapp_can_handle_epel',              # This is used to determine if we can skip removing the EPEL repo pre_leapp or not
             'leapp_can_handle_imunify',           # This is used to determine if we can skip the Imunify component or not
             'leapp_can_handle_kernelcare',        # This is used to determine if we can skip the kernelcare component or not
             'leapp_data_pkg',                     # This is used to determine which leapp data package to install
@@ -6088,7 +6077,6 @@ EOS
     use constant elevate_rpm_url                 => 'https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.noarch.rpm';
     use constant leapp_repo_prod                 => 'elevate';
     use constant leapp_repo_beta                 => 'elevate-updates-testing';
-    use constant leapp_can_handle_epel           => 1;
     use constant leapp_can_handle_imunify        => 1;
     use constant leapp_can_handle_kernelcare     => 1;
     use constant leapp_data_pkg                  => 'leapp-data-cloudlinux';
@@ -6183,7 +6171,6 @@ EOS
     use constant ea_alias                        => undef;
     use constant elevate_rpm_url                 => undef;
     use constant is_supported                    => 1;
-    use constant leapp_can_handle_epel           => 0;
     use constant leapp_can_handle_imunify        => 0;
     use constant leapp_can_handle_kernelcare     => 0;
     use constant leapp_data_package              => undef;

--- a/lib/Elevate/Components/Repositories.pm
+++ b/lib/Elevate/Components/Repositories.pm
@@ -25,7 +25,6 @@ use parent qw{Elevate::Components::Base};
 
 sub pre_leapp ($self) {
 
-    $self->run_once("_disable_epel");
     $self->run_once("_disable_yum_plugin_fastestmirror");
     $self->run_once("_disable_known_yum_repositories");
 
@@ -54,15 +53,6 @@ sub _disable_known_yum_repositories {
 
 sub _disable_yum_plugin_fastestmirror ($self) {
     my $pkg = 'yum-plugin-fastestmirror';
-    $self->_erase_package($pkg);
-    return;
-}
-
-sub _disable_epel ($self) {
-
-    return if Elevate::OS::leapp_can_handle_epel();
-
-    my $pkg = 'epel-release';
     $self->_erase_package($pkg);
     return;
 }

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -85,7 +85,6 @@ BEGIN {
         'leapp_repo_prod',                    # This is the repo name for the production repo.
         'leapp_repo_beta',                    # This is the repo name for the beta repo. The OS might not provide a beta repo in which case it'll be blank.
         'is_supported',                       # This is used to determine if the OS is supported or not
-        'leapp_can_handle_epel',              # This is used to determine if we can skip removing the EPEL repo pre_leapp or not
         'leapp_can_handle_imunify',           # This is used to determine if we can skip the Imunify component or not
         'leapp_can_handle_kernelcare',        # This is used to determine if we can skip the kernelcare component or not
         'leapp_data_pkg',                     # This is used to determine which leapp data package to install

--- a/lib/Elevate/OS/CloudLinux7.pm
+++ b/lib/Elevate/OS/CloudLinux7.pm
@@ -19,7 +19,6 @@ use constant ea_alias                        => 'CloudLinux_8';
 use constant elevate_rpm_url                 => 'https://repo.cloudlinux.com/elevate/elevate-release-latest-el7.noarch.rpm';
 use constant leapp_repo_prod                 => 'elevate';
 use constant leapp_repo_beta                 => 'elevate-updates-testing';
-use constant leapp_can_handle_epel           => 1;
 use constant leapp_can_handle_imunify        => 1;
 use constant leapp_can_handle_kernelcare     => 1;
 use constant leapp_data_pkg                  => 'leapp-data-cloudlinux';

--- a/lib/Elevate/OS/RHEL.pm
+++ b/lib/Elevate/OS/RHEL.pm
@@ -70,7 +70,6 @@ use constant default_upgrade_to              => undef;
 use constant ea_alias                        => undef;
 use constant elevate_rpm_url                 => undef;
 use constant is_supported                    => 1;
-use constant leapp_can_handle_epel           => 0;
 use constant leapp_can_handle_imunify        => 0;
 use constant leapp_can_handle_kernelcare     => 0;
 use constant leapp_data_package              => undef;


### PR DESCRIPTION
Case RE-247: Leapp natively handles the update of the EPEL repository, so our handling of EPEL is superfluous. Remove it.

Changelog: Permit leapp to handle updates to the EPEL repository.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

