### PR TITLE
Add a whitelist for some legacy packages without a repo

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1855,6 +1855,24 @@ EOS
     use constant YUM_COMPLETE_TRANSACTION_BIN => '/usr/sbin/yum-complete-transaction';
     use constant FIX_RPM_SCRIPT               => '/usr/local/cpanel/scripts/find_and_fix_rpm_issues';
 
+    use constant EXPECTED_EXTRA_PACKAGES => (
+        qr/^cpanel-/,
+        qr/^easy-/,
+        qr/^kernel/,
+        qr/^mysql/i,
+        qr/^plesk-/,
+        'awscli',
+        'basesystem',
+        'filesystem',
+        'grub',
+        'grubby',
+        'python35',
+        'python38-opt',
+        'virt-what',
+        'vzdummy-systemd-el7',
+      ),
+      Elevate::Constants::R1SOFT_AGENT_PACKAGES;
+
     sub check ($self) {
         my $ok = 1;
         $ok = 0 if $self->_blocker_packages_installed_without_associated_repo;
@@ -1865,11 +1883,17 @@ EOS
     }
 
     sub _blocker_packages_installed_without_associated_repo ($self) {
-        my @extra_packages = $self->yum->get_extra_packages();
-        return unless scalar @extra_packages;
+        my @extra_packages = map { $_->{package} } $self->yum->get_extra_packages();
 
-        my @packages   = map { $_->{package} } @extra_packages;
-        my $pkg_string = join "\n", @packages;
+        my @unexpected_extra_packages;
+        foreach my $pkg (@extra_packages) {
+            next if grep { $pkg =~ m/$_/ } EXPECTED_EXTRA_PACKAGES();
+            push @unexpected_extra_packages, $pkg;
+        }
+
+        return unless scalar @unexpected_extra_packages;
+
+        my $pkg_string = join "\n", @unexpected_extra_packages;
         return $self->has_blocker( <<~EOS );
     There are packages installed that do not have associated repositories:
 
@@ -8493,13 +8517,6 @@ EOS
 
             $package =~ s/\.(noarch|x86_64)$//;
             my $arch = $1 // '?';
-
-            next if $package =~ m/^cpanel-/;
-            next if $package =~ m/^kernel/;
-            next if $package eq 'filesystem';
-            next if $package eq 'basesystem';
-            next if $package eq 'virt-what';
-            next if ( scalar grep { $_ eq $package } Elevate::Constants::R1SOFT_AGENT_PACKAGES );
 
             push @extra_packages, { package => $package, version => $version, arch => $arch };
         }

--- a/lib/Elevate/YUM.pm
+++ b/lib/Elevate/YUM.pm
@@ -131,13 +131,6 @@ sub get_extra_packages ($self) {
         $package =~ s/\.(noarch|x86_64)$//;
         my $arch = $1 // '?';
 
-        next if $package =~ m/^cpanel-/;
-        next if $package =~ m/^kernel/;
-        next if $package eq 'filesystem';
-        next if $package eq 'basesystem';
-        next if $package eq 'virt-what';
-        next if ( scalar grep { $_ eq $package } Elevate::Constants::R1SOFT_AGENT_PACKAGES );
-
         push @extra_packages, { package => $package, version => $version, arch => $arch };
     }
 


### PR DESCRIPTION
Case RE-603: In RE-420, we started blocking on packages that do not have an associated repo.  This led to a significant spike in the number of servers that were eligible to be elevated out of the box.  Upon looking at the data returned from the blocker added via RE-420, we found that there were several packages that we could whitelist for this blocker which would reduce the number of servers that were blocked out of the box.  This change creates the whitelist and ignores the packages that were added in it.

Changelog: Add a whitelist for some legacy pacakges without a repo

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

