### PR TITLE
Genericize `--no-leapp`, et al.

### DIFF
--- a/docs-website-src/content/_index.md
+++ b/docs-website-src/content/_index.md
@@ -217,17 +217,17 @@ A final reboot is performed at the end of this stage.
 By default, the elevate script runs the [leapp process](https://almalinux.org/elevate/)
 to upgrade you from 7 to 8. `Leapp` may not be compatible with your system.
 
-Using the `--no-leapp` option gives you a way to do the actual distro upgrade in your own way.
+Using the `--upgrade-distro-manually` option gives you a way to do the actual distro upgrade in your own way.
 This, for instance, can be used to allow `Virtuozzo` systems to upgrade cPanel systems, which are not supported by `Leapp`.
 
-A `--no-leapp` upgrade would look like:
+A `--upgrade-distro-manually` upgrade would look like:
 
-1. User runs `/scripts/elevate-cpanel --start --no-leapp` which starts the upgrade process.
+1. User runs `/scripts/elevate-cpanel --start --upgrade-distro-manually` which starts the upgrade process.
 2. `elevate-cpanel` does all preparatory steps to upgrade the system prior to the distro upgrade.
 3. Elevate will then create the file `/waiting_for_distro_upgrade` to indicate that the operating system is ready for an upgrade.
     * This is when you would use your distro upgrade tool.
     * When you have completed upgrading your system to 8, simply remove `/waiting_for_distro_upgrade` and reboot the system into normal multi-user mode.
-5. Elevate will resume upon reboot and complete the upgrade just like it would have without `--no-leapp`
+5. Elevate will resume upon reboot and complete the upgrade just like it would have without `--upgrade-distro-manually`
 
 ### Using the LEAPP_OVL_SIZE environment variable
 

--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -177,7 +177,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
         my @_DELEGATE_TO_CPEV = qw{
           getopt
           upgrade_to_pretty_name
-          should_run_leapp
+          should_run_distro_upgrade
           ssystem
           ssystem_capture_output
           ssystem_hide_and_capture_output
@@ -491,7 +491,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     sub check ($self) {
 
-        return 1 unless $self->should_run_leapp;    # skip when --no-leapp is provided
+        return 1 unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
 
         my $ok = 0;
         try {
@@ -1158,7 +1158,7 @@ EOS
 
     sub check ($self) {
 
-        return 1 unless $self->should_run_leapp;    # skip when --no-leapp is provided
+        return 1 unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
 
         my $ok = 1;
         $ok = 0 unless $self->_blocker_grub2_workaround;
@@ -1393,7 +1393,7 @@ EOS
 
     sub check ($self) {    # $self is a cpev object here
 
-        return 0 unless $self->should_run_leapp;
+        return 0 unless $self->should_run_distro_upgrade;
 
         if ( _is_container_envtype() ) {
             return $self->has_blocker( <<~'EOS');
@@ -1554,7 +1554,7 @@ EOS
     use constant SBIN_IP         => Elevate::Constants::SBIN_IP;
 
     sub check ($self) {
-        return 1 unless $self->should_run_leapp;    # skip when --no-leapp is provided
+        return 1 unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
         return $self->_blocker_bad_nics_naming;
     }
 
@@ -2452,7 +2452,7 @@ EOS
 
         return if $self->is_check_mode();    # skip for --check
 
-        return unless $self->should_run_leapp;    # skip when --no-leapp is provided
+        return unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
 
         return if ( $self->blockers->num_blockers_found() > 0 );    # skip if any blockers have already been found
 
@@ -2577,7 +2577,7 @@ EOS
         my @_DELEGATE_TO_CPEV = qw{
           getopt
           upgrade_to_pretty_name
-          should_run_leapp
+          should_run_distro_upgrade
           ssystem
           ssystem_and_die
           ssystem_capture_output
@@ -3536,7 +3536,7 @@ EOS
     }
 
     sub verify_cmdline ($self) {
-        if ( $self->cpev->should_run_leapp() ) {
+        if ( $self->cpev->should_run_distro_upgrade() ) {
             my $arg = "elevate-" . _persistent_id;
             INFO("Checking for \"$arg\" in booted kernel's command line...");
 
@@ -6969,7 +6969,7 @@ EOS
 
     sub upgrade ($self) {
 
-        return unless $self->cpev->should_run_leapp();
+        return unless $self->cpev->should_run_distro_upgrade();
 
         $self->cpev->run_once(
             setup_answer_file => sub {
@@ -7097,7 +7097,7 @@ EOS
 
     sub wait_for_leapp_completion ($self) {
 
-        return 1 unless $self->cpev->should_run_leapp();
+        return 1 unless $self->cpev->should_run_distro_upgrade();
 
         my $upgrade_log = LEAPP_UPGRADE_LOG;
 
@@ -8220,7 +8220,7 @@ EOS
           service start clean continue manual-reboots status log check:s
           skip-cpanel-version-check skip-elevate-version-check
           update version
-          no-leapp
+          upgrade-distro-manually no-leapp
           non-interactive
           leappbeta
         );
@@ -8577,8 +8577,9 @@ CloudLinux 7 => CloudLinux 8
        --skip-cpanel-version-check               Skip the check for whether cPanel is up to date.
                                                  This option is intended only for testing!
 
-       --no-leapp                                Do not try to run leapp, and pause instead.
-                                                 Once leapp has been run you should remove the file
+       --upgrade-distro-manually
+       --no-leapp                                Do not try to run the distro upgrade process, and pause instead.
+                                                 Once the upgrade has been run you should remove the file
                                                  /waiting_for_distro_upgrade
 
        --help                                    Display this documentation.
@@ -8650,14 +8651,14 @@ the update process by running:
 By default, the elevate script runs the L<leapp process|https://almalinux.org/elevate/>
 to upgrade you from 7 to 8. `Leapp` may not be compatible with your system.
 
-Using the `--no-leapp` option gives you a way to do the actual distro upgrade in your own way.
+Using the `--upgrade-distro-manually` option gives you a way to do the actual distro upgrade in your own way.
 This, for instance, can be used to allow `Virtuozzo` systems to upgrade cPanel systems, which are not supported by `Leapp`.
 
-A `--no-leapp` upgrade would look like:
+A `--upgrade-distro-manually` upgrade would look like:
 
 =over
 
-=item 1. User runs `/scripts/elevate-cpanel --start --no-leapp` which starts the upgrade process.
+=item 1. User runs `/scripts/elevate-cpanel --start --upgrade-distro-manually` which starts the upgrade process.
 
 =item 2. `elevate-cpanel` does all preparatory steps to upgrade the system prior to the distro upgrade.
 
@@ -8671,11 +8672,11 @@ A `--no-leapp` upgrade would look like:
 
 =back
 
-=item 4. Elevate will resume upon reboot and complete the upgrade just like it would have without `--no-leapp`
+=item 4. Elevate will resume upon reboot and complete the upgrade just like it would have without `--upgrade-distro-manually`
 
 =back
 
-NOTE: `--no-leapp` is not required for helper commands like `--continue` or `--status`
+NOTE: `--upgrade-distro-manually` is not required for helper commands like `--continue` or `--status`
 
 =head1 WARNINGS
 
@@ -9067,17 +9068,17 @@ sub start ($self) {
 
     $self->_capture_env_variables();    # capture at startup
 
-    if ( $self->getopt('no-leapp') ) {
+    if ( $self->getopt('upgrade-distro-manually') || $self->getopt('no-leapp') ) {
         my $touchfile = PAUSE_ELEVATE_TOUCHFILE;
         WARN( <<~"EOS");
-        'leapp' checks and run are disabled.
+        Automated upgrade of the distro has been disabled.
         Please wait for the file '$touchfile' to be created.
-        At that stage the elevation process is paused then you can upgrade from 7 to 8 on your own.
+        At that stage, the ELevate process is paused, and you can upgrade from 7 to 8 on your own.
 
-        Once the system has been successfully upgraded from 7 to 8 you can then remove that file
-        to let the elevation process continue and update cPanel for the updated distribution.
+        Once the system has been successfully upgraded from 7 to 8, you can then remove that file
+        to let the ELevate process continue and update cPanel for the new distribution.
         EOS
-        Elevate::StageFile::update_stage_file( { no_leapp => 1 } );
+        Elevate::StageFile::update_stage_file( { upgrade_distro_manually => 1 } );
     }
 
     # This starts the service for us:
@@ -9451,7 +9452,7 @@ sub run_stage_1 ($self) {
 
     Elevate::Motd->setup();
 
-    if ( !$self->should_run_leapp() ) {
+    if ( !$self->should_run_distro_upgrade() ) {
         Elevate::Stages::bump_stage();
         return ACTION_CONTINUE;
     }
@@ -9529,7 +9530,7 @@ sub run_stage_3 ($self) {
 
     $self->run_once('run_final_components_pre_leapp');
 
-    if ( !$self->should_run_leapp() ) {
+    if ( !$self->should_run_distro_upgrade() ) {
         return $self->_request_to_upgrade_distro_manually();
     }
 
@@ -10004,13 +10005,13 @@ sub post_upgrade_check ($self) {
 
 # TODO: We're going to need to store reboot time so we know if the last reboot has happened when we re-run the script.
 
-sub should_run_leapp ($self) {
+sub should_run_distro_upgrade ($self) {
 
-    # we store the no_leapp option, but prefer using a positive check instead
-    # we need to check to see if the no-leapp option is passed via CLI here too in order
-    # to allow users to run this script with the '--check --no-leapp' options
-    my $no_leapp = Elevate::StageFile::read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
-    return !$no_leapp;
+    # we store the upgrade_distro_manually option, but prefer using a positive check instead
+    # we need to check to see if the CLI option is passed here too in order
+    # to allow users to run this script with the '--check --upgrade-distro-manually', etc. options
+    my $manual_distro_upgrade = scalar grep { $self->getopt($_) || Elevate::StageFile::read_stage_file( tr/-/_/r, 0 ) } qw/upgrade-distro-manually no-leapp/;
+    return !$manual_distro_upgrade;
 }
 
 sub get_current_status ($self) {

--- a/lib/Elevate/Blockers/Base.pm
+++ b/lib/Elevate/Blockers/Base.pm
@@ -46,7 +46,7 @@ BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
       upgrade_to_pretty_name
-      should_run_leapp
+      should_run_distro_upgrade
       ssystem
       ssystem_capture_output
       ssystem_hide_and_capture_output

--- a/lib/Elevate/Blockers/BootKernel.pm
+++ b/lib/Elevate/Blockers/BootKernel.pm
@@ -28,7 +28,7 @@ use Try::Tiny;
 
 sub check ($self) {
 
-    return 1 unless $self->should_run_leapp;    # skip when --no-leapp is provided
+    return 1 unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
 
     my $ok = 0;
     try {

--- a/lib/Elevate/Blockers/Grub2.pm
+++ b/lib/Elevate/Blockers/Grub2.pm
@@ -33,7 +33,7 @@ sub GRUB2_PREFIX_RHEL   { return '/boot/grub2' }
 
 sub check ($self) {
 
-    return 1 unless $self->should_run_leapp;    # skip when --no-leapp is provided
+    return 1 unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
 
     my $ok = 1;
     $ok = 0 unless $self->_blocker_grub2_workaround;

--- a/lib/Elevate/Blockers/IsContainer.pm
+++ b/lib/Elevate/Blockers/IsContainer.pm
@@ -17,7 +17,7 @@ use Log::Log4perl qw(:easy);
 
 sub check ($self) {    # $self is a cpev object here
 
-    return 0 unless $self->should_run_leapp;
+    return 0 unless $self->should_run_distro_upgrade;
 
     if ( _is_container_envtype() ) {
         return $self->has_blocker( <<~'EOS');

--- a/lib/Elevate/Blockers/Leapp.pm
+++ b/lib/Elevate/Blockers/Leapp.pm
@@ -23,7 +23,7 @@ sub check ($self) {
 
     return if $self->is_check_mode();    # skip for --check
 
-    return unless $self->should_run_leapp;    # skip when --no-leapp is provided
+    return unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
 
     return if ( $self->blockers->num_blockers_found() > 0 );    # skip if any blockers have already been found
 

--- a/lib/Elevate/Blockers/NICs.pm
+++ b/lib/Elevate/Blockers/NICs.pm
@@ -23,7 +23,7 @@ use constant ETH_FILE_PREFIX => Elevate::Constants::ETH_FILE_PREFIX;
 use constant SBIN_IP         => Elevate::Constants::SBIN_IP;
 
 sub check ($self) {
-    return 1 unless $self->should_run_leapp;    # skip when --no-leapp is provided
+    return 1 unless $self->should_run_distro_upgrade;    # skip when --upgrade-distro-manually is provided
     return $self->_blocker_bad_nics_naming;
 }
 

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -30,7 +30,7 @@ BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
       upgrade_to_pretty_name
-      should_run_leapp
+      should_run_distro_upgrade
       ssystem
       ssystem_and_die
       ssystem_capture_output

--- a/lib/Elevate/Components/Grub2.pm
+++ b/lib/Elevate/Components/Grub2.pm
@@ -88,7 +88,7 @@ sub _remove_but_dont_stop_service ($self) {
 }
 
 sub verify_cmdline ($self) {
-    if ( $self->cpev->should_run_leapp() ) {
+    if ( $self->cpev->should_run_distro_upgrade() ) {
         my $arg = "elevate-" . _persistent_id;
         INFO("Checking for \"$arg\" in booted kernel's command line...");
 

--- a/lib/Elevate/Leapp.pm
+++ b/lib/Elevate/Leapp.pm
@@ -94,7 +94,7 @@ sub preupgrade ($self) {
 
 sub upgrade ($self) {
 
-    return unless $self->cpev->should_run_leapp();
+    return unless $self->cpev->should_run_distro_upgrade();
 
     $self->cpev->run_once(
         setup_answer_file => sub {
@@ -244,7 +244,7 @@ sub extract_error_block_from_output ( $self, $text_ar ) {
 sub wait_for_leapp_completion ($self) {
 
     # No use waiting for leapp to complete if we did not run leapp
-    return 1 unless $self->cpev->should_run_leapp();
+    return 1 unless $self->cpev->should_run_distro_upgrade();
 
     my $upgrade_log = LEAPP_UPGRADE_LOG;
 

--- a/lib/Elevate/Usage.pm
+++ b/lib/Elevate/Usage.pm
@@ -20,7 +20,7 @@ sub _OPTIONS {
       service start clean continue manual-reboots status log check:s
       skip-cpanel-version-check skip-elevate-version-check
       update version
-      no-leapp
+      upgrade-distro-manually no-leapp
       non-interactive
       leappbeta
     );

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -64,8 +64,9 @@ CloudLinux 7 => CloudLinux 8
        --skip-cpanel-version-check               Skip the check for whether cPanel is up to date.
                                                  This option is intended only for testing!
 
-       --no-leapp                                Do not try to run leapp, and pause instead.
-                                                 Once leapp has been run you should remove the file
+       --upgrade-distro-manually
+       --no-leapp                                Do not try to run the distro upgrade process, and pause instead.
+                                                 Once the upgrade has been run you should remove the file
                                                  /waiting_for_distro_upgrade
 
        --help                                    Display this documentation.
@@ -137,14 +138,14 @@ the update process by running:
 By default, the elevate script runs the L<leapp process|https://almalinux.org/elevate/>
 to upgrade you from 7 to 8. `Leapp` may not be compatible with your system.
 
-Using the `--no-leapp` option gives you a way to do the actual distro upgrade in your own way.
+Using the `--upgrade-distro-manually` option gives you a way to do the actual distro upgrade in your own way.
 This, for instance, can be used to allow `Virtuozzo` systems to upgrade cPanel systems, which are not supported by `Leapp`.
 
-A `--no-leapp` upgrade would look like:
+A `--upgrade-distro-manually` upgrade would look like:
 
 =over
 
-=item 1. User runs `/scripts/elevate-cpanel --start --no-leapp` which starts the upgrade process.
+=item 1. User runs `/scripts/elevate-cpanel --start --upgrade-distro-manually` which starts the upgrade process.
 
 =item 2. `elevate-cpanel` does all preparatory steps to upgrade the system prior to the distro upgrade.
 
@@ -158,11 +159,11 @@ A `--no-leapp` upgrade would look like:
 
 =back
 
-=item 4. Elevate will resume upon reboot and complete the upgrade just like it would have without `--no-leapp`
+=item 4. Elevate will resume upon reboot and complete the upgrade just like it would have without `--upgrade-distro-manually`
 
 =back
 
-NOTE: `--no-leapp` is not required for helper commands like `--continue` or `--status`
+NOTE: `--upgrade-distro-manually` is not required for helper commands like `--continue` or `--status`
 
 =head1 WARNINGS
 
@@ -554,17 +555,17 @@ sub start ($self) {
 
     $self->_capture_env_variables();    # capture at startup
 
-    if ( $self->getopt('no-leapp') ) {
+    if ( $self->getopt('upgrade-distro-manually') || $self->getopt('no-leapp') ) {
         my $touchfile = PAUSE_ELEVATE_TOUCHFILE;
         WARN( <<~"EOS");
-        'leapp' checks and run are disabled.
+        Automated upgrade of the distro has been disabled.
         Please wait for the file '$touchfile' to be created.
-        At that stage the elevation process is paused then you can upgrade from 7 to 8 on your own.
+        At that stage, the ELevate process is paused, and you can upgrade from 7 to 8 on your own.
 
-        Once the system has been successfully upgraded from 7 to 8 you can then remove that file
-        to let the elevation process continue and update cPanel for the updated distribution.
+        Once the system has been successfully upgraded from 7 to 8, you can then remove that file
+        to let the ELevate process continue and update cPanel for the new distribution.
         EOS
-        Elevate::StageFile::update_stage_file( { no_leapp => 1 } );
+        Elevate::StageFile::update_stage_file( { upgrade_distro_manually => 1 } );
     }
 
     # This starts the service for us:
@@ -938,7 +939,7 @@ sub run_stage_1 ($self) {
 
     Elevate::Motd->setup();
 
-    if ( !$self->should_run_leapp() ) {
+    if ( !$self->should_run_distro_upgrade() ) {
         Elevate::Stages::bump_stage();
         return ACTION_CONTINUE;
     }
@@ -1016,7 +1017,7 @@ sub run_stage_3 ($self) {
 
     $self->run_once('run_final_components_pre_leapp');
 
-    if ( !$self->should_run_leapp() ) {
+    if ( !$self->should_run_distro_upgrade() ) {
         return $self->_request_to_upgrade_distro_manually();
     }
 
@@ -1491,13 +1492,13 @@ sub post_upgrade_check ($self) {
 
 # TODO: We're going to need to store reboot time so we know if the last reboot has happened when we re-run the script.
 
-sub should_run_leapp ($self) {
+sub should_run_distro_upgrade ($self) {
 
-    # we store the no_leapp option, but prefer using a positive check instead
-    # we need to check to see if the no-leapp option is passed via CLI here too in order
-    # to allow users to run this script with the '--check --no-leapp' options
-    my $no_leapp = Elevate::StageFile::read_stage_file( 'no_leapp', 0 ) || $self->getopt('no-leapp');
-    return !$no_leapp;
+    # we store the upgrade_distro_manually option, but prefer using a positive check instead
+    # we need to check to see if the CLI option is passed here too in order
+    # to allow users to run this script with the '--check --upgrade-distro-manually', etc. options
+    my $manual_distro_upgrade = scalar grep { $self->getopt($_) || Elevate::StageFile::read_stage_file( tr/-/_/r, 0 ) } qw/upgrade-distro-manually no-leapp/;
+    return !$manual_distro_upgrade;
 }
 
 sub get_current_status ($self) {

--- a/t/components-Grub2.t
+++ b/t/components-Grub2.t
@@ -55,8 +55,8 @@ $mock_stage_file->redefine( _save_stage_file => sub { $stage_data = $_[0]; retur
     my $cmdline;
     $mock_slurp->redefine( read_binary => sub { return $cmdline } );
 
-    $mock_cpev->redefine( should_run_leapp => 1 );
-    $mock_cpev->redefine( do_cleanup       => sub { $stage_data = undef; return; } );
+    $mock_cpev->redefine( should_run_distro_upgrade => 1 );
+    $mock_cpev->redefine( do_cleanup                => sub { $stage_data = undef; return; } );
 
     my $mock_comp = Test::MockModule->new('Elevate::Components::Grub2');
     $mock_comp->redefine( _default_kernel               => "kernel-image" );

--- a/t/leapp_upgrade.t
+++ b/t/leapp_upgrade.t
@@ -314,13 +314,13 @@ note 'LEAPP upgrade log failure checks';
     $mock_leapp_upgrade_log->unlink;
 
     $mock_elevate->redefine(
-        should_run_leapp => 0,
+        should_run_distro_upgrade => 0,
     );
 
     is( cpev->leapp->wait_for_leapp_completion, 1, 'wait_for_leapp_completion returns early when it should NOT run leapp' );
 
     $mock_elevate->redefine(
-        should_run_leapp => 1,
+        should_run_distro_upgrade => 1,
     );
 
     is( cpev->leapp->wait_for_leapp_completion, 0, "wait_for_leapp_completion fails when the upgrade log is missing." );

--- a/t/usage.t
+++ b/t/usage.t
@@ -154,6 +154,11 @@ my @TEST_DATA = (
         fail_msg => q/Option "continue" is not compatible with any other option/,
     },
     {
+        options  => [qw/--continue --upgrade-distro-manually/],
+        passed   => 0,
+        fail_msg => q/Option "continue" is not compatible with any other option/,
+    },
+    {
         options  => [qw/--log --status/],
         passed   => 0,
         fail_msg => q/Option "log" is not compatible with any other option/,
@@ -165,6 +170,11 @@ my @TEST_DATA = (
     },
     {
         options  => [qw/--status --no-leapp/],
+        passed   => 0,
+        fail_msg => q/Option "status" is not compatible with any other option/,
+    },
+    {
+        options  => [qw/--status --upgrade-distro-manually/],
         passed   => 0,
         fail_msg => q/Option "status" is not compatible with any other option/,
     },
@@ -197,6 +207,12 @@ my @TEST_DATA = (
         warning_regex => qr/Unknown option/,
     },
     {
+        options       => [qw/--check --upgrade-to almalinux --skip-cpanel-version-check --skip-elevate-version-check --upgrade-distro-manually/],
+        passed        => 0,
+        fail_msg      => 'Invalid Option',
+        warning_regex => qr/Unknown option/,
+    },
+    {
         options  => [qw/--check --non-interactive/],
         passed   => 0,
         fail_msg => q/Option "non-interactive" is only compatible with "start"/,
@@ -224,6 +240,12 @@ my @TEST_DATA = (
     },
     {
         options       => [qw/--start --upgrade-to rocky  --skip-cpanel-version-check --skip-elevate-version-check --no-leapp --manual-reboots --non-interactive/],
+        passed        => 0,
+        fail_msg      => 'Invalid Option',
+        warning_regex => qr/Unknown option/,
+    },
+    {
+        options       => [qw/--start --upgrade-to rocky  --skip-cpanel-version-check --skip-elevate-version-check --upgrade-distro-manually --manual-reboots --non-interactive/],
         passed        => 0,
         fail_msg      => 'Invalid Option',
         warning_regex => qr/Unknown option/,


### PR DESCRIPTION
Case RE-695: Don't assume that leapp will be the only distro upgrade process we will be wrapping.

Changelog: Turn `--no-leapp` into a more generic
 `--upgrade-distro-manually` option, but continue to recognize
 `--no-leapp` as an alias for it.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

