### PR TITLE
RE-699: Swap 'return 42' line to Carp::croak()

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -7661,7 +7661,7 @@ EOS
     sub _ssystem ( $command, %opts ) {
         my @args = @{ $command // [] };
 
-        return 42 if $args[0] !~ '^/' || !-x $args[0];
+        Carp::croak("Program is not an executable absolute path.") if $args[0] !~ '^/' || !-x $args[0];
 
         INFO( "Running: " . join( " ", @args ) );
         INFO();    # Buffer so they can more easily read the output.

--- a/lib/Elevate/Roles/Run.pm
+++ b/lib/Elevate/Roles/Run.pm
@@ -74,7 +74,7 @@ sub _ssystem ( $command, %opts ) {
     my @args = @{ $command // [] };
 
     # Only allow the program to be an executable absolute path
-    return 42 if $args[0] !~ '^/' || !-x $args[0];
+    Carp::croak("Program is not an executable absolute path.") if $args[0] !~ '^/' || !-x $args[0];
 
     INFO( "Running: " . join( " ", @args ) );
     INFO();    # Buffer so they can more easily read the output.

--- a/t/ssystem.t
+++ b/t/ssystem.t
@@ -28,10 +28,28 @@ my $mock_log_file = Test::MockFile->file('/var/log/elevate-cpanel.log');
 
 my $cpev = cpev->new->_init;
 
-is( cpev->ssystem('nope'), 42, q[ssystem( 'nope' ) is disallowed] );
-is( cpev->ssystem('grep'), 42, 'Commands that are not absolute paths are not allowed' );
+like(
+    dies { cpev->ssystem('nope') },
+    qr/Program is not an executable absolute path/,
+    'Program is not an executable path.'
+);
 
-is( cpev->ssystem('/etc/apache2/conf/httpd.conf'), 42, 'Commands that are not executable are not allowed' );
+like(
+    dies { cpev->ssystem('grep') },
+    qr/Program is not an executable absolute path/,
+    'Program is not an executable absolute path.'
+);
+
+like(
+    dies { cpev->ssystem('/etc/apache2/conf/httpd.conf') },
+    qr/Program is not an executable absolute path/,
+    'Paths that are not executable are not allowed.'
+);
+
+ok(
+    lives { cpev->ssystem('/bin/true') },
+    'Program is not an executable absolute path.'
+);
 
 is( cpev->ssystem("/bin/true"), 0, q[ssystem( "/bin/true" ) == 0] );
 isnt( my $status_false = cpev->ssystem("/bin/false"), 0, q[ssystem( "/bin/false" ) != 0] );


### PR DESCRIPTION
RE-699: die() instead of `return 42` within _ssystem().