### PR TITLE
Support elevate for systems with Acronis backup agent

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -55,6 +55,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Components/UnconvertedModules.pm'} = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/WHM.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/WPToolkit.pm'}          = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Components/Acronis.pm'}            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS.pm'}                            = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CentOS7.pm'}                    = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/OS/CloudLinux7.pm'}                = 'script/elevate-cpanel.PL.static';
@@ -120,6 +121,15 @@ BEGIN {    # Suppress load of all of these at earliest point.
       serverbackup-async-agent-2-6
       serverbackup-enterprise-agent
       serverbackup-setup
+    };
+
+    use constant ACRONIS_BACKUP_PACKAGE => 'acronis-backup-cpanel';
+    use constant ACRONIS_OTHER_PACKAGES => qw{
+      BackupAndRecoveryAgent
+      BackupAndRecoveryBootableComponents
+      dkms
+      file_protector
+      snapapi26_modules
     };
 
     use constant POSTGRESQL_SYSTEM_DATADIR => '/var/lib/pgsql/data';
@@ -334,6 +344,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Elevate::Components::UnconvertedModules ();
     use Elevate::Components::WHM                ();
     use Elevate::Components::WPToolkit          ();
+    use Elevate::Components::Acronis            ();
 
     use Simple::Accessor qw(
       cpev
@@ -393,6 +404,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       WPToolkit
       cPanelPlugins
       cPanelPrep
+      Acronis
     };
 
     push @CHECKS, @NOOP_CHECKS;
@@ -5119,7 +5131,8 @@ EOS
         'virt-what',
         'vzdummy-systemd-el7',
       ),
-      Elevate::Constants::R1SOFT_AGENT_PACKAGES;
+      Elevate::Constants::R1SOFT_AGENT_PACKAGES,
+      Elevate::Constants::ACRONIS_OTHER_PACKAGES;
 
     sub pre_distro_upgrade ($self) {
 
@@ -5727,6 +5740,11 @@ EOS
     our @ISA;
     BEGIN { push @ISA, qw(Elevate::Components::Base); }
 
+    use constant EXEMPTED_PACKAGES => (
+        qr/^kernel-/,
+        qr/^acronis/,
+    );
+
     sub post_distro_upgrade ($self) {
         $self->run_once('_remove_leapp_packages');
         $self->run_once('_warn_about_other_modules_that_did_not_convert');
@@ -5754,20 +5772,25 @@ EOS
     }
 
     sub _warn_about_other_modules_that_did_not_convert ($self) {
-        my @installed_packages                    = $self->rpm->get_installed_rpms();
-        my @el7_installed_packages                = grep { $_ =~ m/el7/ } @installed_packages;
-        my @exclude_kernel_el7_installed_packages = grep { $_ !~ m/^kernel-/ } @el7_installed_packages;
+        my @installed_packages     = $self->rpm->get_installed_rpms();
+        my @el7_installed_packages = grep { $_ =~ m/el7/ } @installed_packages;
 
-        return unless @exclude_kernel_el7_installed_packages;
+        my @el7_packages_minus_exemptions;
+        foreach my $pkg (@el7_installed_packages) {
+            next if grep { $pkg =~ m/$_/ } EXEMPTED_PACKAGES();
+            push @el7_packages_minus_exemptions, $pkg;
+        }
+
+        return unless @el7_packages_minus_exemptions;
 
         my $pretty_distro_name = Elevate::OS::upgrade_to_pretty_name();
 
         my $msg = "The following packages should probably be removed as they will not function on $pretty_distro_name\n\n";
-        foreach my $pkg (@exclude_kernel_el7_installed_packages) {
+        foreach my $pkg (@el7_packages_minus_exemptions) {
             $msg .= "    $pkg\n";
         }
 
-        $msg .= "\nYou can remove these by running: yum -y remove " . join( ' ', @exclude_kernel_el7_installed_packages ) . "\n";
+        $msg .= "\nYou can remove these by running: yum -y remove " . join( ' ', @el7_packages_minus_exemptions ) . "\n";
 
         Elevate::Notify::add_final_notification($msg);
 
@@ -6027,6 +6050,48 @@ EOS
     1;
 
 }    # --- END lib/Elevate/Components/WPToolkit.pm
+
+{    # --- BEGIN lib/Elevate/Components/Acronis.pm
+
+    package Elevate::Components::Acronis;
+
+    use cPstrict;
+
+    use Elevate::Constants ();
+    use Elevate::StageFile ();
+
+    use Cpanel::Pkgr ();
+
+    # use Elevate::Components::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Components::Base); }
+
+    sub pre_distro_upgrade ($self) {
+
+        return unless Cpanel::Pkgr::is_installed(Elevate::Constants::ACRONIS_BACKUP_PACKAGE);
+
+        $self->yum->remove(
+            Elevate::Constants::ACRONIS_BACKUP_PACKAGE,
+            Elevate::Constants::ACRONIS_OTHER_PACKAGES
+        );
+
+        Elevate::StageFile::update_stage_file( { 'reinstall' => { 'acronis' => 1 } } );
+
+        return;
+    }
+
+    sub post_distro_upgrade ($self) {
+
+        return unless Elevate::StageFile::read_stage_file('reinstall')->{'acronis'};
+
+        $self->dnf->install(Elevate::Constants::ACRONIS_BACKUP_PACKAGE);
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Components/Acronis.pm
 
 {    # --- BEGIN lib/Elevate/OS.pm
 
@@ -8590,6 +8655,7 @@ use Elevate::Components::SSH                ();
 use Elevate::Components::UnconvertedModules ();
 use Elevate::Components::WHM                ();
 use Elevate::Components::WPToolkit          ();
+use Elevate::Components::Acronis            ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -9633,6 +9699,7 @@ sub run_final_components_pre_distro_upgrade ($self) {
     $self->run_component_once( 'ELS'              => 'pre_distro_upgrade' );
     $self->run_component_once( 'R1Soft'           => 'pre_distro_upgrade' );
     $self->run_component_once( 'Panopta'          => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Acronis'          => 'pre_distro_upgrade' );
     $self->run_component_once( 'RpmDB'            => 'pre_distro_upgrade' );    # remove the RPMs last
 
     return;
@@ -9663,6 +9730,7 @@ sub post_distro_upgrade_update_restore ($self) {
     $self->run_component_once( 'LiteSpeed'       => 'post_distro_upgrade' );
     $self->run_component_once( 'R1Soft'          => 'post_distro_upgrade' );
     $self->run_component_once( 'PackageRestore'  => 'post_distro_upgrade' );
+    $self->run_component_once( 'Acronis'         => 'post_distro_upgrade' );
 
     return;
 }

--- a/lib/Elevate/Components.pm
+++ b/lib/Elevate/Components.pm
@@ -59,6 +59,7 @@ use Elevate::Components::SSH                ();
 use Elevate::Components::UnconvertedModules ();
 use Elevate::Components::WHM                ();
 use Elevate::Components::WPToolkit          ();
+use Elevate::Components::Acronis            ();
 
 use Simple::Accessor qw(
   cpev
@@ -121,6 +122,7 @@ our @NOOP_CHECKS = qw{
   WPToolkit
   cPanelPlugins
   cPanelPrep
+  Acronis
 };
 
 push @CHECKS, @NOOP_CHECKS;

--- a/lib/Elevate/Components/Acronis.pm
+++ b/lib/Elevate/Components/Acronis.pm
@@ -1,0 +1,58 @@
+package Elevate::Components::Acronis;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Components::Acronis
+
+=head2 check
+
+noop
+
+=head2 pre_distro_upgrade
+
+Find out if Acronis is installed.
+If it is, uninstall it & make a note in the stage file.
+(We'll need to reinstall it after the OS upgrade.)
+
+=head2 post_distro_upgrade
+
+If the agent had been installed:
+Re-install the agent.
+
+=cut
+
+use cPstrict;
+
+use Elevate::Constants ();
+use Elevate::StageFile ();
+
+use Cpanel::Pkgr ();
+
+use parent qw{Elevate::Components::Base};
+
+sub pre_distro_upgrade ($self) {
+
+    return unless Cpanel::Pkgr::is_installed(Elevate::Constants::ACRONIS_BACKUP_PACKAGE);
+
+    $self->yum->remove(
+        Elevate::Constants::ACRONIS_BACKUP_PACKAGE,
+        Elevate::Constants::ACRONIS_OTHER_PACKAGES
+    );
+
+    Elevate::StageFile::update_stage_file( { 'reinstall' => { 'acronis' => 1 } } );
+
+    return;
+}
+
+sub post_distro_upgrade ($self) {
+
+    return unless Elevate::StageFile::read_stage_file('reinstall')->{'acronis'};
+
+    $self->dnf->install(Elevate::Constants::ACRONIS_BACKUP_PACKAGE);
+
+    return;
+}
+
+1;

--- a/lib/Elevate/Components/Repositories.pm
+++ b/lib/Elevate/Components/Repositories.pm
@@ -54,7 +54,8 @@ use constant EXPECTED_EXTRA_PACKAGES => (
     'virt-what',
     'vzdummy-systemd-el7',
   ),
-  Elevate::Constants::R1SOFT_AGENT_PACKAGES;
+  Elevate::Constants::R1SOFT_AGENT_PACKAGES,
+  Elevate::Constants::ACRONIS_OTHER_PACKAGES;
 
 sub pre_distro_upgrade ($self) {
 

--- a/lib/Elevate/Constants.pm
+++ b/lib/Elevate/Constants.pm
@@ -52,6 +52,15 @@ use constant R1SOFT_AGENT_PACKAGES => qw{
   serverbackup-setup
 };
 
+use constant ACRONIS_BACKUP_PACKAGE => 'acronis-backup-cpanel';
+use constant ACRONIS_OTHER_PACKAGES => qw{
+  BackupAndRecoveryAgent
+  BackupAndRecoveryBootableComponents
+  dkms
+  file_protector
+  snapapi26_modules
+};
+
 use constant POSTGRESQL_SYSTEM_DATADIR => '/var/lib/pgsql/data';
 
 use constant OVH_MONITORING_TOUCH_FILE => '/var/cpanel/acknowledge_ovh_monitoring_for_elevate';

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -279,6 +279,7 @@ use Elevate::Components::SSH                ();
 use Elevate::Components::UnconvertedModules ();
 use Elevate::Components::WHM                ();
 use Elevate::Components::WPToolkit          ();
+use Elevate::Components::Acronis            ();
 
 # - fatpack OS
 use Elevate::OS              ();
@@ -1322,6 +1323,7 @@ sub run_final_components_pre_distro_upgrade ($self) {
     $self->run_component_once( 'ELS'              => 'pre_distro_upgrade' );
     $self->run_component_once( 'R1Soft'           => 'pre_distro_upgrade' );
     $self->run_component_once( 'Panopta'          => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Acronis'          => 'pre_distro_upgrade' );
     $self->run_component_once( 'RpmDB'            => 'pre_distro_upgrade' );    # remove the RPMs last
 
     return;
@@ -1352,6 +1354,7 @@ sub post_distro_upgrade_update_restore ($self) {
     $self->run_component_once( 'LiteSpeed'       => 'post_distro_upgrade' );
     $self->run_component_once( 'R1Soft'          => 'post_distro_upgrade' );
     $self->run_component_once( 'PackageRestore'  => 'post_distro_upgrade' );
+    $self->run_component_once( 'Acronis'         => 'post_distro_upgrade' );
 
     return;
 }

--- a/t/components-Acronis.t
+++ b/t/components-Acronis.t
@@ -1,0 +1,106 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::components;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use cPstrict;
+
+my $acronis = cpev->new->get_component('Acronis');
+
+{
+    note "Checking pre_distro_upgrade";
+
+    my $is_installed;
+    my $yum_remove_called;
+    my $stage_file_data;
+
+    my $mock_pkgr = Test::MockModule->new('Cpanel::Pkgr');
+    $mock_pkgr->redefine(
+        is_installed => sub { return $is_installed; },
+    );
+
+    my $mock_yum = Test::MockModule->new('Elevate::YUM');
+    $mock_yum->redefine(
+        remove => sub { $yum_remove_called = 1; },
+    );
+
+    my $mock_upsf = Test::MockModule->new('Elevate::StageFile');
+    $mock_upsf->redefine(
+        update_stage_file => sub { $stage_file_data = shift; },
+    );
+
+    # Test when Acronis is not installed
+    $is_installed      = 0;
+    $yum_remove_called = 0;
+    $stage_file_data   = {};
+
+    $acronis->pre_distro_upgrade();
+    is( $yum_remove_called, 0,  'When package not installed:  did not uninstall package' );
+    is( $stage_file_data,   {}, 'When package not installed:  did not update the stage file' );
+
+    # Test when Acronis is installed
+    $is_installed      = 1;
+    $yum_remove_called = 0;
+    $stage_file_data   = {};
+
+    $acronis->pre_distro_upgrade();
+    is( $yum_remove_called, 1, 'When package is installed:  uninstalled package' );
+    is(
+        $stage_file_data,
+        {
+            'reinstall' => {
+                'acronis' => 1,
+            },
+        },
+        'When package is installed:  updated the stage file'
+    );
+}
+
+{
+    note "Checking post_distro_upgrade";
+
+    my $stage_file_data;
+    my $dnf_install_called;
+
+    my $mock_upsf = Test::MockModule->new('Elevate::StageFile');
+    $mock_upsf->redefine(
+        read_stage_file => sub { return $stage_file_data; },
+    );
+
+    my $mock_dnf = Test::MockModule->new('Elevate::DNF');
+    $mock_dnf->redefine(
+        install => sub { $dnf_install_called = 1; },
+    );
+
+    # Test when had not been installed
+    $stage_file_data    = {};
+    $dnf_install_called = 0;
+
+    $acronis->post_distro_upgrade();
+    is( $dnf_install_called, 0, 'When package was never installed:  did not reinstall' );
+
+    # Test when had been installed
+    $stage_file_data    = { 'acronis' => 1 };
+    $dnf_install_called = 1;
+
+    $acronis->post_distro_upgrade();
+    is( $dnf_install_called, 1, 'When package had been installed:  reinstalled package' );
+}
+
+done_testing();

--- a/t/components-UnconvertedModules.t
+++ b/t/components-UnconvertedModules.t
@@ -85,7 +85,7 @@ my $unconvertedmodules = cpev->new->get_component('UnconvertedModules');
         },
     );
 
-    @mock_packages = qw{ foo bar finn-el7 };
+    @mock_packages = qw{ foo bar finn-el7 acronis-backup-cpanel kernel-3.10.el7.x86_64 kernel-tools-3.10.el7.x86_64 };
     $unconvertedmodules->_warn_about_other_modules_that_did_not_convert();
     is(
         $message,


### PR DESCRIPTION
Case RE-575:

For Acronis, we must remove the Acronis backup agent package before the distro upgrade and re-install it after the distro upgrade.

Changelog: Support running elevate on systems that have the
  Acronis backup agent installed.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

