### PR TITLE
Re-install Softaculous after upgrade

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -53,6 +53,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     $INC{'Elevate/Components/RmMod.pm'}              = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/RpmDB.pm'}              = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/SSH.pm'}                = 'script/elevate-cpanel.PL.static';
+    $INC{'Elevate/Components/Softaculous.pm'}        = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/UnconvertedModules.pm'} = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/WHM.pm'}                = 'script/elevate-cpanel.PL.static';
     $INC{'Elevate/Components/WPToolkit.pm'}          = 'script/elevate-cpanel.PL.static';
@@ -330,6 +331,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
     use Elevate::Components::RmMod              ();
     use Elevate::Components::RpmDB              ();
     use Elevate::Components::SSH                ();
+    use Elevate::Components::Softaculous        ();
     use Elevate::Components::UnconvertedModules ();
     use Elevate::Components::WHM                ();
     use Elevate::Components::WPToolkit          ();
@@ -390,6 +392,7 @@ BEGIN {    # Suppress load of all of these at earliest point.
       R1Soft
       RmMod
       RpmDB
+      Softaculous
       UnconvertedModules
       WPToolkit
       cPanelPlugins
@@ -5941,6 +5944,80 @@ EOS
 
 }    # --- END lib/Elevate/Components/SSH.pm
 
+{    # --- BEGIN lib/Elevate/Components/Softaculous.pm
+
+    package Elevate::Components::Softaculous;
+
+    use cPstrict;
+
+    use Elevate::Fetch     ();
+    use Elevate::StageFile ();
+
+    use Cpanel::Binaries        ();
+    use Cpanel::SafeRun::Object ();
+
+    # use Log::Log4perl qw(:easy);
+    INIT { Log::Log4perl->import(qw{:easy}); }
+
+    # use Elevate::Components::Base();
+    our @ISA;
+    BEGIN { push @ISA, qw(Elevate::Components::Base); }
+
+    # use Simple::Accessor qw(cli_path);
+    INIT { Simple::Accessor->import(qw{cli_path}); }
+
+    sub _build_cli_path { return '/usr/local/cpanel/whostmgr/docroot/cgi/softaculous/cli.php' }
+
+    sub pre_distro_upgrade ($self) {
+
+        return unless -r $self->cli_path;
+
+        my $sr = _run_script( $self->cli_path );
+
+        return if $sr->exec_failed() || $sr->to_exception();
+
+        my $version = $sr->stdout() // '';
+        chomp $version;
+
+        if ( length $version ) {
+            INFO('Softaculous has been detected. The system will re-install that software after the distro upgrade.');
+            Elevate::StageFile::update_stage_file( { softaculous => $version } );
+        }
+
+        return;
+    }
+
+    sub _run_script ($path) {
+        return Cpanel::SafeRun::Object->new(
+            program => Cpanel::Binaries::path('php'),
+            args    => [ $path, '--version' ],
+        );
+    }
+
+    sub post_distro_upgrade ($self) {
+
+        my $version = Elevate::StageFile::read_stage_file( 'softaculous', '' );
+        return unless length $version;
+
+        my $path = Elevate::Fetch::script( 'https://files.softaculous.com/install.sh', 'softaculous_install' );
+
+        if ($path) {
+            INFO('Re-installing Softaculous:');
+            if ( $self->ssystem( Cpanel::Binaries::path('bash'), $path, '--reinstall' ) ) {
+                ERROR('Re-installation of Softaculous failed.');
+            }
+        }
+        else {
+            ERROR('Failed to download Softaculous installer.');
+        }
+
+        return;
+    }
+
+    1;
+
+}    # --- END lib/Elevate/Components/Softaculous.pm
+
 {    # --- BEGIN lib/Elevate/Components/UnconvertedModules.pm
 
     package Elevate::Components::UnconvertedModules;
@@ -9237,6 +9314,7 @@ use Elevate::Components::Repositories       ();
 use Elevate::Components::RmMod              ();
 use Elevate::Components::RpmDB              ();
 use Elevate::Components::SSH                ();
+use Elevate::Components::Softaculous        ();
 use Elevate::Components::UnconvertedModules ();
 use Elevate::Components::WHM                ();
 use Elevate::Components::WPToolkit          ();
@@ -10288,6 +10366,7 @@ sub run_final_components_pre_distro_upgrade ($self) {
     $self->run_component_once( 'AbsoluteSymlinks' => 'pre_distro_upgrade' );
     $self->run_component_once( 'ELS'              => 'pre_distro_upgrade' );
     $self->run_component_once( 'R1Soft'           => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Softaculous'      => 'pre_distro_upgrade' );
     $self->run_component_once( 'Panopta'          => 'pre_distro_upgrade' );
     $self->run_component_once( 'Acronis'          => 'pre_distro_upgrade' );
     $self->run_component_once( 'RpmDB'            => 'pre_distro_upgrade' );    # remove the RPMs last
@@ -10319,6 +10398,7 @@ sub post_distro_upgrade_update_restore ($self) {
     $self->run_component_once( 'NixStats'        => 'post_distro_upgrade' );
     $self->run_component_once( 'LiteSpeed'       => 'post_distro_upgrade' );
     $self->run_component_once( 'R1Soft'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'Softaculous'     => 'post_distro_upgrade' );
     $self->run_component_once( 'PackageRestore'  => 'post_distro_upgrade' );
     $self->run_component_once( 'Acronis'         => 'post_distro_upgrade' );
 

--- a/lib/Elevate/Components.pm
+++ b/lib/Elevate/Components.pm
@@ -57,6 +57,7 @@ use Elevate::Components::Repositories       ();
 use Elevate::Components::RmMod              ();
 use Elevate::Components::RpmDB              ();
 use Elevate::Components::SSH                ();
+use Elevate::Components::Softaculous        ();
 use Elevate::Components::UnconvertedModules ();
 use Elevate::Components::WHM                ();
 use Elevate::Components::WPToolkit          ();
@@ -120,6 +121,7 @@ our @NOOP_CHECKS = qw{
   R1Soft
   RmMod
   RpmDB
+  Softaculous
   UnconvertedModules
   WPToolkit
   cPanelPlugins

--- a/lib/Elevate/Components/Softaculous.pm
+++ b/lib/Elevate/Components/Softaculous.pm
@@ -1,0 +1,84 @@
+package Elevate::Components::Softaculous;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::Components::Softaculous
+
+=head2 pre_distro_upgrade
+
+If we can query the version of Softaculous through their CLI tool, it is installed.
+
+=head2 post_distro_upgrade
+
+If Softaculous is installed, re-install it after the upgrade.
+
+NOTE: This needs to happen after cPanel is updated to work with the new OS, since Softaculous relies on cPanel PHP.
+
+=cut
+
+use cPstrict;
+
+use Elevate::Fetch     ();
+use Elevate::StageFile ();
+
+use Cpanel::Binaries        ();
+use Cpanel::SafeRun::Object ();
+
+use Log::Log4perl qw(:easy);
+
+use parent qw{Elevate::Components::Base};
+
+use Simple::Accessor qw(cli_path);
+
+sub _build_cli_path { return '/usr/local/cpanel/whostmgr/docroot/cgi/softaculous/cli.php' }
+
+sub pre_distro_upgrade ($self) {
+
+    return unless -r $self->cli_path;
+
+    my $sr = _run_script( $self->cli_path );
+
+    return if $sr->exec_failed() || $sr->to_exception();
+
+    my $version = $sr->stdout() // '';
+    chomp $version;
+
+    if ( length $version ) {
+        INFO('Softaculous has been detected. The system will re-install that software after the distro upgrade.');
+        Elevate::StageFile::update_stage_file( { softaculous => $version } );
+    }
+
+    return;
+}
+
+# split out for mocking purposes
+sub _run_script ($path) {
+    return Cpanel::SafeRun::Object->new(
+        program => Cpanel::Binaries::path('php'),
+        args    => [ $path, '--version' ],
+    );
+}
+
+sub post_distro_upgrade ($self) {
+
+    my $version = Elevate::StageFile::read_stage_file( 'softaculous', '' );
+    return unless length $version;
+
+    my $path = Elevate::Fetch::script( 'https://files.softaculous.com/install.sh', 'softaculous_install' );
+
+    if ($path) {
+        INFO('Re-installing Softaculous:');
+        if ( $self->ssystem( Cpanel::Binaries::path('bash'), $path, '--reinstall' ) ) {
+            ERROR('Re-installation of Softaculous failed.');
+        }
+    }
+    else {
+        ERROR('Failed to download Softaculous installer.');
+    }
+
+    return;
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -277,6 +277,7 @@ use Elevate::Components::Repositories       ();
 use Elevate::Components::RmMod              ();
 use Elevate::Components::RpmDB              ();
 use Elevate::Components::SSH                ();
+use Elevate::Components::Softaculous        ();
 use Elevate::Components::UnconvertedModules ();
 use Elevate::Components::WHM                ();
 use Elevate::Components::WPToolkit          ();
@@ -1328,6 +1329,7 @@ sub run_final_components_pre_distro_upgrade ($self) {
     $self->run_component_once( 'AbsoluteSymlinks' => 'pre_distro_upgrade' );
     $self->run_component_once( 'ELS'              => 'pre_distro_upgrade' );
     $self->run_component_once( 'R1Soft'           => 'pre_distro_upgrade' );
+    $self->run_component_once( 'Softaculous'      => 'pre_distro_upgrade' );
     $self->run_component_once( 'Panopta'          => 'pre_distro_upgrade' );
     $self->run_component_once( 'Acronis'          => 'pre_distro_upgrade' );
     $self->run_component_once( 'RpmDB'            => 'pre_distro_upgrade' );    # remove the RPMs last
@@ -1359,6 +1361,7 @@ sub post_distro_upgrade_update_restore ($self) {
     $self->run_component_once( 'NixStats'        => 'post_distro_upgrade' );
     $self->run_component_once( 'LiteSpeed'       => 'post_distro_upgrade' );
     $self->run_component_once( 'R1Soft'          => 'post_distro_upgrade' );
+    $self->run_component_once( 'Softaculous'     => 'post_distro_upgrade' );
     $self->run_component_once( 'PackageRestore'  => 'post_distro_upgrade' );
     $self->run_component_once( 'Acronis'         => 'post_distro_upgrade' );
 

--- a/t/components-Softaculous.t
+++ b/t/components-Softaculous.t
@@ -1,0 +1,82 @@
+#!/usr/local/cpanel/3rdparty/bin/perl
+
+#                                      Copyright 2024 WebPros International, LLC
+#                                                           All rights reserved.
+# copyright@cpanel.net                                         http://cpanel.net
+# This code is subject to the cPanel license. Unauthorized copying is prohibited.
+
+package test::cpev::components;
+
+use FindBin;
+
+use Test2::V0;
+use Test2::Tools::Explain;
+use Test2::Plugin::NoWarnings;
+use Test2::Tools::Exception;
+use Test2::Tools::Mock;
+
+use Test::MockModule qw/strict/;
+
+use lib $FindBin::Bin . "/lib";
+use Test::Elevate;
+
+use Cpanel::Exception ();
+use File::Temp        ();
+
+use cPstrict;
+
+my $comp = cpev->new->get_component('Softaculous');
+
+{
+    note "Checking pre_distro_upgrade";
+
+    ok( length $comp->cli_path, 'cli_path defaults to a reasonable string' );
+
+    my $mock_run = Test::MockModule->new('Elevate::Components::Softaculous');
+
+    $comp->cli_path('/file/does/not/exist');
+    $mock_run->redefine( _run_script => sub { die "I shouldn't run yet!" } );
+
+    ok( lives { $comp->pre_distro_upgrade() }, "Short-circuits if Softaculous CLI script does not exist" );
+    no_messages_seen();
+
+    my $tempfile = File::Temp->new();
+    $comp->cli_path( $tempfile->filename );
+
+    my ( $stdout, $exec_failed, $exception );
+    $mock_run->redefine(
+        _run_script => sub {
+            return mock {} => (
+                add => [
+                    stdout       => sub { return $stdout },
+                    exec_failed  => sub { return $exec_failed },
+                    to_exception => sub { return $exception },
+                ],
+            );
+        }
+    );
+
+    $stdout      = '1.2.3';
+    $exec_failed = 0;
+    $exception   = undef;
+
+    ok( lives { $comp->pre_distro_upgrade() }, "Runs correctly with no errors" );
+    message_seen( INFO => 'Softaculous has been detected. The system will re-install that software after the distro upgrade.' );
+    no_messages_seen();
+
+    $exec_failed = 1;
+    ok( lives { $comp->pre_distro_upgrade() }, "Short-circuits if SafeRun could not exec()" );
+    no_messages_seen();
+
+    $exec_failed = 0;
+    $exception   = Cpanel::Exception::create( 'ProcessFailed::Error' => [ error_code => 1 ] );
+    ok( lives { $comp->pre_distro_upgrade() }, "Short-circuits if script exits with error" );
+    no_messages_seen();
+
+    $exception = undef;
+    $stdout    = undef;
+    ok( lives { $comp->pre_distro_upgrade() }, "Runs correctly but returns no data (can this even happen?)" );
+    no_messages_seen();
+}
+
+done_testing();


### PR DESCRIPTION
Case RE-846: It was reported that the Softaculous plugin for cPanel was displaying blank pages after ELevate, and that a re-install of the plugin fixed this issue. That seems reasonable, so detect Softaculous and re-install if present.

Changelog: Re-install Softaculous after upgrade.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

