### PR TITLE
Make 'upgrade_to_pretty_name' an Elevate::OS key

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -176,7 +176,6 @@ BEGIN {    # Suppress load of all of these at earliest point.
     BEGIN {
         my @_DELEGATE_TO_CPEV = qw{
           getopt
-          upgrade_to_pretty_name
           should_run_distro_upgrade
           ssystem
           ssystem_capture_output
@@ -639,7 +638,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
         return 0 if length $db_version && $db_version >= 55;
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         $db_type = Elevate::Database::pretty_type_name($db_type);
 
         $db_version =~ s/([0-9])$/\.$1/;
@@ -668,7 +667,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
             return 0;
         }
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         $db_type = Elevate::Database::get_database_type_name_from_version($db_version);
         my $upgrade_version     = Elevate::Database::get_default_upgrade_version();
         my $upgrade_dbtype_name = Elevate::Database::get_database_type_name_from_version($upgrade_version);
@@ -753,6 +752,8 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     use Cpanel::SafeRun::Simple ();
 
+    use Elevate::OS ();
+
     # use Elevate::Blockers::Base();
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Blockers::Base); }
@@ -821,7 +822,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
         my $details = join( "\n", @errors );
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         my $error = <<"EOS";
 ** Warning **: your system does not have enough disk space available to update to $pretty_distro_name
@@ -881,7 +882,7 @@ EOS
     sub _blocker_is_old_centos7 ($self) {
 
         if ( Cpanel::OS::minor() < MINIMUM_CENTOS_7_SUPPORTED ) {    ## no critic(Cpanel::CpanelOS)
-            my $pretty_distro_name = $self->upgrade_to_pretty_name();
+            my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
             return $self->has_blocker(
                 sprintf(
                     'You need to run CentOS 7.%s and later to upgrade %s. You are currently using %s',    #
@@ -918,6 +919,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::OS        ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -944,7 +946,7 @@ EOS
     sub _blocker_non_bind_powerdns ( $self, $nameserver = '' ) {
 
         if ( $nameserver eq 'nsd' or $nameserver eq 'mydns' ) {
-            my $pretty_distro_name = $self->upgrade_to_pretty_name();
+            my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
             return $self->has_blocker( <<~"EOS");
         $pretty_distro_name only supports bind or powerdns. We suggest you switch to powerdns.
         Before upgrading, we suggest you run: /scripts/setupnameserver powerdns.
@@ -966,6 +968,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::EA4       ();
+    use Elevate::OS        ();
     use Elevate::StageFile ();
 
     use Cpanel::JSON            ();
@@ -990,7 +993,7 @@ EOS
 
     sub _blocker_ea4_profile ($self) {
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 
@@ -1339,6 +1342,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::OS        ();
 
     use Cpanel::JSON ();
 
@@ -1363,7 +1367,7 @@ EOS
 
         if ( !ref $license_data->{license} || !$license_data->{license}->{status} ) {
 
-            my $pretty_distro_name = $self->upgrade_to_pretty_name();
+            my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
             return $self->has_blocker( <<~"EOS");
         The Imunify license is reporting that it is not currently valid.  Since
         Imunify is installed on this system, a valid Imunify license is required
@@ -1430,6 +1434,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::OS        ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -1450,7 +1455,7 @@ EOS
 
         return 0 unless $self->_use_jetbackup4_or_earlier();
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         return $self->has_blocker( <<~"END" );
     $pretty_distro_name does not support JetBackup prior to version 5.
@@ -1542,6 +1547,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::NICs      ();
+    use Elevate::OS        ();
 
     # use Elevate::Blockers::Base();
     our @ISA;
@@ -1577,7 +1583,7 @@ EOS
 
             return if $self->_nics_have_missing_ifcfg_files(@eths);
 
-            my $pretty_distro_name = $self->upgrade_to_pretty_name();
+            my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
             WARN( <<~"EOS" );
         Prior to elevating this system to $pretty_distro_name, we will
         automatically rename these interfaces.
@@ -2266,6 +2272,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::Notify    ();
+    use Elevate::OS        ();
 
     use Cpanel::Backup::Sync    ();
     use Cpanel::Version::Tiny   ();
@@ -2319,7 +2326,7 @@ EOS
     sub _blocker_is_newer_than_lts ($self) {
         my $major = $Cpanel::Version::Tiny::major_version;
         if ( $major <= Elevate::Constants::MINIMUM_LTS_SUPPORTED - 2 || $major > Elevate::Constants::MAXIMUM_LTS_SUPPORTED ) {
-            my $pretty_distro_name = $self->upgrade_to_pretty_name();
+            my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
             return $self->has_blocker(
                 sprintf(
                     "This version %s does not support upgrades to %s. Please ensure the cPanel version is %s.",
@@ -2576,7 +2583,6 @@ EOS
     BEGIN {
         my @_DELEGATE_TO_CPEV = qw{
           getopt
-          upgrade_to_pretty_name
           should_run_distro_upgrade
           ssystem
           ssystem_and_die
@@ -3458,6 +3464,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::OS        ();
     use Elevate::StageFile ();
 
     use Cwd ();
@@ -3558,7 +3565,7 @@ EOS
             if ( !$detected ) {
 
                 my $stage              = Elevate::Stages::get_stage();
-                my $pretty_distro_name = $self->cpev->upgrade_to_pretty_name();
+                my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
                 my $msg                = <<"EOS";
 The elevation process failed during stage $stage.
 
@@ -4266,6 +4273,7 @@ EOS
     use cPstrict;
 
     use Elevate::Constants ();
+    use Elevate::OS        ();
 
     use Cwd ();
 
@@ -4296,7 +4304,7 @@ EOS
         return unless @kernel_rpms;
         chomp @kernel_rpms;
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         my $msg = "The following kernels should probably be removed as they will not function on $pretty_distro_name:\n\n";
         foreach my $kernel (@kernel_rpms) {
@@ -4918,6 +4926,7 @@ EOS
 
     use Elevate::Constants ();
     use Elevate::Notify    ();
+    use Elevate::OS        ();
     use Elevate::StageFile ();
 
     use Config;
@@ -4984,7 +4993,7 @@ EOS
             }
         }
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         my $stash = {};
         if (%rpms_to_restore) {
@@ -5352,6 +5361,8 @@ EOS
 
     use cPstrict;
 
+    use Elevate::OS ();
+
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
@@ -5396,7 +5407,7 @@ EOS
 
         return unless @exclude_kernel_el7_installed_packages;
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         my $msg = "The following packages should probably be removed as they will not function on $pretty_distro_name\n\n";
         foreach my $pkg (@exclude_kernel_el7_installed_packages) {
@@ -6312,6 +6323,7 @@ EOS
             'provides_mysql_governor',            # This is used to determine if the OS provides the governor-mysql package
             'remove_els',                         # This is used to indicate if we are to remove ELS for this OS
             'should_check_cloudlinux_license',    # This is used to determine if we should check the cloudlinux license
+            'upgrade_to_pretty_name',             # Returns the pretty name of the OS we are upgrading to (i.e. 'Ubuntu 22')
             'vetted_mysql_yum_repo_ids',          # This is a list of known mysql yum repo ids
             'vetted_yum_repo',                    # This is a list of known yum repos that we do not block on
         );
@@ -6364,14 +6376,15 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::OS::RHEL); }
 
-    use constant default_upgrade_to => 'AlmaLinux';
-    use constant ea_alias           => 'CentOS_8';
-    use constant elevate_rpm_url    => 'https://repo.almalinux.org/elevate/elevate-release-latest-el7.noarch.rpm';
-    use constant leapp_data_pkg     => 'leapp-data-almalinux';
-    use constant leapp_repo_prod    => 'elevate';
-    use constant name               => 'CentOS7';
-    use constant pretty_name        => 'CentOS 7';
-    use constant remove_els         => 1;
+    use constant default_upgrade_to     => 'AlmaLinux';
+    use constant ea_alias               => 'CentOS_8';
+    use constant elevate_rpm_url        => 'https://repo.almalinux.org/elevate/elevate-release-latest-el7.noarch.rpm';
+    use constant leapp_data_pkg         => 'leapp-data-almalinux';
+    use constant leapp_repo_prod        => 'elevate';
+    use constant name                   => 'CentOS7';
+    use constant pretty_name            => 'CentOS 7';
+    use constant remove_els             => 1;
+    use constant upgrade_to_pretty_name => 'AlmaLinux 8';
 
     sub vetted_yum_repo ($self) {
 
@@ -6411,6 +6424,7 @@ EOS
     use constant pretty_name                     => 'CloudLinux 7';
     use constant provides_mysql_governor         => 1;
     use constant should_check_cloudlinux_license => 1;
+    use constant upgrade_to_pretty_name          => 'CloudLinux 8';
 
     sub vetted_yum_repo ($self) {
         my @vetted_cloudlinux_yum_repo = (
@@ -7864,6 +7878,7 @@ EOS
     use Cpanel::RestartSrv::Systemd ();
 
     use Elevate::Constants ();
+    use Elevate::OS        ();
 
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
@@ -7906,16 +7921,17 @@ EOS
 
     sub install ($self) {
 
-        my $pretty_distro_name = $self->cpev->upgrade_to_pretty_name();
+        my $upgrade_from = Elevate::OS::pretty_name();
+        my $upgrade_to   = Elevate::OS::upgrade_to_pretty_name();
 
         my $name = $self->name;
 
-        INFO( "Installing service $name which will upgrade the server to " . $pretty_distro_name );
+        INFO( "Installing service $name which will upgrade the server to " . $upgrade_to );
         open( my $fh, '>', $self->file ) or die;
 
         print {$fh} <<~"EOF";
         [Unit]
-        Description=Upgrade process from CentOS 7 to $pretty_distro_name.
+        Description=Upgrade process from $upgrade_from to $upgrade_to.
         After=network.target network-online.target
 
         [Service]
@@ -9001,11 +9017,6 @@ sub do_update ($self) {
     return 0;
 }
 
-sub upgrade_to_pretty_name ($self) {    # used by output messages
-    return q[CloudLinux 8] if Elevate::OS::default_upgrade_to() eq 'CloudLinux';
-    return q[AlmaLinux 8];
-}
-
 sub monitor_upgrade ($self) {
     my $stage = Elevate::Stages::get_stage();
 
@@ -9098,7 +9109,7 @@ sub _capture_env_variables ($self) {
 sub give_last_chance ($self) {
 
     my $upgrade_from_name  = Elevate::OS::pretty_name();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     print_box(qq[/!\ Warning: You are about to convert your cPanel & WHM $upgrade_from_name to $pretty_distro_name server.]);
 
@@ -9300,7 +9311,7 @@ sub check_status ($self) {
 sub _notify_success ($self) {
 
     my $upgrade_from_name  = Elevate::OS::pretty_name();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     my $msg = <<"EOS";
 The cPanel & WHM server has completed the elevation process from $upgrade_from_name to $pretty_distro_name.
@@ -9342,7 +9353,7 @@ $error
 
 EOS
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
     Elevate::Notify::send_notification( qq[Failed to update to $pretty_distro_name] => $msg );
 
     return;
@@ -9595,7 +9606,7 @@ sub run_stage_4 ($self) {
     }
 
     if ( Cpanel::OS::major() != 8 ) {    ## no critic(Cpanel::CpanelOS)
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         my $current_distro     = Cpanel::OS::pretty_distro();
 
         if ( Cpanel::OS::major() == 7 ) {    ## no critic(Cpanel::CpanelOS)
@@ -9697,7 +9708,7 @@ sub run_stage_5 ($self) {
     $self->ssystem(qw{/usr/bin/dnf -y --allowerasing update});
 
     Elevate::Motd->cleanup();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
     print_box("Great SUCCESS! Your upgrade to $pretty_distro_name is complete.");
 
     return ACTION_REBOOT_NEEDED;
@@ -9993,7 +10004,7 @@ sub post_upgrade_check ($self) {
     $expect_distro = lc $expect_distro;
 
     unless ( Cpanel::OS::major() == 8 && Cpanel::OS::distro() eq $expect_distro ) {    ## no critic(Cpanel::CpanelOS)
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         die "Your distro does not look like $pretty_distro_name.\n";
     }
 

--- a/lib/Elevate/Blockers/Base.pm
+++ b/lib/Elevate/Blockers/Base.pm
@@ -45,7 +45,6 @@ sub cpev ($self) {
 BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
-      upgrade_to_pretty_name
       should_run_distro_upgrade
       ssystem
       ssystem_capture_output

--- a/lib/Elevate/Blockers/DNS.pm
+++ b/lib/Elevate/Blockers/DNS.pm
@@ -13,6 +13,7 @@ Blocker to check if the DNS server is supported.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::OS        ();
 
 use parent qw{Elevate::Blockers::Base};
 
@@ -35,7 +36,7 @@ sub _get_nameserver_type () {
 sub _blocker_non_bind_powerdns ( $self, $nameserver = '' ) {
 
     if ( $nameserver eq 'nsd' or $nameserver eq 'mydns' ) {
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         return $self->has_blocker( <<~"EOS");
         $pretty_distro_name only supports bind or powerdns. We suggest you switch to powerdns.
         Before upgrading, we suggest you run: /scripts/setupnameserver powerdns.

--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -51,7 +51,7 @@ sub _blocker_old_cloudlinux_mysql ($self) {
     # for the version in the RPM package name
     return 0 if length $db_version && $db_version >= 55;
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
     $db_type = Elevate::Database::pretty_type_name($db_type);
 
     # Shift decimal one place to the left
@@ -86,7 +86,7 @@ sub _blocker_old_cpanel_mysql ($self) {
         return 0;
     }
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
     $db_type = Elevate::Database::get_database_type_name_from_version($db_version);
     my $upgrade_version     = Elevate::Database::get_default_upgrade_version();
     my $upgrade_dbtype_name = Elevate::Database::get_database_type_name_from_version($upgrade_version);

--- a/lib/Elevate/Blockers/DiskSpace.pm
+++ b/lib/Elevate/Blockers/DiskSpace.pm
@@ -14,6 +14,8 @@ use cPstrict;
 
 use Cpanel::SafeRun::Simple ();
 
+use Elevate::OS ();
+
 use parent qw{Elevate::Blockers::Base};
 
 use Log::Log4perl qw(:easy);
@@ -84,7 +86,7 @@ sub _disk_space_check ($self) {
 
     my $details = join( "\n", @errors );
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     my $error = <<"EOS";
 ** Warning **: your system does not have enough disk space available to update to $pretty_distro_name

--- a/lib/Elevate/Blockers/Distros.pm
+++ b/lib/Elevate/Blockers/Distros.pm
@@ -46,7 +46,7 @@ sub _blocker_os_is_not_supported ($self) {
 sub _blocker_is_old_centos7 ($self) {
 
     if ( Cpanel::OS::minor() < MINIMUM_CENTOS_7_SUPPORTED ) {    ## no critic(Cpanel::CpanelOS)
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         return $self->has_blocker(
             sprintf(
                 'You need to run CentOS 7.%s and later to upgrade %s. You are currently using %s',    #

--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::EA4       ();
+use Elevate::OS        ();
 use Elevate::StageFile ();
 
 use Cpanel::JSON            ();
@@ -40,7 +41,7 @@ sub _blocker_ea4_profile ($self) {
 
     # perform an early backup so we can check the list of dropped packages
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 

--- a/lib/Elevate/Blockers/Imunify.pm
+++ b/lib/Elevate/Blockers/Imunify.pm
@@ -13,6 +13,7 @@ Blocker to check that the Imunify license is valid when Imunify is installed.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::OS        ();
 
 use Cpanel::JSON ();
 
@@ -34,7 +35,7 @@ sub _check_imunify_license ($self) {
 
     if ( !ref $license_data->{license} || !$license_data->{license}->{status} ) {
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         return $self->has_blocker( <<~"EOS");
         The Imunify license is reporting that it is not currently valid.  Since
         Imunify is installed on this system, a valid Imunify license is required

--- a/lib/Elevate/Blockers/JetBackup.pm
+++ b/lib/Elevate/Blockers/JetBackup.pm
@@ -13,6 +13,7 @@ Blocker to check if JetBackup is supported.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::OS        ();
 
 use parent qw{Elevate::Blockers::Base};
 
@@ -29,7 +30,7 @@ sub _blocker_old_jetbackup ($self) {
 
     return 0 unless $self->_use_jetbackup4_or_earlier();
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     return $self->has_blocker( <<~"END" );
     $pretty_distro_name does not support JetBackup prior to version 5.

--- a/lib/Elevate/Blockers/NICs.pm
+++ b/lib/Elevate/Blockers/NICs.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::NICs      ();
+use Elevate::OS        ();
 
 use parent qw{Elevate::Blockers::Base};
 
@@ -46,7 +47,7 @@ sub _blocker_bad_nics_naming ($self) {
 
         return if $self->_nics_have_missing_ifcfg_files(@eths);
 
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         WARN( <<~"EOS" );
         Prior to elevating this system to $pretty_distro_name, we will
         automatically rename these interfaces.

--- a/lib/Elevate/Blockers/WHM.pm
+++ b/lib/Elevate/Blockers/WHM.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::Notify    ();
+use Elevate::OS        ();
 
 use Cpanel::Backup::Sync    ();
 use Cpanel::Version::Tiny   ();
@@ -64,7 +65,7 @@ sub _blocker_is_invalid_cpanel_whm ($self) {
 sub _blocker_is_newer_than_lts ($self) {
     my $major = $Cpanel::Version::Tiny::major_version;
     if ( $major <= Elevate::Constants::MINIMUM_LTS_SUPPORTED - 2 || $major > Elevate::Constants::MAXIMUM_LTS_SUPPORTED ) {
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         return $self->has_blocker(
             sprintf(
                 "This version %s does not support upgrades to %s. Please ensure the cPanel version is %s.",

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -29,7 +29,6 @@ use Log::Log4perl qw(:easy);
 BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
-      upgrade_to_pretty_name
       should_run_distro_upgrade
       ssystem
       ssystem_and_die

--- a/lib/Elevate/Components/Grub2.pm
+++ b/lib/Elevate/Components/Grub2.pm
@@ -13,6 +13,7 @@ Logic to update and fix grub2 configuration.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::OS        ();
 use Elevate::StageFile ();
 
 use Cwd           ();
@@ -113,7 +114,7 @@ sub verify_cmdline ($self) {
             # tells you to use --continue, which won't work here due to the
             # do_cleanup invocation:
             my $stage              = Elevate::Stages::get_stage();
-            my $pretty_distro_name = $self->cpev->upgrade_to_pretty_name();
+            my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
             my $msg                = <<"EOS";
 The elevation process failed during stage $stage.
 

--- a/lib/Elevate/Components/Kernel.pm
+++ b/lib/Elevate/Components/Kernel.pm
@@ -13,6 +13,7 @@ Perform some kernel checks.
 use cPstrict;
 
 use Elevate::Constants ();
+use Elevate::OS        ();
 
 use Cwd           ();
 use Log::Log4perl qw(:easy);
@@ -41,7 +42,7 @@ sub _kernel_check ($self) {
     return unless @kernel_rpms;
     chomp @kernel_rpms;
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     my $msg = "The following kernels should probably be removed as they will not function on $pretty_distro_name:\n\n";
     foreach my $kernel (@kernel_rpms) {

--- a/lib/Elevate/Components/PerlXS.pm
+++ b/lib/Elevate/Components/PerlXS.pm
@@ -14,6 +14,7 @@ use cPstrict;
 
 use Elevate::Constants ();
 use Elevate::Notify    ();
+use Elevate::OS        ();
 use Elevate::StageFile ();
 
 use Config;
@@ -77,7 +78,7 @@ sub purge_perl_xs ( $self, $path ) {
         }
     }
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     my $stash = {};
     if (%rpms_to_restore) {

--- a/lib/Elevate/Components/UnconvertedModules.pm
+++ b/lib/Elevate/Components/UnconvertedModules.pm
@@ -16,6 +16,8 @@ likely will not work properly after the upgrade
 
 use cPstrict;
 
+use Elevate::OS ();
+
 use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
@@ -57,7 +59,7 @@ sub _warn_about_other_modules_that_did_not_convert ($self) {
 
     return unless @exclude_kernel_el7_installed_packages;
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     my $msg = "The following packages should probably be removed as they will not function on $pretty_distro_name\n\n";
     foreach my $pkg (@exclude_kernel_el7_installed_packages) {

--- a/lib/Elevate/OS.pm
+++ b/lib/Elevate/OS.pm
@@ -94,6 +94,7 @@ BEGIN {
         'provides_mysql_governor',            # This is used to determine if the OS provides the governor-mysql package
         'remove_els',                         # This is used to indicate if we are to remove ELS for this OS
         'should_check_cloudlinux_license',    # This is used to determine if we should check the cloudlinux license
+        'upgrade_to_pretty_name',             # Returns the pretty name of the OS we are upgrading to (i.e. 'Ubuntu 22')
         'vetted_mysql_yum_repo_ids',          # This is a list of known mysql yum repo ids
         'vetted_yum_repo',                    # This is a list of known yum repos that we do not block on
     );

--- a/lib/Elevate/OS/CentOS7.pm
+++ b/lib/Elevate/OS/CentOS7.pm
@@ -14,14 +14,15 @@ use Log::Log4perl qw(:easy);
 
 use parent 'Elevate::OS::RHEL';
 
-use constant default_upgrade_to => 'AlmaLinux';
-use constant ea_alias           => 'CentOS_8';
-use constant elevate_rpm_url    => 'https://repo.almalinux.org/elevate/elevate-release-latest-el7.noarch.rpm';
-use constant leapp_data_pkg     => 'leapp-data-almalinux';
-use constant leapp_repo_prod    => 'elevate';
-use constant name               => 'CentOS7';
-use constant pretty_name        => 'CentOS 7';
-use constant remove_els         => 1;
+use constant default_upgrade_to     => 'AlmaLinux';
+use constant ea_alias               => 'CentOS_8';
+use constant elevate_rpm_url        => 'https://repo.almalinux.org/elevate/elevate-release-latest-el7.noarch.rpm';
+use constant leapp_data_pkg         => 'leapp-data-almalinux';
+use constant leapp_repo_prod        => 'elevate';
+use constant name                   => 'CentOS7';
+use constant pretty_name            => 'CentOS 7';
+use constant remove_els             => 1;
+use constant upgrade_to_pretty_name => 'AlmaLinux 8';
 
 sub vetted_yum_repo ($self) {
 

--- a/lib/Elevate/OS/CloudLinux7.pm
+++ b/lib/Elevate/OS/CloudLinux7.pm
@@ -27,6 +27,7 @@ use constant name                            => 'CloudLinux7';
 use constant pretty_name                     => 'CloudLinux 7';
 use constant provides_mysql_governor         => 1;
 use constant should_check_cloudlinux_license => 1;
+use constant upgrade_to_pretty_name          => 'CloudLinux 8';
 
 sub vetted_yum_repo ($self) {
     my @vetted_cloudlinux_yum_repo = (

--- a/lib/Elevate/Service.pm
+++ b/lib/Elevate/Service.pm
@@ -16,6 +16,7 @@ use Cpanel::SafeRun::Simple     ();
 use Cpanel::RestartSrv::Systemd ();
 
 use Elevate::Constants ();
+use Elevate::OS        ();
 
 use Log::Log4perl qw(:easy);
 
@@ -55,16 +56,17 @@ sub _build_cpev {
 
 sub install ($self) {
 
-    my $pretty_distro_name = $self->cpev->upgrade_to_pretty_name();
+    my $upgrade_from = Elevate::OS::pretty_name();
+    my $upgrade_to   = Elevate::OS::upgrade_to_pretty_name();
 
     my $name = $self->name;
 
-    INFO( "Installing service $name which will upgrade the server to " . $pretty_distro_name );
+    INFO( "Installing service $name which will upgrade the server to " . $upgrade_to );
     open( my $fh, '>', $self->file ) or die;
 
     print {$fh} <<~"EOF";
         [Unit]
-        Description=Upgrade process from CentOS 7 to $pretty_distro_name.
+        Description=Upgrade process from $upgrade_from to $upgrade_to.
         After=network.target network-online.target
 
         [Service]

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -488,11 +488,6 @@ sub do_update ($self) {
     return 0;
 }
 
-sub upgrade_to_pretty_name ($self) {    # used by output messages
-    return q[CloudLinux 8] if Elevate::OS::default_upgrade_to() eq 'CloudLinux';
-    return q[AlmaLinux 8];
-}
-
 sub monitor_upgrade ($self) {
     my $stage = Elevate::Stages::get_stage();
 
@@ -585,7 +580,7 @@ sub _capture_env_variables ($self) {
 sub give_last_chance ($self) {
 
     my $upgrade_from_name  = Elevate::OS::pretty_name();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     print_box(qq[/!\ Warning: You are about to convert your cPanel & WHM $upgrade_from_name to $pretty_distro_name server.]);
 
@@ -787,7 +782,7 @@ sub check_status ($self) {
 sub _notify_success ($self) {
 
     my $upgrade_from_name  = Elevate::OS::pretty_name();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
     my $msg = <<"EOS";
 The cPanel & WHM server has completed the elevation process from $upgrade_from_name to $pretty_distro_name.
@@ -829,7 +824,7 @@ $error
 
 EOS
 
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
     Elevate::Notify::send_notification( qq[Failed to update to $pretty_distro_name] => $msg );
 
     return;
@@ -1082,7 +1077,7 @@ sub run_stage_4 ($self) {
     }
 
     if ( Cpanel::OS::major() != 8 ) {    ## no critic(Cpanel::CpanelOS)
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         my $current_distro     = Cpanel::OS::pretty_distro();
 
         if ( Cpanel::OS::major() == 7 ) {    ## no critic(Cpanel::CpanelOS)
@@ -1184,7 +1179,7 @@ sub run_stage_5 ($self) {
     $self->ssystem(qw{/usr/bin/dnf -y --allowerasing update});
 
     Elevate::Motd->cleanup();
-    my $pretty_distro_name = $self->upgrade_to_pretty_name();
+    my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
     print_box("Great SUCCESS! Your upgrade to $pretty_distro_name is complete.");
 
     return ACTION_REBOOT_NEEDED;
@@ -1480,7 +1475,7 @@ sub post_upgrade_check ($self) {
     $expect_distro = lc $expect_distro;
 
     unless ( Cpanel::OS::major() == 8 && Cpanel::OS::distro() eq $expect_distro ) {    ## no critic(Cpanel::CpanelOS)
-        my $pretty_distro_name = $self->upgrade_to_pretty_name();
+        my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
         die "Your distro does not look like $pretty_distro_name.\n";
     }
 

--- a/t/blocker-Databases.t
+++ b/t/blocker-Databases.t
@@ -58,7 +58,7 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
     my $upgrade_version = '42';
     my $stash           = undef;
     my $is_check_mode   = 1;
-    my $os_pretty_name  = 'ShinyOS';
+    my $os_pretty_name  = 'AlmaLinux 8';
     my $user_consent    = 0;
 
     my $mock_db = Test::MockModule->new('Elevate::Database');
@@ -76,8 +76,7 @@ my $mock_elevate = Test::MockFile->file('/var/cpanel/elevate');
 
     my $mock_db_blocker = Test::MockModule->new('Elevate::Blockers::Databases');
     $mock_db_blocker->redefine(
-        is_check_mode          => sub { return $is_check_mode; },
-        upgrade_to_pretty_name => sub { return $os_pretty_name; },
+        is_check_mode => sub { return $is_check_mode; },
     );
 
     my $mock_io_prompt = Test::MockModule->new('IO::Prompt');


### PR DESCRIPTION
Case RE-697:  This is a refactor to remove the
'upgrade_to_pretty_name()' sub from the main script and make it an Elevate::OS key instead.  Additionally, this change resolves RE-698 by removing a hard coded value for the OS we are upgrading from the service file that we provide.

Changelog: Make 'upgrade_to_pretty_name' an Elevate::OS key

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

