### PR TITLE
Fix race condition that can occur between ssh_retry and reboot_watch

### DIFF
--- a/.github/workflows/openstack.yml
+++ b/.github/workflows/openstack.yml
@@ -505,9 +505,17 @@ jobs:
           run: |
             ./ssh_retry ${{ steps.VM_IP.outputs.VM_IP }}
 
-    watch_for_final_reboot:
+    delay_final_reboot_watch:
       runs-on: self-hosted
       needs: wait_for_stage_5_reboot
+      steps:
+        - name: Wait 10 seconds
+          uses: actions/download-artifact@v4
+          run: sleep 10
+
+    watch_for_final_reboot:
+      runs-on: self-hosted
+      needs: delay_final_reboot_watch
       outputs:
         VM_IP: ${{ steps.VM_IP.outputs.VM_IP }}
       steps:

--- a/.github/workflows/openstack/ssh_retry
+++ b/.github/workflows/openstack/ssh_retry
@@ -6,7 +6,7 @@ my $HOST    = $ARGV[0];
 my $PORT    = $ARGV[1] // 22;
 my $RETVAL  = 1;
 my $RETRIES = 0;
-my $RETRY   = $ARGV[2] // 240;
+my $RETRY   = $ARGV[2] // 900;
 
 return unless defined $HOST;
 
@@ -32,5 +32,5 @@ while ( $RETVAL != 0 ) {
         print "## [$time] [ERROR]: ssh_retry.pl: MAX_RETRIES has been reached.\n";
         exit 1;
     }
-    sleep 5;
+    sleep 1;
 }


### PR DESCRIPTION
Case RE-928: Fix race condition that can occur

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

PLEASE LEAVE THIS OPEN UNTIL ADVISED

