### PR TITLE
Assure DB integrity before elevation

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -3464,6 +3464,8 @@ EOS
     use Cpanel::SafeRun::Simple            ();
     use Cpanel::DB::Map::Collection::Index ();
     use Cpanel::Exception                  ();
+    use Cpanel::MysqlUtils::MyCnf::Basic   ();
+    use Cpanel::MysqlUtils::Running        ();
 
     use Elevate::Database  ();
     use Elevate::Notify    ();
@@ -3655,6 +3657,7 @@ EOS
         my $ok = 1;
         $ok = 0 unless $self->_blocker_old_mysql;
         $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
+        $ok = 0 unless $self->_blocker_mysql_database_corrupted;
         $self->_warning_mysql_not_enabled();
         return $ok;
     }
@@ -3759,6 +3762,44 @@ EOS
     sub _blocker_mysql_upgrade_in_progress ($self) {
         if ( -e q[/var/cpanel/mysql_upgrade_in_progress] ) {
             return $self->has_blocker(q[MySQL/MariaDB upgrade in progress. Please wait for the upgrade to finish.]);
+        }
+
+        return 0;
+    }
+
+    sub _blocker_mysql_database_corrupted ($self) {
+
+        return 0 unless Cpanel::MysqlUtils::MyCnf::Basic::is_local_mysql();
+
+        if ( !Cpanel::MysqlUtils::Running::is_mysql_running() ) {
+
+            return 0 unless Cpanel::Services::Enabled::is_enabled('mysql');
+
+            my $output = $self->ssystem_capture_output(qw{/scripts/restartsrv_mysql});
+
+            WARN('Database server was down, starting it to check database integrity');
+            unless ( Cpanel::MysqlUtils::Running::is_mysql_running()
+                && grep { /mysql (?:re)?started successfully/ } @{ $output->{stdout} } ) {
+
+                return $self->has_blocker( <<~"EOS" );
+            Unable to to start the database server to check database integrity.  
+            Additional information can be found in the error log located at /var/log/mysqld.log
+            To attempt to start the database server, execute: /scripts/restartsrv_mysql
+            EOS
+            }
+        }
+
+        my $mysqlcheck_path = Cpanel::Binaries::path('mysqlcheck');
+        my $output          = $self->ssystem_capture_output( $mysqlcheck_path, '-c', '-m', '-A', '--silent' );
+
+        if ( scalar grep { /^error/i } @{ $output->{stdout} } ) {
+
+            my $issues_found = join( "\n", @{ $output->{stdout} } );
+            return $self->has_blocker( <<~"EOS" );
+            We have found the following problems with your database(s):
+            $issues_found
+            You should repair any corrupted databases before elevating the system.
+            EOS
         }
 
         return 0;

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -36,6 +36,8 @@ use Cpanel::JSON                       ();
 use Cpanel::SafeRun::Simple            ();
 use Cpanel::DB::Map::Collection::Index ();
 use Cpanel::Exception                  ();
+use Cpanel::MysqlUtils::MyCnf::Basic   ();
+use Cpanel::MysqlUtils::Running        ();
 
 use Elevate::Database  ();
 use Elevate::Notify    ();
@@ -242,6 +244,7 @@ sub check ($self) {
     my $ok = 1;
     $ok = 0 unless $self->_blocker_old_mysql;
     $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
+    $ok = 0 unless $self->_blocker_mysql_database_corrupted;
     $self->_warning_mysql_not_enabled();
     return $ok;
 }
@@ -355,6 +358,52 @@ sub _blocker_old_cpanel_mysql ($self) {
 sub _blocker_mysql_upgrade_in_progress ($self) {
     if ( -e q[/var/cpanel/mysql_upgrade_in_progress] ) {
         return $self->has_blocker(q[MySQL/MariaDB upgrade in progress. Please wait for the upgrade to finish.]);
+    }
+
+    return 0;
+}
+
+sub _blocker_mysql_database_corrupted ($self) {
+
+    # Do not perform this check for remote mysql
+    return 0 unless Cpanel::MysqlUtils::MyCnf::Basic::is_local_mysql();
+
+    # We cannot run mysqlcheck if mysql is not running
+    if ( !Cpanel::MysqlUtils::Running::is_mysql_running() ) {
+
+        # No blocker if it is not running because it is not enabled
+        # No need to check the database integrity if MySQL is disabled
+        return 0 unless Cpanel::Services::Enabled::is_enabled('mysql');
+
+        my $output = $self->ssystem_capture_output(qw{/scripts/restartsrv_mysql});
+
+        WARN('Database server was down, starting it to check database integrity');
+        unless ( Cpanel::MysqlUtils::Running::is_mysql_running()
+            && grep { /mysql (?:re)?started successfully/ } @{ $output->{stdout} } ) {
+
+            return $self->has_blocker( <<~"EOS" );
+            Unable to to start the database server to check database integrity.  
+            Additional information can be found in the error log located at /var/log/mysqld.log
+            To attempt to start the database server, execute: /scripts/restartsrv_mysql
+            EOS
+        }
+    }
+
+    # Perform a medium check on all databases and only output errors
+    my $mysqlcheck_path = Cpanel::Binaries::path('mysqlcheck');
+    my $output          = $self->ssystem_capture_output( $mysqlcheck_path, '-c', '-m', '-A', '--silent' );
+
+    # mysqlcheck doesn't return an error code
+    # We check for lines that actually begin with "Error" (or "error")
+    # because we don't want to block of only warnings are found
+    if ( scalar grep { /^error/i } @{ $output->{stdout} } ) {
+
+        my $issues_found = join( "\n", @{ $output->{stdout} } );
+        return $self->has_blocker( <<~"EOS" );
+            We have found the following problems with your database(s):
+            $issues_found
+            You should repair any corrupted databases before elevating the system.
+            EOS
     }
 
     return 0;


### PR DESCRIPTION
Case RE-782:

Use mysqlcheck to check the integrity of their databases. Block if errors are found.

Changelog: Verify integrity of databases before elevation.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

