### PR TITLE
Ensure Imunify upgrade is not executing before uninstalling it

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2797,15 +2797,25 @@ EOS
             return;
         };
 
-        INFO("Imunify360: Removing $product_type prior to upgrade.");
-        INFO("Imunify360: Product $product_type detected. Uninstalling before upgrade for later restore.");
-
         my $installer_script = _fetch_imunify_installer($product_type) or do {
             WARN("Imunify360: Failed to fetch script for $product_type. Skipping upgrade.");
             return;
         };
+
+        my $imunify_pid = Cpanel::LoadFile::load_if_exists('/var/lock/i360deploy.lck') || Cpanel::LoadFile::load_if_exists('/var/lock/imav-deploy.lck');
+        if ($imunify_pid) {
+            INFO("Waiting for Imunify update to complete before uninstalling it");
+            while ( kill 0, $imunify_pid ) {
+                sleep 1;
+            }
+            INFO("Imunify update has completed");
+        }
+
+        INFO("Imunify360: Removing $product_type prior to upgrade.");
+        INFO("Imunify360: Product $product_type detected. Uninstalling before upgrade for later restore.");
+
         if ( $self->ssystem( '/usr/bin/bash', $installer_script, '--uninstall' ) != 0 ) {
-            WARN("Imunify360: Failed to uninstall $product_type.");
+            LOGDIE("Imunify360: Failed to uninstall $product_type.");
             return;
         }
         unlink $installer_script;

--- a/lib/Elevate/Components/Imunify.pm
+++ b/lib/Elevate/Components/Imunify.pm
@@ -232,15 +232,29 @@ sub _remove_imunify_360 ($self) {
         return;
     };
 
-    INFO("Imunify360: Removing $product_type prior to upgrade.");
-    INFO("Imunify360: Product $product_type detected. Uninstalling before upgrade for later restore.");
-
     my $installer_script = _fetch_imunify_installer($product_type) or do {
         WARN("Imunify360: Failed to fetch script for $product_type. Skipping upgrade.");
         return;
     };
+
+    # Imunify can auto-update itself.  If this happens, it will
+    # put a lock file in place that will prevent the uninstall from
+    # succeeding.  Ensure it is not updating before attempting
+    # the uninstall
+    my $imunify_pid = Cpanel::LoadFile::load_if_exists('/var/lock/i360deploy.lck') || Cpanel::LoadFile::load_if_exists('/var/lock/imav-deploy.lck');
+    if ($imunify_pid) {
+        INFO("Waiting for Imunify update to complete before uninstalling it");
+        while ( kill 0, $imunify_pid ) {
+            sleep 1;
+        }
+        INFO("Imunify update has completed");
+    }
+
+    INFO("Imunify360: Removing $product_type prior to upgrade.");
+    INFO("Imunify360: Product $product_type detected. Uninstalling before upgrade for later restore.");
+
     if ( $self->ssystem( '/usr/bin/bash', $installer_script, '--uninstall' ) != 0 ) {
-        WARN("Imunify360: Failed to uninstall $product_type.");
+        LOGDIE("Imunify360: Failed to uninstall $product_type.");
         return;
     }
     unlink $installer_script;


### PR DESCRIPTION
Case RE-862: The Imunify products have the ability to auto update themselves which can trigger a lock file being in place that will prevent the Imunify installer(s) from executing.  This change makes it so that we check to see if the lock file exists and wait for the PID to complete before attempting to uninstall Imunify in the pre_distro_upgrade stage.

Changelog: Ensure Imunify upgrade is not executing before attempting to
 uninstall it

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

