### PR TITLE
Replace the use of leapp in our naming scheme for elevate

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2651,7 +2651,7 @@ EOS
         return %links;
     }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->ssystem(qw{/usr/bin/ln -snf usr/local/cpanel/scripts /scripts});
         $self->_absolute_symlinks;
@@ -2678,7 +2678,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return;
     }
@@ -2724,7 +2724,7 @@ EOS
         contacts  => 'vcard',
     );
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
         my $ccs_installed = Cpanel::Pkgr::is_installed(CCS_PACKAGE);
         Elevate::StageFile::update_stage_file( { ccs_installed => $ccs_installed } );
         return unless $ccs_installed;
@@ -2919,7 +2919,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
         return unless Elevate::StageFile::read_stage_file('ccs_installed');
 
         $self->run_once('move_pgsql_directory');
@@ -3118,7 +3118,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         my @installed_arch_cpanel_plugins;
 
@@ -3135,7 +3135,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         my $stash            = Elevate::StageFile::read_stage_file();
         my $yum_arch_plugins = $stash->{'restore'}->{'yum'} // [];
@@ -3175,7 +3175,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         unlink('/usr/local/cpanel/scripts/upcp');
         unlink('/usr/local/cpanel/bin/backup');
@@ -3287,12 +3287,12 @@ EOS
         return;
     }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
         $self->run_once('_cleanup_rpm_db');
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->run_once('_restore_ea4_profile');
         $self->run_once('_restore_ea_addons');
@@ -3591,7 +3591,7 @@ EOS
         return;
     }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once('_update_grub2_workaround_if_needed');    # required part
         $self->run_once('_merge_grub_directories_if_needed');     # best-effort part
@@ -3688,7 +3688,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         my $proc_cmd_line = eval { File::Slurper::read_binary('/proc/cmdline') } // '';
         return unless $proc_cmd_line =~ m{net.ifnames=0};
@@ -3757,7 +3757,7 @@ EOS
     use constant IMUNIFY_LICENSE_FILE   => '/var/imunify360/license.json';
     use constant IMUNIFY_LICENSE_BACKUP => Elevate::Constants::ELEVATE_BACKUP_DIR . '/imunify-backup-license.json';
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         return if Elevate::OS::leapp_can_handle_imunify();
 
@@ -3770,7 +3770,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return if Elevate::OS::leapp_can_handle_imunify();
 
@@ -4025,7 +4025,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         Elevate::StageFile::remove_from_stage_file('reinstall.influxdb');
 
@@ -4037,7 +4037,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return unless Elevate::StageFile::read_stage_file('reinstall')->{'influxdb'};
 
@@ -4070,7 +4070,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         Elevate::StageFile::remove_from_stage_file('reinstall.jetbackup');
 
@@ -4098,7 +4098,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         my $data = Elevate::StageFile::read_stage_file('reinstall')->{'jetbackup'};
         return unless ref $data && ref $data->{packages};
@@ -4136,7 +4136,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         Elevate::StageFile::remove_from_stage_file('reinstall.litespeed');
 
@@ -4157,7 +4157,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         my $data = Elevate::StageFile::read_stage_file('reinstall')->{'litespeed'};
         return unless ref $data;
@@ -4199,7 +4199,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         return if Elevate::OS::leapp_can_handle_kernelcare();
 
@@ -4208,7 +4208,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return if Elevate::OS::leapp_can_handle_kernelcare();
 
@@ -4276,12 +4276,12 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->run_once('_kernel_check');
 
@@ -4339,14 +4339,14 @@ EOS
 
     my $cnf_file = '/etc/my.cnf';
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
         return if Elevate::Database::is_database_provided_by_cloudlinux();
 
         $self->run_once("_cleanup_mysql_packages");
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
         return if Elevate::Database::is_database_provided_by_cloudlinux();
 
         $self->run_once('_reinstall_mysql_packages');
@@ -4424,7 +4424,7 @@ EOS
             return;
         }
 
-        File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_leapp_orig" );
+        File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_distro_upgrade_orig" );
 
         INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
         File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file );
@@ -4437,7 +4437,7 @@ EOS
         return if grep { $_ =~ m{mysql (?:re)?started successfully} } @restart_lines;
 
         INFO('The database server failed to start.  Restoring my.cnf to default.');
-        File::Copy::copy( "$cnf_file.elevate_post_leapp_orig", $cnf_file );
+        File::Copy::copy( "$cnf_file.elevate_post_distro_upgrade_orig", $cnf_file );
 
         $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
         @restart_lines = split "\n", $restart_out;
@@ -4541,7 +4541,7 @@ EOS
     use constant NIC_PREFIX                => q[cp];
     use constant PERSISTENT_NET_RULES_PATH => q[/etc/udev/rules.d/70-persistent-net.rules];
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->_rename_nics();
 
@@ -4602,7 +4602,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
         return;
     }
 
@@ -4631,14 +4631,14 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once("_remove_nixstats");
 
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->run_once('_restore_nixstats');
 
@@ -4780,14 +4780,14 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once("_backup_pecl_packages");
 
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->run_once('_check_pecl_packages');
 
@@ -4933,7 +4933,7 @@ EOS
 
     use constant DISTRO_PERL_XS_PATH => '/usr/local/lib64/perl5';
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->purge_perl_xs(DISTRO_PERL_XS_PATH);
         $self->purge_perl_xs( $Config{'installsitearch'} );
@@ -4941,7 +4941,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->restore_perl_xs(DISTRO_PERL_XS_PATH);
         $self->restore_perl_xs( $Config{'installsitearch'} );
@@ -5096,7 +5096,7 @@ EOS
         return Elevate::SystemctlService->new( name => 'postgresql' );
     }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
         if ( Cpanel::Pkgr::is_installed('postgresql-server') ) {
             $self->_store_postgresql_encoding_and_locale();
             $self->_disable_postgresql_service();
@@ -5196,7 +5196,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
         if ( Cpanel::Pkgr::is_installed('postgresql-server') ) {
             $self->_perform_config_workaround();
             $self->_perform_postgresql_upgrade();
@@ -5359,11 +5359,11 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
         $self->run_once('_remove_leapp_packages');
         $self->run_once('_warn_about_other_modules_that_did_not_convert');
         return;
@@ -5435,7 +5435,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once("_disable_yum_plugin_fastestmirror");
         $self->run_once("_disable_known_yum_repositories");
@@ -5511,7 +5511,7 @@ EOS
         'yum-plugin-universal-hooks',
     );
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once("_cleanup_rpms");
 
@@ -5533,7 +5533,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->run_once("_sysup");
 
@@ -5586,7 +5586,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once("_rmod_ln");
 
@@ -5625,14 +5625,14 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         $self->run_once("_remove_wordpress_toolkit");
 
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         $self->run_once('_reinstall_wordpress_toolkit');
 
@@ -5698,7 +5698,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         my $sshd_config = q[/etc/ssh/sshd_config];
 
@@ -5717,7 +5717,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return;
     }
@@ -5738,7 +5738,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         if ( is_using_sectigo() ) {
             $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/autorepair set_autossl_to_lets_encrypt});
@@ -5747,7 +5747,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return;
     }
@@ -5801,7 +5801,7 @@ EOS
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         return if Elevate::Database::is_database_provided_by_cloudlinux();
 
@@ -5814,7 +5814,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
         return unless -e MYSQL_PROFILE_FILE;
 
         my $original_profile = File::Slurper::read_text(MYSQL_PROFILE_FILE) // 'localhost';
@@ -5983,7 +5983,7 @@ EOS
 
     use constant ELS_PACKAGE => 'els-define';
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         return unless Elevate::OS::remove_els();
 
@@ -6003,7 +6003,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return;
     }
@@ -6032,7 +6032,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         my $r1soft_agent_installed = 0;
         my $r1soft_repo_present    = 0;
@@ -6071,7 +6071,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         my $r1soft_info = Elevate::StageFile::read_stage_file('r1soft');
 
@@ -6151,7 +6151,7 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         if ( Cpanel::Pkgr::is_installed('panopta-agent') ) {
 
@@ -6161,7 +6161,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         return;
     }
@@ -6190,7 +6190,7 @@ EOS
         };
     }
 
-    sub pre_leapp ($self) {
+    sub pre_distro_upgrade ($self) {
 
         my @package_list = _get_packages_to_check();
         my @installed_packages;
@@ -6212,7 +6212,7 @@ EOS
         return;
     }
 
-    sub post_leapp ($self) {
+    sub post_distro_upgrade ($self) {
 
         my $package_info = Elevate::StageFile::read_stage_file('packages_to_restore');
         return unless defined $package_info and ref $package_info eq 'HASH';
@@ -8667,7 +8667,7 @@ A `--no-leapp` upgrade would look like:
 
 =item * This is when you would use your distro upgrade tool.
 
-=item * When you have completed upgrading your system to 8, simply remove `/waiting_for_distro_upgrade` and reboot the system into normal multi-user mode.
+=item * When you have completed upgrading your system, simply remove `/waiting_for_distro_upgrade` and reboot the system into normal multi-user mode.
 
 =back
 
@@ -9477,21 +9477,21 @@ sub run_stage_2 ($self) {
 
     # This needs to happen before the database upgrade because
     # it will remove the packages we want to detect
-    $self->run_component_once( 'PackageRestore' => 'pre_leapp' );
+    $self->run_component_once( 'PackageRestore' => 'pre_distro_upgrade' );
 
     # This needs to execute before we disable cPanel services
     # or exporting the CCS data will fail
-    $self->run_component_once( 'CCS'             => 'pre_leapp' );
-    $self->run_component_once( 'DatabaseUpgrade' => 'pre_leapp' );
+    $self->run_component_once( 'CCS'             => 'pre_distro_upgrade' );
+    $self->run_component_once( 'DatabaseUpgrade' => 'pre_distro_upgrade' );
 
     # This disable cPanel services
-    $self->run_component_once( 'cPanelPrep' => 'pre_leapp' );
+    $self->run_component_once( 'cPanelPrep' => 'pre_distro_upgrade' );
 
-    $self->run_component_once( 'SSH'        => 'pre_leapp' );
-    $self->run_component_once( 'AutoSSL'    => 'pre_leapp' );
-    $self->run_component_once( 'KernelCare' => 'pre_leapp' );
-    $self->run_component_once( 'Grub2'      => 'pre_leapp' );
-    $self->run_component_once( 'NICs'       => 'pre_leapp' );
+    $self->run_component_once( 'SSH'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'AutoSSL'    => 'pre_distro_upgrade' );
+    $self->run_component_once( 'KernelCare' => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Grub2'      => 'pre_distro_upgrade' );
+    $self->run_component_once( 'NICs'       => 'pre_distro_upgrade' );
 
     # Imunify depends on EA4 so the Imunify component needs to
     # run before EA4 is removed.  However, Imunify 360 can provide
@@ -9500,9 +9500,9 @@ sub run_stage_2 ($self) {
     # to be executed before Imunify and left the removal until
     # after Imunify
     $self->run_component_once( 'EA4'     => 'pre_imunify' );
-    $self->run_component_once( 'Imunify' => 'pre_leapp' );
-    $self->run_component_once( 'PECL'    => 'pre_leapp' );
-    $self->run_component_once( 'EA4'     => 'pre_leapp' );
+    $self->run_component_once( 'Imunify' => 'pre_distro_upgrade' );
+    $self->run_component_once( 'PECL'    => 'pre_distro_upgrade' );
+    $self->run_component_once( 'EA4'     => 'pre_distro_upgrade' );
 
     # This reboot will invalidate the cPanel license causing
     # further whmapi1 calls to fail until stage 4
@@ -9527,7 +9527,7 @@ some conflicting packages.
 
 sub run_stage_3 ($self) {
 
-    $self->run_once('run_final_components_pre_leapp');
+    $self->run_once('run_final_components_pre_distro_upgrade');
 
     if ( !$self->should_run_leapp() ) {
         return $self->_request_to_upgrade_distro_manually();
@@ -9621,7 +9621,7 @@ sub run_stage_4 ($self) {
 
     $stash->{stage4} //= {};    # run once each blocks
 
-    $self->run_component_once( 'RpmDB', => 'post_leapp' );
+    $self->run_component_once( 'RpmDB', => 'post_distro_upgrade' );
 
     $self->run_once(
         restore_cpanel_services => sub {
@@ -9633,8 +9633,8 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->run_component_once( 'Imunify' => 'post_leapp' );
-    $self->run_component_once( 'EA4'     => 'post_leapp' );
+    $self->run_component_once( 'Imunify' => 'post_distro_upgrade' );
+    $self->run_component_once( 'EA4'     => 'post_distro_upgrade' );
 
     $self->run_once(
         upcp => sub {
@@ -9653,9 +9653,9 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->post_leapp_update_restore();
+    $self->post_distro_upgrade_update_restore();
 
-    $self->run_component_once( 'UnconvertedModules' => 'post_leapp' );
+    $self->run_component_once( 'UnconvertedModules' => 'post_distro_upgrade' );
 
     # run upcp a second time as we had to run it before with CPANEL_BASE_INSTALL=1
     $self->run_once(
@@ -9664,7 +9664,7 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->run_component_once( 'CCS' => 'post_leapp' );
+    $self->run_component_once( 'CCS' => 'post_distro_upgrade' );
 
     return ACTION_REBOOT_NEEDED;
 }
@@ -9686,7 +9686,7 @@ sub run_stage_5 ($self) {
     my $el_backup_dir = Elevate::Constants::ELEVATE_BACKUP_DIR;
     File::Path::remove_tree($el_backup_dir) if -d $el_backup_dir;
 
-    $self->run_component_once( 'Grub2' => 'post_leapp' );
+    $self->run_component_once( 'Grub2' => 'post_distro_upgrade' );
 
     Elevate::Marker::success();
 
@@ -9835,30 +9835,30 @@ sub stop_services_before_upcp ($self) {
 }
 
 # remove and store
-sub run_final_components_pre_leapp ($self) {
+sub run_final_components_pre_distro_upgrade ($self) {
 
     # order matters
-    $self->run_component_once( 'RmMod'            => 'pre_leapp' );
-    $self->run_component_once( 'MySQL'            => 'pre_leapp' );
-    $self->run_component_once( 'PostgreSQL'       => 'pre_leapp' );
-    $self->run_component_once( 'Repositories'     => 'pre_leapp' );
-    $self->run_component_once( 'cPanelPlugins'    => 'pre_leapp' );
-    $self->run_component_once( 'PerlXS'           => 'pre_leapp' );
-    $self->run_component_once( 'WPToolkit'        => 'pre_leapp' );
-    $self->run_component_once( 'InfluxDB'         => 'pre_leapp' );
-    $self->run_component_once( 'JetBackup'        => 'pre_leapp' );
-    $self->run_component_once( 'NixStats'         => 'pre_leapp' );
-    $self->run_component_once( 'LiteSpeed'        => 'pre_leapp' );
-    $self->run_component_once( 'AbsoluteSymlinks' => 'pre_leapp' );
-    $self->run_component_once( 'ELS'              => 'pre_leapp' );
-    $self->run_component_once( 'R1Soft'           => 'pre_leapp' );
-    $self->run_component_once( 'Panopta'          => 'pre_leapp' );
-    $self->run_component_once( 'RpmDB'            => 'pre_leapp' );    # remove the RPMs last
+    $self->run_component_once( 'RmMod'            => 'pre_distro_upgrade' );
+    $self->run_component_once( 'MySQL'            => 'pre_distro_upgrade' );
+    $self->run_component_once( 'PostgreSQL'       => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Repositories'     => 'pre_distro_upgrade' );
+    $self->run_component_once( 'cPanelPlugins'    => 'pre_distro_upgrade' );
+    $self->run_component_once( 'PerlXS'           => 'pre_distro_upgrade' );
+    $self->run_component_once( 'WPToolkit'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'InfluxDB'         => 'pre_distro_upgrade' );
+    $self->run_component_once( 'JetBackup'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'NixStats'         => 'pre_distro_upgrade' );
+    $self->run_component_once( 'LiteSpeed'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'AbsoluteSymlinks' => 'pre_distro_upgrade' );
+    $self->run_component_once( 'ELS'              => 'pre_distro_upgrade' );
+    $self->run_component_once( 'R1Soft'           => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Panopta'          => 'pre_distro_upgrade' );
+    $self->run_component_once( 'RpmDB'            => 'pre_distro_upgrade' );    # remove the RPMs last
 
     return;
 }
 
-sub post_leapp_update_restore ($self) {
+sub post_distro_upgrade_update_restore ($self) {
 
     INFO('Removing leapp from excludes in /etc/yum.conf');
     my $txt = eval { File::Slurper::read_text("/etc/yum.conf") };
@@ -9868,21 +9868,21 @@ sub post_leapp_update_restore ($self) {
     }
 
     # plugins can use MySQL - restore database earlier
-    $self->run_component_once( 'MySQL'           => 'post_leapp' );
-    $self->run_component_once( 'PerlXS'          => 'post_leapp' );
-    $self->run_component_once( 'PostgreSQL'      => 'post_leapp' );
-    $self->run_component_once( 'cPanelPlugins'   => 'post_leapp' );
-    $self->run_component_once( 'DatabaseUpgrade' => 'post_leapp' );
-    $self->run_component_once( 'PECL'            => 'post_leapp' );
-    $self->run_component_once( 'WPToolkit'       => 'post_leapp' );
-    $self->run_component_once( 'InfluxDB'        => 'post_leapp' );
-    $self->run_component_once( 'JetBackup'       => 'post_leapp' );
-    $self->run_component_once( 'Kernel'          => 'post_leapp' );
-    $self->run_component_once( 'KernelCare'      => 'post_leapp' );
-    $self->run_component_once( 'NixStats'        => 'post_leapp' );
-    $self->run_component_once( 'LiteSpeed'       => 'post_leapp' );
-    $self->run_component_once( 'R1Soft'          => 'post_leapp' );
-    $self->run_component_once( 'PackageRestore'  => 'post_leapp' );
+    $self->run_component_once( 'MySQL'           => 'post_distro_upgrade' );
+    $self->run_component_once( 'PerlXS'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'PostgreSQL'      => 'post_distro_upgrade' );
+    $self->run_component_once( 'cPanelPlugins'   => 'post_distro_upgrade' );
+    $self->run_component_once( 'DatabaseUpgrade' => 'post_distro_upgrade' );
+    $self->run_component_once( 'PECL'            => 'post_distro_upgrade' );
+    $self->run_component_once( 'WPToolkit'       => 'post_distro_upgrade' );
+    $self->run_component_once( 'InfluxDB'        => 'post_distro_upgrade' );
+    $self->run_component_once( 'JetBackup'       => 'post_distro_upgrade' );
+    $self->run_component_once( 'Kernel'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'KernelCare'      => 'post_distro_upgrade' );
+    $self->run_component_once( 'NixStats'        => 'post_distro_upgrade' );
+    $self->run_component_once( 'LiteSpeed'       => 'post_distro_upgrade' );
+    $self->run_component_once( 'R1Soft'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'PackageRestore'  => 'post_distro_upgrade' );
 
     return;
 }

--- a/lib/Elevate/Components/AbsoluteSymlinks.pm
+++ b/lib/Elevate/Components/AbsoluteSymlinks.pm
@@ -28,7 +28,7 @@ sub get_abs_symlinks {
     return %links;
 }
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->ssystem(qw{/usr/bin/ln -snf usr/local/cpanel/scripts /scripts});
     $self->_absolute_symlinks;
@@ -59,7 +59,7 @@ sub _absolute_symlinks ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     return;
 }

--- a/lib/Elevate/Components/AutoSSL.pm
+++ b/lib/Elevate/Components/AutoSSL.pm
@@ -16,7 +16,7 @@ use Cpanel::SSL::Auto ();
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     if ( is_using_sectigo() ) {
         $self->ssystem_and_die(qw{/usr/local/cpanel/scripts/autorepair set_autossl_to_lets_encrypt});
@@ -25,7 +25,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     # Nothing to do
     return;

--- a/lib/Elevate/Components/CCS.pm
+++ b/lib/Elevate/Components/CCS.pm
@@ -6,10 +6,10 @@ package Elevate::Components::CCS;
 
 Elevate::Components::CCS
 
-pre_leapp: Export CCS data to a root owned backup directory and remove CCS
+pre_distro_upgrade: Export CCS data to a root owned backup directory and remove CCS
            package
 
-post_leapp: Install CCS package and import the backups taken during pre_leapp
+post_distro_upgrade: Install CCS package and import the backups taken during pre_distro_upgrade
 
 =cut
 
@@ -43,7 +43,7 @@ use constant DUMP_TYPES => (
     contacts  => 'vcard',
 );
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
     my $ccs_installed = Cpanel::Pkgr::is_installed(CCS_PACKAGE);
     Elevate::StageFile::update_stage_file( { ccs_installed => $ccs_installed } );
     return unless $ccs_installed;
@@ -269,10 +269,10 @@ sub _ensure_export_directory ($self) {
 }
 
 ####################################
-##### post_leapp code below this ###
+##### post_distro_upgrade code below this ###
 ####################################
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
     return unless Elevate::StageFile::read_stage_file('ccs_installed');
 
     $self->run_once('move_pgsql_directory');

--- a/lib/Elevate/Components/DatabaseUpgrade.pm
+++ b/lib/Elevate/Components/DatabaseUpgrade.pm
@@ -31,7 +31,7 @@ use constant MYSQL_PROFILE_FILE => '/var/cpanel/elevate-mysql-profile';
 
 use Log::Log4perl qw(:easy);
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     # We don't auto-upgrade the database if provided by cloudlinux
     return if Elevate::Database::is_database_provided_by_cloudlinux();
@@ -46,7 +46,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
     return unless -e MYSQL_PROFILE_FILE;
 
     my $original_profile = File::Slurper::read_text(MYSQL_PROFILE_FILE) // 'localhost';

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -29,12 +29,12 @@ sub pre_imunify ($self) {
     return;
 }
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
     $self->run_once('_cleanup_rpm_db');
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->run_once('_restore_ea4_profile');
     $self->run_once('_restore_ea_addons');

--- a/lib/Elevate/Components/ELS.pm
+++ b/lib/Elevate/Components/ELS.pm
@@ -21,7 +21,7 @@ use parent qw{Elevate::Components::Base};
 
 use constant ELS_PACKAGE => 'els-define';
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     return unless Elevate::OS::remove_els();
 
@@ -41,7 +41,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     # Nothing to do
     return;

--- a/lib/Elevate/Components/Grub2.pm
+++ b/lib/Elevate/Components/Grub2.pm
@@ -146,7 +146,7 @@ EOS
     return;
 }
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once('_update_grub2_workaround_if_needed');    # required part
     $self->run_once('_merge_grub_directories_if_needed');     # best-effort part
@@ -246,7 +246,7 @@ sub _merge_grub_directories_if_needed ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     # for an autofixer
     # return unless -e q[/var/cpanel/version/elevate];

--- a/lib/Elevate/Components/Imunify.pm
+++ b/lib/Elevate/Components/Imunify.pm
@@ -33,7 +33,7 @@ use constant IMUNIFY_AGENT          => Elevate::Constants::IMUNIFY_AGENT;       
 use constant IMUNIFY_LICENSE_FILE   => '/var/imunify360/license.json';
 use constant IMUNIFY_LICENSE_BACKUP => Elevate::Constants::ELEVATE_BACKUP_DIR . '/imunify-backup-license.json';
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     return if Elevate::OS::leapp_can_handle_imunify();
 
@@ -46,7 +46,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     return if Elevate::OS::leapp_can_handle_imunify();
 

--- a/lib/Elevate/Components/InfluxDB.pm
+++ b/lib/Elevate/Components/InfluxDB.pm
@@ -21,7 +21,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     Elevate::StageFile::remove_from_stage_file('reinstall.influxdb');
 
@@ -33,7 +33,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     return unless Elevate::StageFile::read_stage_file('reinstall')->{'influxdb'};
 

--- a/lib/Elevate/Components/JetBackup.pm
+++ b/lib/Elevate/Components/JetBackup.pm
@@ -21,7 +21,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     Elevate::StageFile::remove_from_stage_file('reinstall.jetbackup');
 
@@ -50,7 +50,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     my $data = Elevate::StageFile::read_stage_file('reinstall')->{'jetbackup'};
     return unless ref $data && ref $data->{packages};

--- a/lib/Elevate/Components/Kernel.pm
+++ b/lib/Elevate/Components/Kernel.pm
@@ -19,14 +19,14 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     # nothing to do
 
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->run_once('_kernel_check');
 

--- a/lib/Elevate/Components/KernelCare.pm
+++ b/lib/Elevate/Components/KernelCare.pm
@@ -23,7 +23,7 @@ use Elevate::Fetch ();
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     return if Elevate::OS::leapp_can_handle_kernelcare();
 
@@ -32,7 +32,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     return if Elevate::OS::leapp_can_handle_kernelcare();
 

--- a/lib/Elevate/Components/LiteSpeed.pm
+++ b/lib/Elevate/Components/LiteSpeed.pm
@@ -20,7 +20,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     Elevate::StageFile::remove_from_stage_file('reinstall.litespeed');
 
@@ -42,7 +42,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     my $data = Elevate::StageFile::read_stage_file('reinstall')->{'litespeed'};
     return unless ref $data;

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -27,14 +27,14 @@ use parent qw{Elevate::Components::Base};
 
 my $cnf_file = '/etc/my.cnf';
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
     return if Elevate::Database::is_database_provided_by_cloudlinux();
 
     $self->run_once("_cleanup_mysql_packages");
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
     return if Elevate::Database::is_database_provided_by_cloudlinux();
 
     $self->run_once('_reinstall_mysql_packages');
@@ -131,7 +131,7 @@ sub _reinstall_mysql_packages {
     }
 
     # In case the pre elevate file causes issues for whatever reason
-    File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_leapp_orig" );
+    File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_distro_upgrade_orig" );
 
     # Try to restore any .rpmsave'd configs after we reinstall
     # It *should be here* given we put it there, so no need to do a -f/-s check
@@ -146,11 +146,11 @@ sub _reinstall_mysql_packages {
     DEBUG($restart_out);
     return if grep { $_ =~ m{mysql (?:re)?started successfully} } @restart_lines;
 
-    # The database server is not able to start with the pre_leapp version of
+    # The database server is not able to start with the pre_distro_upgrade version of
     # my.cnf in place.  Revert to the standard one that was created
-    # in the post_leapp restore
+    # in the post_distro_upgrade restore
     INFO('The database server failed to start.  Restoring my.cnf to default.');
-    File::Copy::copy( "$cnf_file.elevate_post_leapp_orig", $cnf_file );
+    File::Copy::copy( "$cnf_file.elevate_post_distro_upgrade_orig", $cnf_file );
 
     $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
     @restart_lines = split "\n", $restart_out;

--- a/lib/Elevate/Components/NICs.pm
+++ b/lib/Elevate/Components/NICs.pm
@@ -25,7 +25,7 @@ use constant ETH_FILE_PREFIX           => Elevate::Constants::ETH_FILE_PREFIX;
 use constant NIC_PREFIX                => q[cp];
 use constant PERSISTENT_NET_RULES_PATH => q[/etc/udev/rules.d/70-persistent-net.rules];
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->_rename_nics();
 
@@ -92,7 +92,7 @@ sub _rename_nics ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
     return;
 }
 

--- a/lib/Elevate/Components/NixStats.pm
+++ b/lib/Elevate/Components/NixStats.pm
@@ -23,14 +23,14 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once("_remove_nixstats");
 
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->run_once('_restore_nixstats');
 

--- a/lib/Elevate/Components/PECL.pm
+++ b/lib/Elevate/Components/PECL.pm
@@ -23,14 +23,14 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once("_backup_pecl_packages");
 
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->run_once('_check_pecl_packages');
 

--- a/lib/Elevate/Components/PackageRestore.pm
+++ b/lib/Elevate/Components/PackageRestore.pm
@@ -8,12 +8,12 @@ Elevate::Components::PackageRestore
 
 Handle restoring packages that get removed during elevate
 
-Before leapp:
+Before distro upgrade:
     Detect which packages in our list are installed and
     store our findings.
 
-After leapp:
-    Reinstall any packages detected pre-leapp
+After distro upgrade:
+    Reinstall any packages detected pre distro upgrade
 
 =cut
 
@@ -34,7 +34,7 @@ sub _get_packages_to_check () {
     };
 }
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     my @package_list = _get_packages_to_check();
     my @installed_packages;
@@ -56,7 +56,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     my $package_info = Elevate::StageFile::read_stage_file('packages_to_restore');
     return unless defined $package_info and ref $package_info eq 'HASH';

--- a/lib/Elevate/Components/Panopta.pm
+++ b/lib/Elevate/Components/Panopta.pm
@@ -8,7 +8,7 @@ Elevate::Components::Panopta
 
 Handle situation where the Panopta agent is installed
 
-Before leapp:
+Before distro upgrade:
     Uninstall the Panopta agent since it is deprecated and
     not compatible with Elevate
 
@@ -20,7 +20,7 @@ use Cpanel::Pkgr ();
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     if ( Cpanel::Pkgr::is_installed('panopta-agent') ) {
 
@@ -30,7 +30,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     return;
 }

--- a/lib/Elevate/Components/PerlXS.pm
+++ b/lib/Elevate/Components/PerlXS.pm
@@ -25,7 +25,7 @@ use parent qw{Elevate::Components::Base};
 
 use constant DISTRO_PERL_XS_PATH => '/usr/local/lib64/perl5';
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->purge_perl_xs(DISTRO_PERL_XS_PATH);
     $self->purge_perl_xs( $Config{'installsitearch'} );
@@ -33,7 +33,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->restore_perl_xs(DISTRO_PERL_XS_PATH);
     $self->restore_perl_xs( $Config{'installsitearch'} );

--- a/lib/Elevate/Components/PostgreSQL.pm
+++ b/lib/Elevate/Components/PostgreSQL.pm
@@ -47,7 +47,7 @@ sub _build_service ($self) {
 
 =cut
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
     if ( Cpanel::Pkgr::is_installed('postgresql-server') ) {
         $self->_store_postgresql_encoding_and_locale();
         $self->_disable_postgresql_service();
@@ -183,7 +183,7 @@ sub _backup_postgresql_datadir ($self) {
 
 =cut
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
     if ( Cpanel::Pkgr::is_installed('postgresql-server') ) {
         $self->_perform_config_workaround();
         $self->_perform_postgresql_upgrade();
@@ -249,7 +249,7 @@ sub _perform_config_workaround ($self) {
 =item _perform_postgresql_upgrade
 
 Performs the upgrade using the EL-provided C<postgresql-setup --upgrade>
-script. If encoding and locale data were collected in the pre-leapp phase, use
+script. If encoding and locale data were collected in the pre distro upgrade phase, use
 them here when provisioning the new cluster.
 
 =cut

--- a/lib/Elevate/Components/R1Soft.pm
+++ b/lib/Elevate/Components/R1Soft.pm
@@ -8,14 +8,14 @@ Elevate::Components::R1Soft
 
 Handle situation where the R1Soft backup agent is installed
 
-Before leapp:
+Before distro upgrade:
     Find out:
         Is the R1Soft agent installed?
         And, if so, is the R1Soft repo present and enabled?
     And, if the agent is installed, go ahead and remove it.
     (We'll need to reinstall it after the OS upgrade.)
 
-After leapp:
+After distro upgrade:
     If the agent had been installed:
         Re-install kernel-devel (needed by the agent install).
         Add the repo if it wasn't present.
@@ -37,7 +37,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     # Three pieces of information we wish to collect
     my $r1soft_agent_installed = 0;
@@ -79,7 +79,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     my $r1soft_info = Elevate::StageFile::read_stage_file('r1soft');
 

--- a/lib/Elevate/Components/Repositories.pm
+++ b/lib/Elevate/Components/Repositories.pm
@@ -23,7 +23,7 @@ use Log::Log4perl           qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once("_disable_yum_plugin_fastestmirror");
     $self->run_once("_disable_known_yum_repositories");

--- a/lib/Elevate/Components/RmMod.pm
+++ b/lib/Elevate/Components/RmMod.pm
@@ -20,7 +20,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once("_rmod_ln");
 

--- a/lib/Elevate/Components/RpmDB.pm
+++ b/lib/Elevate/Components/RpmDB.pm
@@ -35,7 +35,7 @@ use constant OBSOLETE_PACKAGES => (
     'yum-plugin-universal-hooks',
 );
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once("_cleanup_rpms");
 
@@ -62,7 +62,7 @@ sub _remove_obsolete_packages ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->run_once("_sysup");
 

--- a/lib/Elevate/Components/SSH.pm
+++ b/lib/Elevate/Components/SSH.pm
@@ -21,7 +21,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     my $sshd_config = q[/etc/ssh/sshd_config];
 
@@ -42,7 +42,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     # Nothing to do
     return;

--- a/lib/Elevate/Components/UnconvertedModules.pm
+++ b/lib/Elevate/Components/UnconvertedModules.pm
@@ -20,11 +20,11 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
     $self->run_once('_remove_leapp_packages');
     $self->run_once('_warn_about_other_modules_that_did_not_convert');
     return;

--- a/lib/Elevate/Components/WPToolkit.pm
+++ b/lib/Elevate/Components/WPToolkit.pm
@@ -23,14 +23,14 @@ use Log::Log4perl           qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     $self->run_once("_remove_wordpress_toolkit");
 
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     $self->run_once('_reinstall_wordpress_toolkit');
 

--- a/lib/Elevate/Components/cPanelPlugins.pm
+++ b/lib/Elevate/Components/cPanelPlugins.pm
@@ -20,7 +20,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     # Backup arch rpms which we're going to remove and are provided by yum.
     my @installed_arch_cpanel_plugins;
@@ -38,7 +38,7 @@ sub pre_leapp ($self) {
     return;
 }
 
-sub post_leapp ($self) {
+sub post_distro_upgrade ($self) {
 
     # Restore YUM arch plugins.
 

--- a/lib/Elevate/Components/cPanelPrep.pm
+++ b/lib/Elevate/Components/cPanelPrep.pm
@@ -6,7 +6,7 @@ package Elevate::Components::cPanelPrep;
 
 Elevate::Components::cPanelPrep
 
-Perform tasks to ensure cPanel is in a safe state to leapp.
+Perform tasks to ensure cPanel is in a safe state to upgrade the distro.
 
 =cut
 
@@ -26,7 +26,7 @@ use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};
 
-sub pre_leapp ($self) {
+sub pre_distro_upgrade ($self) {
 
     # Remove scripts/upcp and bin/backup to make sure they don't
     # end up running while ELevate is running.

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -154,7 +154,7 @@ A `--no-leapp` upgrade would look like:
 
 =item * This is when you would use your distro upgrade tool.
 
-=item * When you have completed upgrading your system to 8, simply remove `/waiting_for_distro_upgrade` and reboot the system into normal multi-user mode.
+=item * When you have completed upgrading your system, simply remove `/waiting_for_distro_upgrade` and reboot the system into normal multi-user mode.
 
 =back
 
@@ -964,21 +964,21 @@ sub run_stage_2 ($self) {
 
     # This needs to happen before the database upgrade because
     # it will remove the packages we want to detect
-    $self->run_component_once( 'PackageRestore' => 'pre_leapp' );
+    $self->run_component_once( 'PackageRestore' => 'pre_distro_upgrade' );
 
     # This needs to execute before we disable cPanel services
     # or exporting the CCS data will fail
-    $self->run_component_once( 'CCS'             => 'pre_leapp' );
-    $self->run_component_once( 'DatabaseUpgrade' => 'pre_leapp' );
+    $self->run_component_once( 'CCS'             => 'pre_distro_upgrade' );
+    $self->run_component_once( 'DatabaseUpgrade' => 'pre_distro_upgrade' );
 
     # This disable cPanel services
-    $self->run_component_once( 'cPanelPrep' => 'pre_leapp' );
+    $self->run_component_once( 'cPanelPrep' => 'pre_distro_upgrade' );
 
-    $self->run_component_once( 'SSH'        => 'pre_leapp' );
-    $self->run_component_once( 'AutoSSL'    => 'pre_leapp' );
-    $self->run_component_once( 'KernelCare' => 'pre_leapp' );
-    $self->run_component_once( 'Grub2'      => 'pre_leapp' );
-    $self->run_component_once( 'NICs'       => 'pre_leapp' );
+    $self->run_component_once( 'SSH'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'AutoSSL'    => 'pre_distro_upgrade' );
+    $self->run_component_once( 'KernelCare' => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Grub2'      => 'pre_distro_upgrade' );
+    $self->run_component_once( 'NICs'       => 'pre_distro_upgrade' );
 
     # Imunify depends on EA4 so the Imunify component needs to
     # run before EA4 is removed.  However, Imunify 360 can provide
@@ -987,9 +987,9 @@ sub run_stage_2 ($self) {
     # to be executed before Imunify and left the removal until
     # after Imunify
     $self->run_component_once( 'EA4'     => 'pre_imunify' );
-    $self->run_component_once( 'Imunify' => 'pre_leapp' );
-    $self->run_component_once( 'PECL'    => 'pre_leapp' );
-    $self->run_component_once( 'EA4'     => 'pre_leapp' );
+    $self->run_component_once( 'Imunify' => 'pre_distro_upgrade' );
+    $self->run_component_once( 'PECL'    => 'pre_distro_upgrade' );
+    $self->run_component_once( 'EA4'     => 'pre_distro_upgrade' );
 
     # This reboot will invalidate the cPanel license causing
     # further whmapi1 calls to fail until stage 4
@@ -1014,7 +1014,7 @@ some conflicting packages.
 
 sub run_stage_3 ($self) {
 
-    $self->run_once('run_final_components_pre_leapp');
+    $self->run_once('run_final_components_pre_distro_upgrade');
 
     if ( !$self->should_run_leapp() ) {
         return $self->_request_to_upgrade_distro_manually();
@@ -1108,7 +1108,7 @@ sub run_stage_4 ($self) {
 
     $stash->{stage4} //= {};    # run once each blocks
 
-    $self->run_component_once( 'RpmDB', => 'post_leapp' );
+    $self->run_component_once( 'RpmDB', => 'post_distro_upgrade' );
 
     $self->run_once(
         restore_cpanel_services => sub {
@@ -1120,8 +1120,8 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->run_component_once( 'Imunify' => 'post_leapp' );
-    $self->run_component_once( 'EA4'     => 'post_leapp' );
+    $self->run_component_once( 'Imunify' => 'post_distro_upgrade' );
+    $self->run_component_once( 'EA4'     => 'post_distro_upgrade' );
 
     $self->run_once(
         upcp => sub {
@@ -1140,9 +1140,9 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->post_leapp_update_restore();
+    $self->post_distro_upgrade_update_restore();
 
-    $self->run_component_once( 'UnconvertedModules' => 'post_leapp' );
+    $self->run_component_once( 'UnconvertedModules' => 'post_distro_upgrade' );
 
     # run upcp a second time as we had to run it before with CPANEL_BASE_INSTALL=1
     $self->run_once(
@@ -1151,7 +1151,7 @@ sub run_stage_4 ($self) {
         }
     );
 
-    $self->run_component_once( 'CCS' => 'post_leapp' );
+    $self->run_component_once( 'CCS' => 'post_distro_upgrade' );
 
     return ACTION_REBOOT_NEEDED;
 }
@@ -1173,7 +1173,7 @@ sub run_stage_5 ($self) {
     my $el_backup_dir = Elevate::Constants::ELEVATE_BACKUP_DIR;
     File::Path::remove_tree($el_backup_dir) if -d $el_backup_dir;
 
-    $self->run_component_once( 'Grub2' => 'post_leapp' );
+    $self->run_component_once( 'Grub2' => 'post_distro_upgrade' );
 
     Elevate::Marker::success();
 
@@ -1322,30 +1322,30 @@ sub stop_services_before_upcp ($self) {
 }
 
 # remove and store
-sub run_final_components_pre_leapp ($self) {
+sub run_final_components_pre_distro_upgrade ($self) {
 
     # order matters
-    $self->run_component_once( 'RmMod'            => 'pre_leapp' );
-    $self->run_component_once( 'MySQL'            => 'pre_leapp' );
-    $self->run_component_once( 'PostgreSQL'       => 'pre_leapp' );
-    $self->run_component_once( 'Repositories'     => 'pre_leapp' );
-    $self->run_component_once( 'cPanelPlugins'    => 'pre_leapp' );
-    $self->run_component_once( 'PerlXS'           => 'pre_leapp' );
-    $self->run_component_once( 'WPToolkit'        => 'pre_leapp' );
-    $self->run_component_once( 'InfluxDB'         => 'pre_leapp' );
-    $self->run_component_once( 'JetBackup'        => 'pre_leapp' );
-    $self->run_component_once( 'NixStats'         => 'pre_leapp' );
-    $self->run_component_once( 'LiteSpeed'        => 'pre_leapp' );
-    $self->run_component_once( 'AbsoluteSymlinks' => 'pre_leapp' );
-    $self->run_component_once( 'ELS'              => 'pre_leapp' );
-    $self->run_component_once( 'R1Soft'           => 'pre_leapp' );
-    $self->run_component_once( 'Panopta'          => 'pre_leapp' );
-    $self->run_component_once( 'RpmDB'            => 'pre_leapp' );    # remove the RPMs last
+    $self->run_component_once( 'RmMod'            => 'pre_distro_upgrade' );
+    $self->run_component_once( 'MySQL'            => 'pre_distro_upgrade' );
+    $self->run_component_once( 'PostgreSQL'       => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Repositories'     => 'pre_distro_upgrade' );
+    $self->run_component_once( 'cPanelPlugins'    => 'pre_distro_upgrade' );
+    $self->run_component_once( 'PerlXS'           => 'pre_distro_upgrade' );
+    $self->run_component_once( 'WPToolkit'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'InfluxDB'         => 'pre_distro_upgrade' );
+    $self->run_component_once( 'JetBackup'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'NixStats'         => 'pre_distro_upgrade' );
+    $self->run_component_once( 'LiteSpeed'        => 'pre_distro_upgrade' );
+    $self->run_component_once( 'AbsoluteSymlinks' => 'pre_distro_upgrade' );
+    $self->run_component_once( 'ELS'              => 'pre_distro_upgrade' );
+    $self->run_component_once( 'R1Soft'           => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Panopta'          => 'pre_distro_upgrade' );
+    $self->run_component_once( 'RpmDB'            => 'pre_distro_upgrade' );    # remove the RPMs last
 
     return;
 }
 
-sub post_leapp_update_restore ($self) {
+sub post_distro_upgrade_update_restore ($self) {
 
     INFO('Removing leapp from excludes in /etc/yum.conf');
     my $txt = eval { File::Slurper::read_text("/etc/yum.conf") };
@@ -1355,21 +1355,21 @@ sub post_leapp_update_restore ($self) {
     }
 
     # plugins can use MySQL - restore database earlier
-    $self->run_component_once( 'MySQL'           => 'post_leapp' );
-    $self->run_component_once( 'PerlXS'          => 'post_leapp' );
-    $self->run_component_once( 'PostgreSQL'      => 'post_leapp' );
-    $self->run_component_once( 'cPanelPlugins'   => 'post_leapp' );
-    $self->run_component_once( 'DatabaseUpgrade' => 'post_leapp' );
-    $self->run_component_once( 'PECL'            => 'post_leapp' );
-    $self->run_component_once( 'WPToolkit'       => 'post_leapp' );
-    $self->run_component_once( 'InfluxDB'        => 'post_leapp' );
-    $self->run_component_once( 'JetBackup'       => 'post_leapp' );
-    $self->run_component_once( 'Kernel'          => 'post_leapp' );
-    $self->run_component_once( 'KernelCare'      => 'post_leapp' );
-    $self->run_component_once( 'NixStats'        => 'post_leapp' );
-    $self->run_component_once( 'LiteSpeed'       => 'post_leapp' );
-    $self->run_component_once( 'R1Soft'          => 'post_leapp' );
-    $self->run_component_once( 'PackageRestore'  => 'post_leapp' );
+    $self->run_component_once( 'MySQL'           => 'post_distro_upgrade' );
+    $self->run_component_once( 'PerlXS'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'PostgreSQL'      => 'post_distro_upgrade' );
+    $self->run_component_once( 'cPanelPlugins'   => 'post_distro_upgrade' );
+    $self->run_component_once( 'DatabaseUpgrade' => 'post_distro_upgrade' );
+    $self->run_component_once( 'PECL'            => 'post_distro_upgrade' );
+    $self->run_component_once( 'WPToolkit'       => 'post_distro_upgrade' );
+    $self->run_component_once( 'InfluxDB'        => 'post_distro_upgrade' );
+    $self->run_component_once( 'JetBackup'       => 'post_distro_upgrade' );
+    $self->run_component_once( 'Kernel'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'KernelCare'      => 'post_distro_upgrade' );
+    $self->run_component_once( 'NixStats'        => 'post_distro_upgrade' );
+    $self->run_component_once( 'LiteSpeed'       => 'post_distro_upgrade' );
+    $self->run_component_once( 'R1Soft'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'PackageRestore'  => 'post_distro_upgrade' );
 
     return;
 }

--- a/t/check_and_fix_grub.t
+++ b/t/check_and_fix_grub.t
@@ -35,7 +35,7 @@ subtest "check_and_fix_grub kernel using net.ifnames=0" => sub {
     BOOT_IMAGE=(hd0,msdos1)/boot/vmlinuz-4.18.0-425.10.1.el8_7.x86_64 root=UUID=6cd50e51-cfc6-40b9-9ec5-f32fa2e4ff02 ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0 crashkernel=no nosplash nomodeset rootflags=uquota net.ifnames=0
     EOS
 
-    ok !$g2->post_leapp(), "grub file is missing";
+    ok !$g2->post_distro_upgrade(), "grub file is missing";
 
     $grub_cfg->contents( <<~'EOS' );
     GRUB_TIMEOUT=5
@@ -64,7 +64,7 @@ subtest "check_and_fix_grub kernel using net.ifnames=0" => sub {
         }
     );
 
-    ok $g2->post_leapp(), "check_and_fix_grub need to fixup grub config";
+    ok $g2->post_distro_upgrade(), "check_and_fix_grub need to fixup grub config";
 
     is $grub_cfg->contents(), <<~'EOS', "file is fixed";
     GRUB_TIMEOUT=5
@@ -79,7 +79,7 @@ subtest "check_and_fix_grub kernel using net.ifnames=0" => sub {
 
     like $grubenv, qr/^kernelopts=root=UUID=6cd50e51-cfc6-40b9-9ec5-f32fa2e4ff02 ro console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0 crashkernel=no nosplash nomodeset rootflags=uquota net\.ifnames=0\s*$/ma, "GRUB environment variable set correctly";
 
-    ok !$g2->post_leapp(), "do not fix it twice";
+    ok !$g2->post_distro_upgrade(), "do not fix it twice";
 
     return;
 };
@@ -102,11 +102,11 @@ subtest "check_and_fix_grub kernel without net.ifnames=0" => sub {
     GRUB_ENABLE_BLSCFG=true
     EOS
 
-    ok !$g2->post_leapp(), "no need to fix when current kernel does not use net.ifnames=0";
+    ok !$g2->post_distro_upgrade(), "no need to fix when current kernel does not use net.ifnames=0";
 
     $cmdline->contents("whatever");
 
-    ok !$g2->post_leapp(), "no need to fix when current kernel does not use net.ifnames=0";
+    ok !$g2->post_distro_upgrade(), "no need to fix when current kernel does not use net.ifnames=0";
 
     return;
 };

--- a/t/components-AbsoluteSymlink.t
+++ b/t/components-AbsoluteSymlink.t
@@ -26,7 +26,7 @@ my %cabinet;
 $cabinet{'/smang'} = Test::MockFile->symlink( "/home", "/smang" );
 
 my $obj = bless {}, 'Elevate::Components::AbsoluteSymlinks';
-ok( !$obj->post_leapp(), "Nothing to do post leapp" );
+ok( !$obj->post_distro_upgrade(), "Nothing to do post distro upgrade" );
 is( { $obj->get_abs_symlinks() }, { '/smang' => '/home' }, "Got expected from get_abs_symlinks" );
 SKIP: {
     skip "Test::MockFile doesn't yet properly handle symlinks", 1;
@@ -49,7 +49,7 @@ SKIP: {
     # in perl react properly to the existence of Test::MockModule->symlink objects
     # As it stands, this makes the symlink then bombs out with
     # 'readlink is only supported for symlinks'.
-    $obj->pre_leapp();
-    is( readlink("/smang"), 'home', "Symlink corrected by pre_leapp" );
+    $obj->pre_distro_upgrade();
+    is( readlink("/smang"), 'home', "Symlink corrected by pre_distro_upgrade" );
 }
 done_testing();

--- a/t/components-AutoSSL.t
+++ b/t/components-AutoSSL.t
@@ -24,7 +24,7 @@ use cPstrict;
 my $auto_ssl = bless {}, 'Elevate::Components::AutoSSL';
 
 {
-    note "Checking pre_leapp";
+    note "Checking pre_distro_upgrade";
 
     my $is_using_sectigo       = 0;
     my @ssystem_and_die_params = ();
@@ -39,11 +39,11 @@ my $auto_ssl = bless {}, 'Elevate::Components::AutoSSL';
         is_using_sectigo => sub { return $is_using_sectigo; },
     );
 
-    $auto_ssl->pre_leapp();
+    $auto_ssl->pre_distro_upgrade();
     is( \@ssystem_and_die_params, [], 'Autorepair is NOT invoked when NOT using Sectigo' );
 
     $is_using_sectigo = 1;
-    $auto_ssl->pre_leapp();
+    $auto_ssl->pre_distro_upgrade();
     is(
         \@ssystem_and_die_params,
         [qw{/usr/local/cpanel/scripts/autorepair set_autossl_to_lets_encrypt}],

--- a/t/components-CCS.t
+++ b/t/components-CCS.t
@@ -27,7 +27,7 @@ my $mock_ccs       = Test::MockModule->new('Elevate::Components::CCS');
 my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
 
 {
-    note "Checking pre_leapp";
+    note "Checking pre_distro_upgrade";
 
     my $installed = 0;
 
@@ -57,8 +57,8 @@ my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
         },
     );
 
-    is( $ccs->pre_leapp(),         undef, 'pre_leapp is basically a noop if CCS is not installed' );
-    is( $called__load_ccs_modules, 0,     'pre_leapp returned before loading CCS modules when CCS was not installed' );
+    is( $ccs->pre_distro_upgrade(), undef, 'pre_distro_upgrade is basically a noop if CCS is not installed' );
+    is( $called__load_ccs_modules,  0,     'pre_distro_upgrade returned before loading CCS modules when CCS was not installed' );
 
     my @cpusers                  = qw{ foo bar baz };
     my $mock_cpanel_config_users = Test::MockModule->new('Cpanel::Config::Users');
@@ -68,7 +68,7 @@ my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
 
     $installed = 1;
 
-    $ccs->pre_leapp();
+    $ccs->pre_distro_upgrade();
     is( $called__load_ccs_modules, 1, '_load_ccs_modules is called when CCS is installed' );
 
     message_seen( 'INFO', qr/^Exporting CCS data to/ );
@@ -93,7 +93,7 @@ my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
 }
 
 {
-    note "Checking post_leapp";
+    note "Checking post_distro_upgrade";
 
     my $installed = 0;
     $mock_stagefile->redefine(
@@ -120,8 +120,8 @@ my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
         _import_data_for_single_user => sub ( $self, $user ) { push @called_for_user, $user; },
     );
 
-    is( $ccs->post_leapp(),      undef, 'post_leapp is a noop if CCS was not installed' );
-    is( $ssystem_and_die_params, [],    'No system commands were called when CCS was not installed' );
+    is( $ccs->post_distro_upgrade(), undef, 'post_distro_upgrade is a noop if CCS was not installed' );
+    is( $ssystem_and_die_params,     [],    'No system commands were called when CCS was not installed' );
 
     my @cpusers;
     my $mock_cpanel_config_users = Test::MockModule->new('Cpanel::Config::Users');
@@ -131,7 +131,7 @@ my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
 
     $installed = 1;
 
-    $ccs->post_leapp();
+    $ccs->post_distro_upgrade();
 
     message_seen( 'INFO', 'Importing CCS data' );
 
@@ -141,7 +141,7 @@ my $mock_stagefile = Test::MockModule->new('Elevate::StageFile');
             qw{/usr/bin/dnf -y install cpanel-ccs-calendarserver cpanel-z-push},
             qw{/usr/local/cpanel/bin/servers_queue run},
         ],
-        'The expected commands are called during post_leapp when CCS was installed',
+        'The expected commands are called during post_distro_upgrade when CCS was installed',
     );
 
     is( \@called_for_user, \@cpusers, 'CCS data was imported for the expected users' );

--- a/t/components-DatabaseUpgrade.t
+++ b/t/components-DatabaseUpgrade.t
@@ -26,7 +26,7 @@ use constant PROFILE_FILE => Elevate::Components::DatabaseUpgrade::MYSQL_PROFILE
 my $db_upgrade = bless {}, 'Elevate::Components::DatabaseUpgrade';
 
 {
-    note('Checking pre_leapp');
+    note('Checking pre_distro_upgrade');
 
     my $mock_elevate_database = Test::MockModule->new('Elevate::Database');
     $mock_elevate_database->redefine(
@@ -47,14 +47,14 @@ my $db_upgrade = bless {}, 'Elevate::Components::DatabaseUpgrade';
         }
     );
 
-    $db_upgrade->pre_leapp();
+    $db_upgrade->pre_distro_upgrade();
     is \@_ensure_localhost_mysql_profile_is_active_params, [1], '_ensure_localhost_mysql_profile_is_active was called with correct params';
 
     clear_messages_seen();
 }
 
 {
-    note('Checking post_leapp');
+    note('Checking post_distro_upgrade');
 
     my @cmds;
     my @stdout;
@@ -68,12 +68,12 @@ my $db_upgrade = bless {}, 'Elevate::Components::DatabaseUpgrade';
     );
 
     my $mock_profile_file = Test::MockFile->file(PROFILE_FILE);
-    $db_upgrade->post_leapp();
+    $db_upgrade->post_distro_upgrade();
     no_messages_seen();
 
     $mock_profile_file->contents('original-db-profile-name');
     like(
-        dies { $db_upgrade->post_leapp() },
+        dies { $db_upgrade->post_distro_upgrade() },
         qr/Unable to reactivate/,
         'Died as expected when profile activation done is not seen'
     );
@@ -93,7 +93,7 @@ my $db_upgrade = bless {}, 'Elevate::Components::DatabaseUpgrade';
     ok -e PROFILE_FILE, 'profile file still exists after failed reactivation';
 
     @stdout = ('MySQL profile activation done');
-    $db_upgrade->post_leapp();
+    $db_upgrade->post_distro_upgrade();
     message_seen( 'INFO', 'Reactivating "original-db-profile-name" MySQL profile' );
     is \@cmds, [
         [

--- a/t/components-NICs.t
+++ b/t/components-NICs.t
@@ -25,7 +25,7 @@ use cPstrict;
 my $nics = bless {}, 'Elevate::Components::NICs';
 
 {
-    note "checking pre_leapp";
+    note "checking pre_distro_upgrade";
 
     my $mock_nics = Test::MockModule->new('Elevate::NICs');
     $mock_nics->redefine(

--- a/t/components-PackageRestore.t
+++ b/t/components-PackageRestore.t
@@ -24,7 +24,7 @@ use cPstrict;
 my $pkg_restore = cpev->new->component('PackageRestore');
 
 {
-    note "Checking pre_leapp";
+    note "Checking pre_distro_upgrade";
 
     my $stage_file_data;
     my @pkgs_to_check  = qw{ foo bar baz };
@@ -62,7 +62,7 @@ my $pkg_restore = cpev->new->component('PackageRestore');
         update_stage_file => sub { $stage_file_data = shift; },
     );
 
-    $pkg_restore->pre_leapp();
+    $pkg_restore->pre_distro_upgrade();
 
     is(
         [ sort @$pkgs_checked_for_config_files ],
@@ -78,7 +78,7 @@ my $pkg_restore = cpev->new->component('PackageRestore');
 }
 
 {
-    note "Checking post_leapp";
+    note "Checking post_distro_upgrade";
 
     my $stage_file_data = {
         foo => [qw{ myfile1 myfile2 }],
@@ -106,7 +106,7 @@ my $pkg_restore = cpev->new->component('PackageRestore');
         },
     );
 
-    $pkg_restore->post_leapp();
+    $pkg_restore->post_distro_upgrade();
 
     is(
         [ sort @dnf_installed ],

--- a/t/components-PostgreSQL.t
+++ b/t/components-PostgreSQL.t
@@ -53,7 +53,7 @@ $mock_pkgr->redefine(
 );
 
 {
-    note "Checking pre_leapp";
+    note "Checking pre_distro_upgrade";
 
     $installed = 0;
     $mock_pgsql->redefine(
@@ -61,14 +61,14 @@ $mock_pkgr->redefine(
             $_ => sub { die "shouldn't run" }
         } PRE_LEAPP_METHODS->@*
     );
-    ok( lives { $comp_pgsql->pre_leapp() }, "Nothing is run if postgresql-server is not installed" );
+    ok( lives { $comp_pgsql->pre_distro_upgrade() }, "Nothing is run if postgresql-server is not installed" );
     $mock_pgsql->unmock( PRE_LEAPP_METHODS->@* );
 
     $installed = 1;
 }
 
 {
-    note "Checking post_leapp";
+    note "Checking post_distro_upgrade";
 
     $installed = 0;
     $mock_pgsql->redefine(
@@ -76,7 +76,7 @@ $mock_pkgr->redefine(
             $_ => sub { die "shouldn't run" }
         } POST_LEAPP_METHODS->@*
     );
-    ok( lives { $comp_pgsql->post_leapp() }, "Nothing is run if postgresql-server is not installed" );
+    ok( lives { $comp_pgsql->post_distro_upgrade() }, "Nothing is run if postgresql-server is not installed" );
     $mock_pgsql->unmock( POST_LEAPP_METHODS->@* );
 
     $installed = 1;

--- a/t/components-R1Soft.t
+++ b/t/components-R1Soft.t
@@ -24,7 +24,7 @@ use cPstrict;
 my $r1soft = cpev->new->component('R1Soft');
 
 {
-    note "Checking pre_leapp";
+    note "Checking pre_distro_upgrade";
 
     my $stage_file_data;
     my $is_installed;
@@ -89,7 +89,7 @@ my $r1soft = cpev->new->component('R1Soft');
     $is_installed      = 0;
     $yum_remove_called = 0;
 
-    $r1soft->pre_leapp();
+    $r1soft->pre_distro_upgrade();
     is( $yum_remove_called, 0, 'Yum remove was not invoked when agent not installed' );
     is(
         $stage_file_data,
@@ -107,7 +107,7 @@ my $r1soft = cpev->new->component('R1Soft');
     $is_installed      = 1;
     $yum_remove_called = 0;
 
-    $r1soft->pre_leapp();
+    $r1soft->pre_distro_upgrade();
     is( $yum_remove_called, 1, 'Yum remove called when agent is installed' );
     is(
         $stage_file_data,
@@ -125,7 +125,7 @@ my $r1soft = cpev->new->component('R1Soft');
     $yum_remove_called = 0;
     @enabled_repos     = grep { !/^r1soft/ } @enabled_repos;
 
-    $r1soft->pre_leapp();
+    $r1soft->pre_distro_upgrade();
     is( $yum_remove_called, 1, 'Yum remove called when agent is installed' );
     is(
         $stage_file_data,
@@ -143,7 +143,7 @@ my $r1soft = cpev->new->component('R1Soft');
     $yum_remove_called = 0;
     @all_repos         = grep { !/^r1soft/ } @all_repos;
 
-    $r1soft->pre_leapp();
+    $r1soft->pre_distro_upgrade();
     is( $yum_remove_called, 1, 'Yum remove called when agent is installed' );
     is(
         $stage_file_data,
@@ -159,7 +159,7 @@ my $r1soft = cpev->new->component('R1Soft');
 }
 
 {
-    note "Checking post_leapp";
+    note "Checking post_distro_upgrade";
 
     my $stage_file_data;
     my $yum_install_called;
@@ -192,7 +192,7 @@ my $r1soft = cpev->new->component('R1Soft');
     };
     ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
 
-    $r1soft->post_leapp();
+    $r1soft->post_distro_upgrade();
     is( $yum_install_called,  0, 'Yum install not called when agent was not installed' );
     is( $create_repo_called,  0, 'Create repo not called when agent was not installed' );
     is( $enable_repo_called,  0, 'Enable repo not called when agent was not installed' );
@@ -206,7 +206,7 @@ my $r1soft = cpev->new->component('R1Soft');
     };
     ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
 
-    $r1soft->post_leapp();
+    $r1soft->post_distro_upgrade();
     is( $yum_install_called,  1, 'Yum install called when agent was installed' );
     is( $create_repo_called,  0, 'Create repo not called when repo present' );
     is( $enable_repo_called,  0, 'Enable repo not called when repo already enabled' );
@@ -220,7 +220,7 @@ my $r1soft = cpev->new->component('R1Soft');
     };
     ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
 
-    $r1soft->post_leapp();
+    $r1soft->post_distro_upgrade();
     is( $yum_install_called,  1, 'Yum install called when agent was installed' );
     is( $create_repo_called,  0, 'Create repo not called when repo present' );
     is( $enable_repo_called,  1, 'Enable repo called when repo not already enabled' );
@@ -234,7 +234,7 @@ my $r1soft = cpev->new->component('R1Soft');
     };
     ( $yum_install_called, $create_repo_called, $enable_repo_called, $disable_repo_called ) = ( 0, 0, 0, 0 );
 
-    $r1soft->post_leapp();
+    $r1soft->post_distro_upgrade();
     is( $yum_install_called,  1, 'Yum install called when agent was installed' );
     is( $create_repo_called,  1, 'Create repo called when repo not present' );
     is( $enable_repo_called,  0, 'Enable repo not called when repo not present' );

--- a/t/components-SSH.t
+++ b/t/components-SSH.t
@@ -25,42 +25,42 @@ use cPstrict;
 my $ssh = bless {}, 'Elevate::Components::SSH';
 
 {
-    note "checking pre_leapp";
+    note "checking pre_distro_upgrade";
 
     my $mock_sshd_cfg = Test::MockFile->file(q[/etc/ssh/sshd_config]);
 
     $mock_sshd_cfg->contents('');
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), "PermitRootLogin yes\n", 'Added PermitRootLogin to empty config';
 
     my $pre_contents = "PasswordAuthentication no\nUseDNS no\nDenyGroups cpaneldemo\n";
     $mock_sshd_cfg->contents($pre_contents);
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), $pre_contents . "PermitRootLogin yes\n", 'Added PermitRootLogin when ommited, trailing newline';
 
     $pre_contents = "PasswordAuthentication no\nUseDNS no\nDenyGroups cpaneldemo";
     $mock_sshd_cfg->contents($pre_contents);
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), $pre_contents . "\nPermitRootLogin yes\n", 'Added PermitRootLogin when ommited, no trailing newline';
 
     $pre_contents = "PasswordAuthentication no\nPermitRootLogin yes\nUseDNS no\nDenyGroups cpaneldemo";
     $mock_sshd_cfg->contents($pre_contents);
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), $pre_contents, 'Contents unchanged when PermitRootLogin present and active';
 
     $pre_contents = "PermitRootLogin no\nPasswordAuthentication no\nUseDNS no\nDenyGroups cpaneldemo\n";
     $mock_sshd_cfg->contents($pre_contents);
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), $pre_contents, 'Contents unchanged when PermitRootLogin present and active';
 
     $pre_contents = "PasswordAuthentication no\n#PermitRootLogin yes\nUseDNS no\nDenyGroups cpaneldemo";
     $mock_sshd_cfg->contents($pre_contents);
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), $pre_contents . "\nPermitRootLogin yes\n", 'Contents updated when PermitRootLogin present but commented out';
 
     $pre_contents = "# PermitRootLogin no\nPasswordAuthentication no\nUseDNS no\nDenyGroups cpaneldemo\n";
     $mock_sshd_cfg->contents($pre_contents);
-    $ssh->pre_leapp();
+    $ssh->pre_distro_upgrade();
     is $mock_sshd_cfg->contents(), $pre_contents . "PermitRootLogin yes\n", 'Contents updated when PermitRootLogin present but commented out';
 }
 

--- a/t/components-cPanelPrep.t
+++ b/t/components-cPanelPrep.t
@@ -25,7 +25,7 @@ use Elevate::Constants              ();
 my $cpanel_prep = bless {}, 'Elevate::Components::cPanelPrep';
 
 {
-    note "Checking pre_leapp";
+    note "Checking pre_distro_upgrade";
 
     my $mock_scripts_upcp = Test::MockFile->file('/usr/local/cpanel/scripts/upcp');
     my $mock_bin_backup   = Test::MockFile->file('/usr/local/cpanel/bin/backup');
@@ -40,7 +40,7 @@ my $cpanel_prep = bless {}, 'Elevate::Components::cPanelPrep';
         '_flush_task_queue'            => sub { $called{'_flush_task_queue'}            = 1 },
     );
 
-    $cpanel_prep->pre_leapp();
+    $cpanel_prep->pre_distro_upgrade();
 
     ok( $called{'_disable_all_cpanel_services'}, '_disable_all_cpanel_services() was called' );
     ok( $called{'_setup_outdated_services'},     '_setup_outdated_services() was called' );

--- a/t/grub2_workaround.t
+++ b/t/grub2_workaround.t
@@ -239,7 +239,7 @@ subtest 'Testing _merge_grub_directories_if_needed' => sub {
     my $cpev = cpev->new;
     my $g2   = $cpev->component('Grub2');
 
-    $g2->pre_leapp;
+    $g2->pre_distro_upgrade;
 
     is \@ran_once, [
         qw{


### PR DESCRIPTION
Case RE-696:

Since Ubuntu does not rely on leapp to perform distro upgrades, we should change our function names, variable names, etc. to refer to performing a distro upgrade rather than referring to leapp. (Except, of course, with code that actually does interact directly with leapp.)

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

