### PR TITLE
Case RE-851: Only run OpenStack GitHub Action when TestSuite Completes

### DIFF
--- a/.github/workflows/openstack.yml
+++ b/.github/workflows/openstack.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-openstack
   cancel-in-progress: true
 
 env:
@@ -32,7 +32,10 @@ env:
   tf_working_directory: "./.github/workflows/openstack/terraform"
 
 jobs: 
+    testsuite:
+      uses: ./.github/workflows/testsuite.yml
     terraform_openstack_create:
+        needs: [testsuite]
         runs-on: self-hosted
         defaults:
           run:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -9,6 +9,11 @@ on:
       - "*"
   pull_request:
   workflow_dispatch:
+  workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-testsuite
+  cancel-in-progress: true
 
 jobs:
   testsuite:


### PR DESCRIPTION
Case RE-851: Only run OpenStack GitHub Action when TestSuite Completes

Previously each workflow would run at the same time.
Now unit tests in testsuite will need to complete
prior to OpenStack's workflow starting.

Changelog: