### PR TITLE
Make sure website workflow only runs on elevate/main

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -6,6 +6,7 @@ name: website
 
 on:
   push:
+    if: github.repository == 'cpanel/elevate'
     branches:
     - main
   workflow_dispatch:


### PR DESCRIPTION
Case RE-880: Make sure website workflow only runs on elevate/main

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

