### PR TITLE
Restore net-snmp if it had been installed prior to elevate

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -65,6 +65,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Components/ELS.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/R1Soft.pm'}             = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/Panopta.pm'}            = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Components/PackageRestore.pm'}     = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS.pm'}                            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CentOS7.pm'}                    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CloudLinux7.pm'}                = 'script/elevate-cpanel.PL.static';
@@ -6169,6 +6170,67 @@ EOS
 
 }    # --- END lib/Elevate/Components/Panopta.pm
 
+{    # --- BEGIN lib/Elevate/Components/PackageRestore.pm
+
+    package Elevate::Components::PackageRestore;
+
+    use cPstrict;
+
+    use Elevate::StageFile ();
+
+    use Cpanel::Pkgr ();
+
+    # use Elevate::Components::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Components::Base); }
+
+    sub _get_packages_to_check () {
+        return qw{
+          net-snmp
+        };
+    }
+
+    sub pre_leapp ($self) {
+
+        my @package_list = _get_packages_to_check();
+        my @installed_packages;
+
+        foreach my $package (@package_list) {
+            if ( Cpanel::Pkgr::is_installed($package) ) {
+                push @installed_packages, $package;
+            }
+        }
+
+        my $config_files = $self->rpm->get_config_files( \@installed_packages );
+
+        Elevate::StageFile::update_stage_file(
+            {
+                'packages_to_restore' => $config_files,
+            }
+        );
+
+        return;
+    }
+
+    sub post_leapp ($self) {
+
+        my $package_info = Elevate::StageFile::read_stage_file('packages_to_restore');
+        return unless defined $package_info and ref $package_info eq 'HASH';
+
+        foreach my $package ( keys %$package_info ) {
+
+            $self->dnf->install($package);
+
+            $self->rpm->restore_config_files( @{ $package_info->{$package} } );
+        }
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Components/PackageRestore.pm
+
 {    # --- BEGIN lib/Elevate/OS.pm
 
     package Elevate::OS;
@@ -7651,12 +7713,12 @@ EOS
 
         my @installed_rpms = $self->get_installed_rpms(q[%{NAME}\n]);
         my @ea_rpms        = grep { $_ =~ qr/^\Q$prefix\E/ } @installed_rpms;
-        my $config_files   = $self->_get_config_files( \@ea_rpms );
+        my $config_files   = $self->get_config_files( \@ea_rpms );
 
         return $config_files;
     }
 
-    sub _get_config_files ( $self, $pkgs ) {
+    sub get_config_files ( $self, $pkgs ) {
 
         my %config_files;
         foreach my $pkg (@$pkgs) {
@@ -7671,6 +7733,7 @@ EOS
             into place.
             EOS
 
+                $config_files{$pkg} = [];
             }
             else {
 
@@ -8758,6 +8821,7 @@ use Elevate::Components::DatabaseUpgrade    ();
 use Elevate::Components::ELS                ();
 use Elevate::Components::R1Soft             ();
 use Elevate::Components::Panopta            ();
+use Elevate::Components::PackageRestore     ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -9428,6 +9492,10 @@ sub run_stage_2 ($self) {
     $self->ssystem_and_die(qw{/scripts/update-packages});
     $self->ssystem_and_die(qw{/usr/bin/yum -y update});
 
+    # This needs to happen before the database upgrade because
+    # it will remove the packages we want to detect
+    $self->run_component_once( 'PackageRestore' => 'pre_leapp' );
+
     # This needs to execute before we disable cPanel services
     # or exporting the CCS data will fail
     $self->run_component_once( 'CCS'             => 'pre_leapp' );
@@ -9831,6 +9899,7 @@ sub post_leapp_update_restore ($self) {
     $self->run_component_once( 'NixStats'        => 'post_leapp' );
     $self->run_component_once( 'LiteSpeed'       => 'post_leapp' );
     $self->run_component_once( 'R1Soft'          => 'post_leapp' );
+    $self->run_component_once( 'PackageRestore'  => 'post_leapp' );
 
     return;
 }

--- a/lib/Elevate/Components/PackageRestore.pm
+++ b/lib/Elevate/Components/PackageRestore.pm
@@ -1,0 +1,74 @@
+package Elevate::Components::PackageRestore;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Components::PackageRestore
+
+Handle restoring packages that get removed during elevate
+
+Before leapp:
+    Detect which packages in our list are installed and
+    store our findings.
+
+After leapp:
+    Reinstall any packages detected pre-leapp
+
+=cut
+
+use cPstrict;
+
+use Elevate::StageFile ();
+
+use Cpanel::Pkgr ();
+
+use parent qw{Elevate::Components::Base};
+
+#
+# Set as a function for unit testing
+#
+sub _get_packages_to_check () {
+    return qw{
+      net-snmp
+    };
+}
+
+sub pre_leapp ($self) {
+
+    my @package_list = _get_packages_to_check();
+    my @installed_packages;
+
+    foreach my $package (@package_list) {
+        if ( Cpanel::Pkgr::is_installed($package) ) {
+            push @installed_packages, $package;
+        }
+    }
+
+    my $config_files = $self->rpm->get_config_files( \@installed_packages );
+
+    Elevate::StageFile::update_stage_file(
+        {
+            'packages_to_restore' => $config_files,
+        }
+    );
+
+    return;
+}
+
+sub post_leapp ($self) {
+
+    my $package_info = Elevate::StageFile::read_stage_file('packages_to_restore');
+    return unless defined $package_info and ref $package_info eq 'HASH';
+
+    foreach my $package ( keys %$package_info ) {
+
+        $self->dnf->install($package);
+
+        $self->rpm->restore_config_files( @{ $package_info->{$package} } );
+    }
+
+    return;
+}
+
+1;

--- a/lib/Elevate/RPM.pm
+++ b/lib/Elevate/RPM.pm
@@ -28,12 +28,12 @@ sub get_config_files_for_pkg_prefix ( $self, $prefix ) {
 
     my @installed_rpms = $self->get_installed_rpms(q[%{NAME}\n]);
     my @ea_rpms        = grep { $_ =~ qr/^\Q$prefix\E/ } @installed_rpms;
-    my $config_files   = $self->_get_config_files( \@ea_rpms );
+    my $config_files   = $self->get_config_files( \@ea_rpms );
 
     return $config_files;
 }
 
-sub _get_config_files ( $self, $pkgs ) {
+sub get_config_files ( $self, $pkgs ) {
 
     my %config_files;
     foreach my $pkg (@$pkgs) {
@@ -49,6 +49,7 @@ sub _get_config_files ( $self, $pkgs ) {
             into place.
             EOS
 
+            $config_files{$pkg} = [];
         }
         else {
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -291,6 +291,7 @@ use Elevate::Components::DatabaseUpgrade    ();
 use Elevate::Components::ELS                ();
 use Elevate::Components::R1Soft             ();
 use Elevate::Components::Panopta            ();
+use Elevate::Components::PackageRestore     ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -961,6 +962,10 @@ sub run_stage_2 ($self) {
     $self->ssystem_and_die(qw{/scripts/update-packages});
     $self->ssystem_and_die(qw{/usr/bin/yum -y update});
 
+    # This needs to happen before the database upgrade because
+    # it will remove the packages we want to detect
+    $self->run_component_once( 'PackageRestore' => 'pre_leapp' );
+
     # This needs to execute before we disable cPanel services
     # or exporting the CCS data will fail
     $self->run_component_once( 'CCS'             => 'pre_leapp' );
@@ -1364,6 +1369,7 @@ sub post_leapp_update_restore ($self) {
     $self->run_component_once( 'NixStats'        => 'post_leapp' );
     $self->run_component_once( 'LiteSpeed'       => 'post_leapp' );
     $self->run_component_once( 'R1Soft'          => 'post_leapp' );
+    $self->run_component_once( 'PackageRestore'  => 'post_leapp' );
 
     return;
 }

--- a/t/components-PackageRestore.t
+++ b/t/components-PackageRestore.t
@@ -1,0 +1,125 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::components;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $pkg_restore = cpev->new->component('PackageRestore');
+
+{
+    note "Checking pre_leapp";
+
+    my $stage_file_data;
+    my @pkgs_to_check  = qw{ foo bar baz };
+    my %installed_pkgs = (
+        foo => 1,
+        bar => 0,
+        baz => 1,
+    );
+    my $pkgs_checked_for_config_files;
+    my %config_files = (
+        foo => [qw{ myfile1 myfile2 }],
+        baz => [qw{ thisfile thatfile }],
+    );
+
+    my $mock_comp = Test::MockModule->new('Elevate::Components::PackageRestore');
+    $mock_comp->redefine(
+        _get_packages_to_check => sub { return @pkgs_to_check; },
+    );
+
+    my $mock_pkgr = Test::MockModule->new('Cpanel::Pkgr');
+    $mock_pkgr->redefine(
+        is_installed => sub { return $installed_pkgs{ $_[0] }; },
+    );
+
+    my $mock_rpm = Test::MockModule->new('Elevate::RPM');
+    $mock_rpm->redefine(
+        get_config_files => sub {
+            $pkgs_checked_for_config_files = $_[1];
+            return \%config_files;
+        },
+    );
+
+    my $mock_upsf = Test::MockModule->new('Elevate::StageFile');
+    $mock_upsf->redefine(
+        update_stage_file => sub { $stage_file_data = shift; },
+    );
+
+    $pkg_restore->pre_leapp();
+
+    is(
+        [ sort @$pkgs_checked_for_config_files ],
+        [ sort keys %config_files ],
+        'Correctly detects the installed packages'
+    );
+
+    is(
+        $stage_file_data,
+        { 'packages_to_restore' => \%config_files },
+        'Correctly detects the config files and updates the stage file'
+    );
+}
+
+{
+    note "Checking post_leapp";
+
+    my $stage_file_data = {
+        foo => [qw{ myfile1 myfile2 }],
+        bar => [qw{ thisfile thatfile }],
+        baz => [],
+    };
+    my @dnf_installed;
+    my @config_files_restored;
+
+    my $mock_upsf = Test::MockModule->new('Elevate::StageFile');
+    $mock_upsf->redefine(
+        read_stage_file => sub { return $stage_file_data; },
+    );
+
+    my $mock_dnf = Test::MockModule->new('Elevate::DNF');
+    $mock_dnf->redefine(
+        install => sub { push @dnf_installed, $_[1]; },
+    );
+
+    my $mock_rpm = Test::MockModule->new('Elevate::RPM');
+    $mock_rpm->redefine(
+        restore_config_files => sub {
+            my ( $self, @files ) = @_;
+            push @config_files_restored, @files;
+        },
+    );
+
+    $pkg_restore->post_leapp();
+
+    is(
+        [ sort @dnf_installed ],
+        [ sort qw{ foo bar baz } ],
+        'Attempted to install modules listed in the stage file'
+    );
+
+    is(
+        [ sort @config_files_restored ],
+        [ sort qw{ myfile1 myfile2 thisfile thatfile } ],
+        'Attempted to restore all the appropriate config files'
+    )
+
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-574:

During elevate net-snmp will get uninstalled when mysql-libs gets uninstalled. On AlmaLinux 8, net-snmp does not depend on mysql-libs so we can reinstall it after the upgrade.

Changelog: Ensure that system with net-snmp installed will have it
  installed post-elevate.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

