### PR TITLE
Use mv and cp from File::Copy instead of copy and move

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -572,8 +572,8 @@ BEGIN {    # Suppress load of all of these at earliest point.
             while ( -e "$link-$rand_uid" && $tries++ < 10000 ) {
                 $rand_uid = Cpanel::UUID::random_uuid();
             }
-            symlink( $updated, "$link-$rand_uid" )       or die "Can't create symlink $link-$rand_uid to $updated: $!";
-            File::Copy::move( "$link-$rand_uid", $link ) or die "Can't overwite $link: $!";
+            symlink( $updated, "$link-$rand_uid" )     or die "Can't create symlink $link-$rand_uid to $updated: $!";
+            File::Copy::mv( "$link-$rand_uid", $link ) or die "Can't overwite $link: $!";
         }
         return;
     }
@@ -2676,7 +2676,7 @@ EOS
         } grep { m/\S/ } split( "\n", $output );
 
         if ( -f IMUNIFY_LICENSE_FILE ) {
-            File::Copy::move( IMUNIFY_LICENSE_FILE, IMUNIFY_LICENSE_BACKUP );
+            File::Copy::mv( IMUNIFY_LICENSE_FILE, IMUNIFY_LICENSE_BACKUP );
         }
 
         Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify_features' => \@features } } );
@@ -2688,7 +2688,7 @@ EOS
 
         return unless my $features = Elevate::StageFile::read_stage_file('reinstall')->{'imunify_features'};
 
-        File::Copy::move( IMUNIFY_LICENSE_BACKUP, IMUNIFY_LICENSE_FILE ) if -f IMUNIFY_LICENSE_BACKUP;
+        File::Copy::mv( IMUNIFY_LICENSE_BACKUP, IMUNIFY_LICENSE_FILE ) if -f IMUNIFY_LICENSE_BACKUP;
 
         return unless ref $features eq 'ARRAY';
         return unless @$features;
@@ -3153,7 +3153,7 @@ EOS
         if ( -e $conf_file . q[.rpmsave] ) {
             INFO("Restoring Configuration file: $conf_file");
 
-            File::Copy::copy( $conf_file . q[.rpmsave], $conf_file );
+            File::Copy::cp( $conf_file . q[.rpmsave], $conf_file );
         }
 
         INFO("Running kernelcare installer");
@@ -3482,7 +3482,7 @@ EOS
 
         Elevate::StageFile::update_stage_file( { 'mysql-version' => $mysql_version } );
 
-        File::Copy::copy( $cnf_file, "$cnf_file.rpmsave_pre_elevate" ) or WARN("Couldn't backup $cnf_file to $cnf_file.rpmsave_pre_elevate: $!");
+        File::Copy::cp( $cnf_file, "$cnf_file.rpmsave_pre_elevate" ) or WARN("Couldn't backup $cnf_file to $cnf_file.rpmsave_pre_elevate: $!");
 
         $self->_remove_cpanel_mysql_packages();
 
@@ -3542,10 +3542,10 @@ EOS
             return;
         }
 
-        File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_distro_upgrade_orig" );
+        File::Copy::cp( $cnf_file, "$cnf_file.elevate_post_distro_upgrade_orig" );
 
         INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
-        File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file );
+        File::Copy::cp( "$cnf_file.rpmsave_pre_elevate", $cnf_file );
 
         my $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
         my @restart_lines = split "\n", $restart_out;
@@ -3555,7 +3555,7 @@ EOS
         return if grep { $_ =~ m{mysql (?:re)?started successfully} } @restart_lines;
 
         INFO('The database server failed to start.  Restoring my.cnf to default.');
-        File::Copy::copy( "$cnf_file.elevate_post_distro_upgrade_orig", $cnf_file );
+        File::Copy::cp( "$cnf_file.elevate_post_distro_upgrade_orig", $cnf_file );
 
         $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
         @restart_lines = split "\n", $restart_out;
@@ -3953,6 +3953,8 @@ EOS
 
     use cPstrict;
 
+    use File::Copy ();
+
     use Elevate::Constants        ();
     use Elevate::SystemctlService ();
     use Elevate::Fetch            ();
@@ -4005,7 +4007,7 @@ EOS
             next unless -f $f;
             my $name   = File::Basename::basename($f);
             my $backup = "$backup_dir/$name";
-            File::Copy::move( $f, $backup );
+            File::Copy::mv( $f, $backup );
 
             $to_restore->{$backup} = $f;
         }
@@ -4071,7 +4073,7 @@ EOS
         foreach my $src ( sort keys %$to_restore ) {
             my $destination = $to_restore->{$src};
 
-            File::Copy::copy( $src, $destination );
+            File::Copy::cp( $src, $destination );
         }
 
         if ( $data->{service_enabled} ) {
@@ -5138,7 +5140,7 @@ EOS
                 next;
             }
 
-            File::Copy::move( $f, "$f.off" ) or die qq[Failed to disable repo $f];
+            File::Copy::mv( $f, "$f.off" ) or die qq[Failed to disable repo $f];
         }
 
         Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/bin/yum clean all});
@@ -5485,7 +5487,7 @@ EOS
         foreach my $id ( keys %duplicate_ids ) {
             if ( $id =~ m/^MariaDB[0-9]+/ ) {
                 my $path = $duplicate_ids{$id};
-                File::Copy::move( $path, "$path.disabled_by_elevate" );
+                File::Copy::mv( $path, "$path.disabled_by_elevate" );
             }
         }
 
@@ -5526,8 +5528,7 @@ EOS
 
     use Elevate::Constants ();
 
-    use Cwd        ();
-    use File::Copy ();
+    use Cwd ();
 
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
@@ -5563,8 +5564,7 @@ EOS
     use Elevate::Constants ();
     use Elevate::DNF       ();
 
-    use Cwd        ();
-    use File::Copy ();
+    use Cwd ();
 
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
@@ -6021,7 +6021,7 @@ EOS
 
     sub backup_3rdparty_file ($file) {
         my $target = "$file.elevate_backup";
-        return File::Copy::copy( $file, $target );
+        return File::Copy::cp( $file, $target );
     }
 
     1;
@@ -7480,6 +7480,8 @@ EOS
 
     use cPstrict;
 
+    use File::Copy ();
+
     # use Log::Log4perl qw(:easy);
     INIT { Log::Log4perl->import(qw{:easy}); }
 
@@ -7541,7 +7543,7 @@ EOS
 
             next unless -e $backup_file;
 
-            File::Copy::move( $backup_file, $file ) or WARN("Unable to restore config file $backup_file: $!");
+            File::Copy::mv( $backup_file, $file ) or WARN("Unable to restore config file $backup_file: $!");
         }
 
         return;
@@ -7785,7 +7787,7 @@ EOS
     use constant ELEVATE_SUCCESS_FILE => '/var/cpanel/version/elevate';
 
     sub create_success_file () {
-        File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
+        File::Copy::cp( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
         return;
     }
 
@@ -8765,7 +8767,7 @@ sub do_update ($self) {
         return 1 unless $temp_file;    # Elevate::Fetch::script handled the error msg
 
         my $running_from = Cwd::abs_path($0) // '';
-        if ( File::Copy::move( $temp_file, $running_from ) ) {
+        if ( File::Copy::mv( $temp_file, $running_from ) ) {
             chmod 0700, $running_from;
             my $confirmed_version = Cpanel::SafeRun::Simple::saferunnoerror( $running_from, '--version' );
             chomp $confirmed_version;

--- a/lib/Elevate/Components/AbsoluteSymlinks.pm
+++ b/lib/Elevate/Components/AbsoluteSymlinks.pm
@@ -65,8 +65,8 @@ sub _absolute_symlinks ($self) {
         while ( -e "$link-$rand_uid" && $tries++ < 10000 ) {
             $rand_uid = Cpanel::UUID::random_uuid();
         }
-        symlink( $updated, "$link-$rand_uid" )       or die "Can't create symlink $link-$rand_uid to $updated: $!";
-        File::Copy::move( "$link-$rand_uid", $link ) or die "Can't overwite $link: $!";
+        symlink( $updated, "$link-$rand_uid" )     or die "Can't create symlink $link-$rand_uid to $updated: $!";
+        File::Copy::mv( "$link-$rand_uid", $link ) or die "Can't overwite $link: $!";
     }
     return;
 }

--- a/lib/Elevate/Components/Imunify.pm
+++ b/lib/Elevate/Components/Imunify.pm
@@ -106,7 +106,7 @@ sub _capture_imunify_features {
     } grep { m/\S/ } split( "\n", $output );
 
     if ( -f IMUNIFY_LICENSE_FILE ) {
-        File::Copy::move( IMUNIFY_LICENSE_FILE, IMUNIFY_LICENSE_BACKUP );
+        File::Copy::mv( IMUNIFY_LICENSE_FILE, IMUNIFY_LICENSE_BACKUP );
     }
 
     Elevate::StageFile::update_stage_file( { 'reinstall' => { 'imunify_features' => \@features } } );
@@ -118,7 +118,7 @@ sub _restore_imunify_features {
 
     return unless my $features = Elevate::StageFile::read_stage_file('reinstall')->{'imunify_features'};
 
-    File::Copy::move( IMUNIFY_LICENSE_BACKUP, IMUNIFY_LICENSE_FILE ) if -f IMUNIFY_LICENSE_BACKUP;
+    File::Copy::mv( IMUNIFY_LICENSE_BACKUP, IMUNIFY_LICENSE_FILE ) if -f IMUNIFY_LICENSE_BACKUP;
 
     return unless ref $features eq 'ARRAY';
     return unless @$features;

--- a/lib/Elevate/Components/KernelCare.pm
+++ b/lib/Elevate/Components/KernelCare.pm
@@ -77,7 +77,7 @@ sub _restore_kernelcare ($self) {
         INFO("Restoring Configuration file: $conf_file");
 
         # restore configuration file before installing it
-        File::Copy::copy( $conf_file . q[.rpmsave], $conf_file );
+        File::Copy::cp( $conf_file . q[.rpmsave], $conf_file );
     }
 
     INFO("Running kernelcare installer");

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -71,7 +71,7 @@ sub _cleanup_mysql_packages ($self) {
     Elevate::StageFile::update_stage_file( { 'mysql-version' => $mysql_version } );
 
     # Stash current config so we can restore it later.
-    File::Copy::copy( $cnf_file, "$cnf_file.rpmsave_pre_elevate" ) or WARN("Couldn't backup $cnf_file to $cnf_file.rpmsave_pre_elevate: $!");
+    File::Copy::cp( $cnf_file, "$cnf_file.rpmsave_pre_elevate" ) or WARN("Couldn't backup $cnf_file to $cnf_file.rpmsave_pre_elevate: $!");
 
     # make sure all packages from unsupported repo are removed
     #
@@ -139,12 +139,12 @@ sub _reinstall_mysql_packages {
     }
 
     # In case the pre elevate file causes issues for whatever reason
-    File::Copy::copy( $cnf_file, "$cnf_file.elevate_post_distro_upgrade_orig" );
+    File::Copy::cp( $cnf_file, "$cnf_file.elevate_post_distro_upgrade_orig" );
 
     # Try to restore any .rpmsave'd configs after we reinstall
     # It *should be here* given we put it there, so no need to do a -f/-s check
     INFO("Restoring $cnf_file.rpmsave_pre_elevate to $cnf_file...");
-    File::Copy::copy( "$cnf_file.rpmsave_pre_elevate", $cnf_file );
+    File::Copy::cp( "$cnf_file.rpmsave_pre_elevate", $cnf_file );
 
     # Return if MySQL restarts successfully
     my $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
@@ -158,7 +158,7 @@ sub _reinstall_mysql_packages {
     # my.cnf in place.  Revert to the standard one that was created
     # in the post_distro_upgrade restore
     INFO('The database server failed to start.  Restoring my.cnf to default.');
-    File::Copy::copy( "$cnf_file.elevate_post_distro_upgrade_orig", $cnf_file );
+    File::Copy::cp( "$cnf_file.elevate_post_distro_upgrade_orig", $cnf_file );
 
     $restart_out   = Cpanel::SafeRun::Simple::saferunnoerror(qw{/scripts/restartsrv_mysql});
     @restart_lines = split "\n", $restart_out;

--- a/lib/Elevate/Components/NixStats.pm
+++ b/lib/Elevate/Components/NixStats.pm
@@ -22,6 +22,8 @@ Intsall nixstats, restore config files, and start service
 
 use cPstrict;
 
+use File::Copy ();
+
 use Elevate::Constants        ();
 use Elevate::SystemctlService ();
 use Elevate::Fetch            ();
@@ -71,7 +73,7 @@ sub _remove_nixstats ($self) {
         next unless -f $f;
         my $name   = File::Basename::basename($f);
         my $backup = "$backup_dir/$name";
-        File::Copy::move( $f, $backup );
+        File::Copy::mv( $f, $backup );
 
         $to_restore->{$backup} = $f;
     }
@@ -143,7 +145,7 @@ sub _restore_nixstats ($self) {
     foreach my $src ( sort keys %$to_restore ) {
         my $destination = $to_restore->{$src};
 
-        File::Copy::copy( $src, $destination );
+        File::Copy::cp( $src, $destination );
     }
 
     # restoring the state of the service before elevation

--- a/lib/Elevate/Components/Repositories.pm
+++ b/lib/Elevate/Components/Repositories.pm
@@ -76,7 +76,7 @@ sub _disable_known_yum_repositories {
             next;
         }
 
-        File::Copy::move( $f, "$f.off" ) or die qq[Failed to disable repo $f];
+        File::Copy::mv( $f, "$f.off" ) or die qq[Failed to disable repo $f];
     }
 
     Cpanel::SafeRun::Simple::saferunnoerror(qw{/usr/bin/yum clean all});
@@ -437,7 +437,7 @@ sub _autofix_duplicate_repoids ($self) {
     foreach my $id ( keys %duplicate_ids ) {
         if ( $id =~ m/^MariaDB[0-9]+/ ) {
             my $path = $duplicate_ids{$id};
-            File::Copy::move( $path, "$path.disabled_by_elevate" );
+            File::Copy::mv( $path, "$path.disabled_by_elevate" );
         }
     }
 

--- a/lib/Elevate/Components/RmMod.pm
+++ b/lib/Elevate/Components/RmMod.pm
@@ -25,7 +25,6 @@ use cPstrict;
 use Elevate::Constants ();
 
 use Cwd           ();
-use File::Copy    ();
 use Log::Log4perl qw(:easy);
 
 use parent qw{Elevate::Components::Base};

--- a/lib/Elevate/Components/RpmDB.pm
+++ b/lib/Elevate/Components/RpmDB.pm
@@ -31,7 +31,6 @@ use Elevate::Constants ();
 use Elevate::DNF       ();
 
 use Cwd           ();
-use File::Copy    ();
 use Log::Log4perl qw(:easy);
 
 use Cpanel::Pkgr      ();

--- a/lib/Elevate/Components/WPToolkit.pm
+++ b/lib/Elevate/Components/WPToolkit.pm
@@ -81,7 +81,7 @@ sub _reinstall_wordpress_toolkit ($self) {
 
 sub backup_3rdparty_file ($file) {
     my $target = "$file.elevate_backup";
-    return File::Copy::copy( $file, $target );
+    return File::Copy::cp( $file, $target );
 }
 
 1;

--- a/lib/Elevate/RPM.pm
+++ b/lib/Elevate/RPM.pm
@@ -12,6 +12,8 @@ Logic wrapping the 'rpm' system binary
 
 use cPstrict;
 
+use File::Copy ();
+
 use Log::Log4perl qw(:easy);
 
 use Simple::Accessor qw{
@@ -78,7 +80,7 @@ sub restore_config_files ( $self, @files ) {
 
         next unless -e $backup_file;
 
-        File::Copy::move( $backup_file, $file ) or WARN("Unable to restore config file $backup_file: $!");
+        File::Copy::mv( $backup_file, $file ) or WARN("Unable to restore config file $backup_file: $!");
     }
 
     return;

--- a/lib/Elevate/StageFile.pm
+++ b/lib/Elevate/StageFile.pm
@@ -23,7 +23,7 @@ use constant ELEVATE_STAGE_FILE   => '/var/cpanel/elevate';
 use constant ELEVATE_SUCCESS_FILE => '/var/cpanel/version/elevate';
 
 sub create_success_file () {
-    File::Copy::copy( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
+    File::Copy::cp( ELEVATE_STAGE_FILE, ELEVATE_SUCCESS_FILE );
     return;
 }
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -456,7 +456,7 @@ sub do_update ($self) {
         return 1 unless $temp_file;    # Elevate::Fetch::script handled the error msg
 
         my $running_from = Cwd::abs_path($0) // '';
-        if ( File::Copy::move( $temp_file, $running_from ) ) {
+        if ( File::Copy::mv( $temp_file, $running_from ) ) {
             chmod 0700, $running_from;
             my $confirmed_version = Cpanel::SafeRun::Simple::saferunnoerror( $running_from, '--version' );
             chomp $confirmed_version;

--- a/t/components-ea4.t
+++ b/t/components-ea4.t
@@ -492,7 +492,7 @@ sub test_backup_and_restore_config_files : Test(10) ($self) {
     my %config_files_restored;
     my $mock_file_copy = Test::MockModule->new('File::Copy');
     $mock_file_copy->redefine(
-        move => sub {
+        mv => sub {
             my ( $from, $to ) = @_;
             $config_files_restored{$to} = 1;
             return 1;


### PR DESCRIPTION
Case RE-723:  As it turns out, File::Copy provides copy and cp that behave slightly different.  The copy and move subs use the umask provided by the running processes shell.  The cp and mv try to preserve permissions for the file that is being copied or moved.  As such, we should prefer cp and mv over copy and move from File::Copy.

Changelog: Use mv and cp from File::Copy instead of copy and move

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

