### PR TITLE
RE-750: GitHub workflows are stealing jobs from one another.  Fix the Concurrency settings.

### DIFF
--- a/.github/workflows/openstack.yml
+++ b/.github/workflows/openstack.yml
@@ -1,3 +1,5 @@
+name: Openstack Test Run
+
 on:
   push:
     branches:
@@ -7,6 +9,10 @@ on:
       - "*"
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   TF_VAR_application_credential_id: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
@@ -31,8 +37,6 @@ jobs:
         defaults:
           run:
             working-directory: "./.github/workflows/openstack/terraform"
-        outputs:
-            VM_IP: ${{ steps.get_vm_ip.outputs.VM_IP }}
         steps:
         - uses: actions/checkout@v4
         - name: Terraform fmt
@@ -63,52 +67,69 @@ jobs:
 
         - name: Terraform Output File Create
           run: |
-            terraform output -json > ${{ github.workspace }}/tf.out.json
+            terraform output -json > ${{ github.run_id }}-tf.out.json
 
-        - name: Get VM IP from Terraform Output File
+        - name: Make vm_ip file from Terraform Output File
           id: get_vm_ip
           run: |
-            echo "VM_IP=$(jq -r '.address.value' ${{ github.workspace }}/tf.out.json)" >> "$GITHUB_OUTPUT"
-            echo "$(jq -r '.address.value' ${{ github.workspace }}/tf.out.json)" > vm_ip
-
-        - name: Export VM_IP to Env
-          env:
-            VM_IP: ${{ steps.get_vm_ip.outputs.VM_IP }}
-          run: echo "The VM IP is $VM_IP"
+            echo "$(jq -r '.address.value' ${{ github.run_id }}-tf.out.json)" > ${{ github.workspace }}/${{ github.run_id }}-vm_ip
 
         - name: Upload JSON Output
           uses: actions/upload-artifact@v4
           with:
-            name: terraform_output_json
-            path: ${{ github.workspace }}/tf.out.json
+            name: ${{ github.run_id }}-tf.out.json
+            path: ${{ github.workspace }}/
+            overwrite: true
+
+        - name: Upload VM Output
+          uses: actions/upload-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
             overwrite: true
 
     clone_elevate_repo:
       runs-on: self-hosted
       needs: terraform_openstack_create
       outputs:
-        VM_IP: ${{ needs.terraform_openstack_create.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
         - name: Checkout Repo and Commit
           if: github.event_name != 'pull_request'
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.terraform_openstack_create.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
             script: |
               cd /opt
-              echo "[DEBUG]: ${{ github.ref }}"
-              echo "[DEBUG]: ${{ github.ref_name }}"
+              echo "## [INFO]: ${{ github.ref }}"
+              echo "## [INFO]: ${{ github.ref_name }}"
+              echo "## [INFO}: ${{ github.repository }}"
               git clone --depth 1 --branch ${{ github.ref_name }} https://github.com/${{ github.repository }}.git
-              cd /opt/elevate
+              hostname && pwd && ls -la
+              cd /opt/$(echo ${{ github.repository }} | cut -d / -f2)
               git status
-        - name: Checking out Repo and Commit
+
+        - name: Checking out Repo and Pull Request
           if: github.event_name == 'pull_request'
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.terraform_openstack_create.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
@@ -116,73 +137,209 @@ jobs:
               cd /opt
               echo "[DEBUG]: ${{ github.ref }}"
               echo "[DEBUG]: ${{ github.head_ref }}"
+              echo "## [INFO}: ${{ github.repository }}"
               git clone --depth 1 --branch ${{ github.head_ref }} https://github.com/${{ github.repository }}.git
-              cd /opt/elevate
+              cd /opt/$(echo ${{ github.repository }} | cut -d / -f2)
               git status
 
     setup_integration_checks:
       runs-on: self-hosted
       needs: clone_elevate_repo
       outputs:
-        VM_IP: ${{ needs.clone_elevate_repo.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export    to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Setup for Integration Checks Prior to Running Elevate
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.clone_elevate_repo.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
             script: |
-              chmod -v +x /opt/elevate/t/integration/setup
-              /opt/elevate/t/integration/setup
+              REPODIR=$(echo ${{ github.repository }} | cut -d / -f2)
+              chmod -v +x /opt/${REPODIR}/t/integration/setup
+              /opt/${REPODIR}/t/integration/setup
 
     start_elevate:
       runs-on: self-hosted
       needs: setup_integration_checks
       outputs:
-        VM_IP: ${{ needs.setup_integration_checks.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
+
         - name: Starting Elevate
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.setup_integration_checks.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
             timeout: 30m
             command_timeout: 30m
             script: |
-              cp -pv /opt/elevate/elevate-cpanel /scripts/elevate-cpanel
-              cp -pv /opt/elevate/.github/workflows/openstack/status_marker /scripts/status_marker
-              cp -pv /opt/elevate/.github/workflows/openstack/reboot_watch /scripts/reboot_watch
+              REPODIR=$(echo ${{ github.repository }} | cut -d / -f2)
+              cp -pv /opt/${REPODIR}/elevate-cpanel /scripts/elevate-cpanel
+              cp -pv /opt/${REPODIR}/.github/workflows/openstack/status_marker /scripts/status_marker
+              cp -pv /opt/${REPODIR}/.github/workflows/openstack/reboot_watch /scripts/reboot_watch
               chmod -v +x /scripts/elevate-cpanel
               /usr/local/cpanel/cpkeyclt
-              /scripts/elevate-cpanel --non-interactive --start &
-              /scripts/elevate-cpanel --log &
-              /scripts/elevate-cpanel --log | awk '/Rebooting into stage 2 of 5/ { print | "exit" }'
+              /scripts/elevate-cpanel --non-interactive --skip-cpanel-version-check --start &
 
-    wait_for_stage_2_reboot:
+    wait_for_stage_1_reboot:
       runs-on: self-hosted
       needs: start_elevate
       outputs:
-        VM_IP: ${{ needs.start_elevate.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Wait For VM to Come Back From Stage 2 Reboot
           working-directory: "./.github/workflows/openstack/"
           run: |
-            ./ssh_retry ${{ needs.start_elevate.outputs.VM_IP }}
+            ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
+
+    watch_for_stage_2_reboot:
+      runs-on: self-hosted
+      needs: wait_for_stage_1_reboot
+      outputs:
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+      steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
+        - name: Monitor Elevate for Reboot from Stage 1 into Stage 2
+          uses: appleboy/ssh-action@v1.0.3
+          with:
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
+            username: 'root'
+            key: ${{ secrets.SSH_PRIVATE_KEY }}
+            port: '22'
+            timeout: 60m
+            command_timeout: 30m
+            debug: true
+            script: |
+              /scripts/status_marker 1
+              /scripts/elevate-cpanel --log &
+              REBOOT_STRING="/usr/bin/systemctl start elevate-cpanel.service" RETVAL=1 /scripts/reboot_watch
+
+    wait_for_stage_2_reboot:
+      runs-on: self-hosted
+      needs: watch_for_stage_2_reboot
+      outputs:
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+      steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
+        - name: Wait For VM to Come Back From Stage 2 Reboot
+          working-directory: "./.github/workflows/openstack/"
+          run: |
+            ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
 
     watch_for_stage_3_reboot:
       runs-on: self-hosted
       needs: wait_for_stage_2_reboot
       outputs:
-        VM_IP: ${{ needs.wait_for_stage_2_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Monitor Elevate for Stage 3 Reboot
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.wait_for_stage_2_reboot.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
@@ -192,29 +349,63 @@ jobs:
             script: |
               /scripts/status_marker 3
               /scripts/elevate-cpanel --log &
-              REGEX="Rebooting into stage 3 of 5" RETVAL=1 /scripts/reboot_watch
+              REBOOT_STRING="Rebooting into stage 3 of 5" RETVAL=1 /scripts/reboot_watch
     
     wait_for_stage_3_reboot:
       runs-on: self-hosted
       needs: watch_for_stage_3_reboot
       outputs:
-        VM_IP: ${{ needs.watch_for_stage_3_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Wait For VM to Come Back From Stage 3 Reboot
           working-directory: "./.github/workflows/openstack/"
           run: |
-            ./ssh_retry ${{ needs.watch_for_stage_3_reboot.outputs.VM_IP }}
+            ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
 
     watch_for_stage_4_reboot:
       runs-on: self-hosted
       needs: wait_for_stage_3_reboot
       outputs:
-        VM_IP: ${{ needs.wait_for_stage_3_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Monitor Elevate for Stage 4 Reboot
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.wait_for_stage_3_reboot.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
@@ -223,29 +414,63 @@ jobs:
             script: |
               /scripts/status_marker 4
               /scripts/elevate-cpanel --log &
-              REGEX="Rebooting into stage 4 of 5" RETVAL=1 /scripts/reboot_watch
+              REBOOT_STRING="Rebooting into stage 4 of 5" RETVAL=1 /scripts/reboot_watch
 
     wait_for_stage_4_reboot:
       runs-on: self-hosted
       needs: watch_for_stage_4_reboot
       outputs:
-        VM_IP: ${{ needs.watch_for_stage_4_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Wait For VM to Come Back From Stage 4 Reboot
           working-directory: "./.github/workflows/openstack/"
           run: |
-            ./ssh_retry ${{ needs.watch_for_stage_4_reboot.outputs.VM_IP }}
+            ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
 
     watch_for_stage_5_reboot:
       runs-on: self-hosted
       needs: wait_for_stage_4_reboot
       outputs:
-        VM_IP: ${{ needs.wait_for_stage_4_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Monitor Elevate for Stage 5 Reboot
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.wait_for_stage_4_reboot.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
@@ -254,66 +479,71 @@ jobs:
             script: |
               /scripts/status_marker 5
               /scripts/elevate-cpanel --log &
-              REGEX="Rebooting into stage 5 of 5" RETVAL=1 /scripts/reboot_watch
+              REBOOT_STRING="Rebooting into stage 5 of 5" RETVAL=1 /scripts/reboot_watch
 
     wait_for_stage_5_reboot:
       runs-on: self-hosted
       needs: watch_for_stage_5_reboot
       outputs:
-        VM_IP: ${{ needs.watch_for_stage_5_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Wait For VM to Come Back From Stage 5 Reboot
           working-directory: "./.github/workflows/openstack/"
           run: |
-            ./ssh_retry ${{ needs.watch_for_stage_5_reboot.outputs.VM_IP }}
-
-    watch_for_final_reboot:
-      runs-on: self-hosted
-      needs: wait_for_stage_5_reboot
-      outputs:
-        VM_IP: ${{ needs.wait_for_stage_5_reboot.outputs.VM_IP }}
-      steps:
-        - name: Watch Elevate for Final Reboot
-          uses: appleboy/ssh-action@v1.0.3
-          with:
-            host: ${{ needs.wait_for_stage_5_reboot.outputs.VM_IP }}
-            username: 'root'
-            key: ${{ secrets.SSH_PRIVATE_KEY }}
-            port: '22'
-            timeout: 30m
-            command_timeout: 30m
-            script: |
-              /scripts/elevate-cpanel --log &
-              REGEX="Doing final reboot" RETVAL=1 /scripts/reboot_watch
-  
-    wait_for_final_reboot:
-      runs-on: self-hosted
-      needs: watch_for_final_reboot
-      outputs:
-        VM_IP: ${{ needs.watch_for_final_reboot.outputs.VM_IP }}
-      steps:
-        - name: Wait For VM to Come Back From Final Reboot
-          working-directory: "./.github/workflows/openstack/"
-          run: |
-            ./ssh_retry ${{ needs.watch_for_final_reboot.outputs.VM_IP }}
+            ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
 
     verify_upgraded_os:
       runs-on: self-hosted
-      needs: wait_for_final_reboot
+      needs: wait_for_stage_5_reboot
       outputs:
-        VM_IP: ${{ needs.wait_for_final_reboot.outputs.VM_IP }}
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
         - name: Verify End Result Integration Tests
           uses: appleboy/ssh-action@v1.0.3
           with:
-            host: ${{ needs.wait_for_final_reboot.outputs.VM_IP }}
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
             username: 'root'
             key: ${{ secrets.SSH_PRIVATE_KEY }}
             port: '22'
             timeout: 5m
             command_timeout: 1m
             script: |
-              /usr/local/cpanel/3rdparty/bin/prove -lvm /opt/elevate/t/integration/*.t
+              REPODIR=$(echo ${{ github.repository }} | cut -d / -f2)
+              /usr/local/cpanel/3rdparty/bin/prove -lvm /opt/${REPODIR}/t/integration/*.t
 
     terraform_openstack_destroy:
       runs-on: self-hosted
@@ -325,8 +555,8 @@ jobs:
       - name: Download Terraform Output JSON
         uses: actions/download-artifact@v4
         with:
-          name: terraform_output_json
-          path: ${{ github.workspace }}/
+          name: ${{ github.run_id }}-tf.out.json
+          path: ${{ github.workspace }}/tf.out.json
       - name: Destroy OpenStack VM
         run: terraform destroy -no-color -auto-approve 
         

--- a/.github/workflows/openstack/reboot_watch
+++ b/.github/workflows/openstack/reboot_watch
@@ -2,29 +2,48 @@
 
 use constant ELEVATE_LOG_PATH => '/var/log/elevate-cpanel.log';
 
-use Env;
-
 use File::Tail;
 use POSIX;
 
-my $RETVAL  = 1;
-my $RETRIES = 0;
+my $RETVAL = 1;
 
-while ( $RETVAL != 0 ) {
-    _check_elevate_log_for_regex( ELEVATE_LOG_PATH, ${REGEX}, $RETRIES );
+# Verify REBOOT_STRING isn't already in the log before we go into tail mode.  The logodump here is sgnificantly faster than File::Tail.
+# Jump if it's found.
+
+exit 1 if !length( $ENV{REBOOT_STRING} );
+
+open( my $elevate_log_fh, '<', ELEVATE_LOG_PATH ) or die "## [ERROR][reboot_watch]: Unable to open ELEVATE_LOG_PATH: $!\n";
+
+while ( my $line = readline $elevate_log_fh ) {
+    if ( index( $line, $ENV{REBOOT_STRING} ) >= 0 ) {
+        _success_message();
+        close $elevate_log;
+        exit 0;
+    }
 }
 
-sub _check_elevate_log_for_regex {
-    my ( $filepath, $REGEX, $RETRIES ) = @_;
+close $elevate_log_fh;
 
-    my $time = POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime );
+while ( $RETVAL != 0 ) {
+    _check_elevate_log_for_REBOOT_STRING( ELEVATE_LOG_PATH, $ENV{REBOOT_STRING} );
+    exit 0;
+}
+
+sub _check_elevate_log_for_REBOOT_STRING {
+    my ( $filepath, $REBOOT_STRING, $RETRIES ) = @_;
 
     $file = File::Tail->new( name => $filepath, maxinterval => 1, adjustafter => 7, interval => 1 );
     while ( defined( $line = $file->read ) ) {
-        if ( grep { /$REGEX/m } $line ) {
-            print "## [$time] [INFO]: SUCCESS: Reboot regex ( $REGEX ) found in /var/log/elevate-cpanel.log  ##\n";
-            exit 0;
+        if ( index( $line, $ENV{REBOOT_STRING} ) >= 0 ) {
+            _success_message();
         }
-        $RETRIES++;
     }
 }
+
+sub _success_message {
+    my $time = POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime );
+    print "## [$time] [INFO]: SUCCESS: Reboot REBOOT_STRING ( $ENV{REBOOT_STRING} ) found in /var/log/elevate-cpanel.log  ##\n";
+    exit 0;
+}
+
+exit 0;


### PR DESCRIPTION
* reboot_watch refactored to quickly check entire log for regex before it begins tail watching.
* reboot stages refactored starting with the first one which was overloaded to start elevate and then watch for a reboot.  Now we start elevate and move to a seperate job to then watch for the reboot and handle things in a more predictable and stable manner.
* Final stage job refactored to explicitly state and act on stage 5.



