### PR TITLE
Fix: Unable to elevate system while "cl7h" repository is active

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6457,7 +6457,8 @@ EOS
             qr/^cloudlinux-ea4-rollout(?:-[0-9]+)?$/,
             'cl-ea4',
             qr/^cl-mysql(?:-meta)?/,
-            'mysqclient', 'mysql-debuginfo'
+            'mysqclient', 'mysql-debuginfo',
+            'cl7h'
         );
 
         my @repos = $self->SUPER::vetted_yum_repo();


### PR DESCRIPTION
By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

