### PR TITLE
Increase Efficiency of Openstack Workflow

### DIFF
--- a/.github/workflows/openstack.yml
+++ b/.github/workflows/openstack.yml
@@ -108,7 +108,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Checkout Repo and Commit
           if: github.event_name != 'pull_request'
@@ -162,7 +161,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -198,7 +196,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -240,13 +237,12 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
             VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
           run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
-        - name: Wait For VM to Come Back From Stage 2 Reboot
+        - name: Wait For VM to Come Back From Initial Reboot
           working-directory: "./.github/workflows/openstack/"
           run: |
             ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
@@ -268,7 +264,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -287,7 +282,8 @@ jobs:
             script: |
               /scripts/status_marker 1
               /scripts/elevate-cpanel --log &
-              REBOOT_STRING="/usr/bin/systemctl start elevate-cpanel.service" RETVAL=1 /scripts/reboot_watch
+              sleep 1.5
+              REBOOT_STRING="Rebooting into stage 2 of 5" RETVAL=1 /scripts/reboot_watch
 
     wait_for_stage_2_reboot:
       runs-on: self-hosted
@@ -306,7 +302,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -334,7 +329,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -351,8 +345,9 @@ jobs:
             command_timeout: 30m
             debug: true
             script: |
-              /scripts/status_marker 3
+              /scripts/status_marker 2
               /scripts/elevate-cpanel --log &
+              sleep 1.5
               REBOOT_STRING="Rebooting into stage 3 of 5" RETVAL=1 /scripts/reboot_watch
     
     wait_for_stage_3_reboot:
@@ -372,7 +367,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -400,7 +394,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -416,8 +409,9 @@ jobs:
             timeout: 30m
             command_timeout: 30m
             script: |
-              /scripts/status_marker 4
+              /scripts/status_marker 3
               /scripts/elevate-cpanel --log &
+              sleep 1.5
               REBOOT_STRING="Rebooting into stage 4 of 5" RETVAL=1 /scripts/reboot_watch
 
     wait_for_stage_4_reboot:
@@ -437,7 +431,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -465,7 +458,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -481,8 +473,9 @@ jobs:
             timeout: 45m
             command_timeout: 35m
             script: |
-              /scripts/status_marker 5
+              /scripts/status_marker 4
               /scripts/elevate-cpanel --log &
+              sleep 1.5
               REBOOT_STRING="Rebooting into stage 5 of 5" RETVAL=1 /scripts/reboot_watch
 
     wait_for_stage_5_reboot:
@@ -502,7 +495,6 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
 
         - name: Export VM_IP to env
           env:
@@ -513,7 +505,7 @@ jobs:
           run: |
             ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
 
-    verify_upgraded_os:
+    watch_for_final_reboot:
       runs-on: self-hosted
       needs: wait_for_stage_5_reboot
       outputs:
@@ -530,7 +522,70 @@ jobs:
           run: |
             echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
             cat ${{ github.run_id }}-vm_ip > VM_IP
-            ls -la
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
+        - name: Monitor Elevate for Final Reboot
+          uses: appleboy/ssh-action@v1.0.3
+          with:
+            host: ${{ steps.VM_IP.outputs.VM_IP }}
+            username: 'root'
+            key: ${{ secrets.SSH_PRIVATE_KEY }}
+            port: '22'
+            timeout: 45m
+            command_timeout: 35m
+            script: |
+              /scripts/status_marker 5
+              /scripts/elevate-cpanel --log &
+              sleep 1.5
+              SKIP_PID_CHECK=1 REBOOT_STRING="Doing final reboot" RETVAL=1 /scripts/reboot_watch
+
+    wait_for_final_reboot:
+      runs-on: self-hosted
+      needs: watch_for_final_reboot
+      outputs:
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+      steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
+
+        - name: Export VM_IP to env
+          env:
+            VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+          run: echo "VM_IP is ${{ steps.VM_IP.outputs.VM_IP }}"
+        - name: Wait For VM to Come Back From Final Reboot
+          working-directory: "./.github/workflows/openstack/"
+          run: |
+            ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
+
+    verify_upgraded_os:
+      runs-on: self-hosted
+      needs: wait_for_final_reboot
+      outputs:
+        VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
+      steps:
+        - name: Download VM IP
+          uses: actions/download-artifact@v4
+          with:
+            name: ${{ github.run_id }}-vm_ip
+            path: ${{ github.workspace }}/
+
+        - name: Get VM IP from Artifact
+          id: VM_IP
+          run: |
+            echo "VM_IP=$(cat ${{ github.run_id }}-vm_ip)" >> "$GITHUB_OUTPUT"
+            cat ${{ github.run_id }}-vm_ip > VM_IP
 
         - name: Export VM_IP to env
           env:

--- a/.github/workflows/openstack/reboot_watch
+++ b/.github/workflows/openstack/reboot_watch
@@ -1,6 +1,7 @@
 #!/usr/local/cpanel/3rdparty/bin/perl
 
 use constant ELEVATE_LOG_PATH => '/var/log/elevate-cpanel.log';
+use constant ELEVATE_PID      => '/var/run/elevate-cpanel.pid';
 
 use File::Tail;
 use POSIX;
@@ -10,15 +11,17 @@ my $RETVAL = 1;
 # Verify REBOOT_STRING isn't already in the log before we go into tail mode.  The logodump here is sgnificantly faster than File::Tail.
 # Jump if it's found.
 
-exit 1 if !length( $ENV{REBOOT_STRING} );
+_pid_check() unless $ENV{SKIP_PID_CHECK};
+
+_exit_with_haste(1) if !length( $ENV{REBOOT_STRING} );
 
 open( my $elevate_log_fh, '<', ELEVATE_LOG_PATH ) or die "## [ERROR][reboot_watch]: Unable to open ELEVATE_LOG_PATH: $!\n";
 
 while ( my $line = readline $elevate_log_fh ) {
     if ( index( $line, $ENV{REBOOT_STRING} ) >= 0 ) {
-        _success_message();
         close $elevate_log;
-        exit 0;
+        _pre_success_message();
+        _exit_with_haste_(0);
     }
 }
 
@@ -26,24 +29,49 @@ close $elevate_log_fh;
 
 while ( $RETVAL != 0 ) {
     _check_elevate_log_for_REBOOT_STRING( ELEVATE_LOG_PATH, $ENV{REBOOT_STRING} );
-    exit 0;
+    _exit_with_haste(0);
 }
 
 sub _check_elevate_log_for_REBOOT_STRING {
     my ( $filepath, $REBOOT_STRING, $RETRIES ) = @_;
 
-    $file = File::Tail->new( name => $filepath, maxinterval => 1, adjustafter => 7, interval => 1 );
+    $file = File::Tail->new( name => $filepath, maxinterval => 1, adjustafter => 5, interval => 1 );
     while ( defined( $line = $file->read ) ) {
+        _pid_check() unless $ENV{SKIP_PID_CHECK};
         if ( index( $line, $ENV{REBOOT_STRING} ) >= 0 ) {
             _success_message();
+            _exit_with_haste(0);
         }
     }
+}
+
+sub _pre_success_message {
+    my $time = POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime );
+    print "## [$time] [INFO][PRE-TAIL]: SUCCESS: Reboot REBOOT_STRING ( $ENV{REBOOT_STRING} ) already exists in /var/log/elevate-cpanel.log prior to tail.  Timings may be off  ##\n";
+    _exit_with_haste(0);
 }
 
 sub _success_message {
     my $time = POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime );
     print "## [$time] [INFO]: SUCCESS: Reboot REBOOT_STRING ( $ENV{REBOOT_STRING} ) found in /var/log/elevate-cpanel.log  ##\n";
-    exit 0;
+    _exit_with_haste(0);
 }
 
-exit 0;
+sub _exit_with_haste {
+    my $code = shift;
+    print "## [INFO]: Attempting to kill tail and exit_code($code) stage left. ##\n";
+    eval { system(qq{pkill --signal 9 --full "tail -n40 -F /var/log/elevate-cpanel.log"}) };
+    print $@ if $@;
+    exit $code;
+}
+
+sub _pid_check {
+    ## Make sure the PID is in place before we continue parsing through.  This can prevent the timeout from being hit when we miss elevate has already died.
+    if ( !-s ELEVATE_PID ) {
+        print "## [ERROR]: NO PID for elevate-cpanel detected.  Exiting. ##\n";
+        _exit_with_haste(1);
+    }
+    return 0;
+}
+
+_exit_with_haste(1);

--- a/.github/workflows/openstack/ssh_retry
+++ b/.github/workflows/openstack/ssh_retry
@@ -6,7 +6,7 @@ my $HOST    = $ARGV[0];
 my $PORT    = $ARGV[1] // 22;
 my $RETVAL  = 1;
 my $RETRIES = 0;
-my $RETRY   = $ARGV[2] // 60;
+my $RETRY   = $ARGV[2] // 240;
 
 return unless defined $HOST;
 
@@ -32,5 +32,5 @@ while ( $RETVAL != 0 ) {
         print "## [$time] [ERROR]: ssh_retry.pl: MAX_RETRIES has been reached.\n";
         exit 1;
     }
-    sleep 15;
+    sleep 5;
 }


### PR DESCRIPTION
Case RE-889: Increase Efficiency of Openstack Workflow
 - reboot_retry:
   - Now has pkill ability to end tail watching tasks that cause race conditions.
   - Now more aggresive in handling exit codes.
   - Better DEBUG verbiage.
   - PID tracking to detect if elevate-cpanel has ended.
 - openstack workflow
   - Additional section required for Final Reboot accuracy.
   - Removal of some verbose output no longer needed.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

