### PR TITLE
Ensure final dnf update is executed

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -6717,8 +6717,8 @@ EOS
         return instance()->update_with_options( $options, $pkgs );
     }
 
-    sub update_allow_erasing (@args) {
-        return instance()->update_allow_erasing(@args);
+    sub update_allow_erasing (@additional_args) {
+        return instance()->update_allow_erasing(@additional_args);
     }
 
     sub makecache () {
@@ -6893,7 +6893,7 @@ EOS
         die "update_with_options unimplemented";
     }
 
-    sub update_allow_erasing ( $self, @args ) {
+    sub update_allow_erasing ( $self, @additional_args ) {
         die "update_allow_erasing unimplemented";
     }
 
@@ -7153,13 +7153,16 @@ EOS
         return;
     }
 
-    sub update_allow_erasing ( $self, @args ) {
+    sub update_allow_erasing ( $self, @additional_args ) {
         my $pkgmgr = $self->_pkgmgr();
 
-        my @additional_args = scalar @args ? @args : '';
+        my @args = (
+            '-y',
+            '--allowerasing',
+        );
 
-        $self->ssystem( $pkgmgr, '-y', '--allowerasing', @additional_args, 'update' );
-
+        push @args, @additional_args;
+        $self->ssystem_and_die( $pkgmgr, @args, 'update' );
         return;
     }
 

--- a/lib/Elevate/PkgMgr.pm
+++ b/lib/Elevate/PkgMgr.pm
@@ -125,8 +125,8 @@ sub update_with_options ( $options, $pkgs ) {
     return instance()->update_with_options( $options, $pkgs );
 }
 
-sub update_allow_erasing (@args) {
-    return instance()->update_allow_erasing(@args);
+sub update_allow_erasing (@additional_args) {
+    return instance()->update_allow_erasing(@additional_args);
 }
 
 sub makecache () {

--- a/lib/Elevate/PkgMgr/Base.pm
+++ b/lib/Elevate/PkgMgr/Base.pm
@@ -156,7 +156,7 @@ sub update_with_options ( $self, $options, $pkgs ) {
     die "update_with_options unimplemented";
 }
 
-sub update_allow_erasing ( $self, @args ) {
+sub update_allow_erasing ( $self, @additional_args ) {
     die "update_allow_erasing unimplemented";
 }
 

--- a/lib/Elevate/PkgMgr/YUM.pm
+++ b/lib/Elevate/PkgMgr/YUM.pm
@@ -254,13 +254,16 @@ sub update_with_options ( $self, $options, $pkgs ) {
     return;
 }
 
-sub update_allow_erasing ( $self, @args ) {
+sub update_allow_erasing ( $self, @additional_args ) {
     my $pkgmgr = $self->_pkgmgr();
 
-    my @additional_args = scalar @args ? @args : '';
+    my @args = (
+        '-y',
+        '--allowerasing',
+    );
 
-    $self->ssystem( $pkgmgr, '-y', '--allowerasing', @additional_args, 'update' );
-
+    push @args, @additional_args;
+    $self->ssystem_and_die( $pkgmgr, @args, 'update' );
     return;
 }
 


### PR DESCRIPTION
Case RE-934: In RE-252, a bug was introduced that resulted in the final dnf update spitting out help text instead of updating the system.  This change updates the command to be valid again so that the final update takes place.

Changelog: Ensure final dnf update is executed

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

