### PR TITLE
Add 'sys-snap' to the list of packages that PackageRestore handles

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4354,6 +4354,7 @@ EOS
     sub _get_packages_to_check () {
         return qw{
           net-snmp
+          sys-snap
         };
     }
 
@@ -4367,6 +4368,8 @@ EOS
                 push @installed_packages, $package;
             }
         }
+
+        Elevate::PkgMgr::remove(@installed_packages);
 
         my $config_files = Elevate::PkgMgr::get_config_files( \@installed_packages );
 

--- a/lib/Elevate/Components/PackageRestore.pm
+++ b/lib/Elevate/Components/PackageRestore.pm
@@ -35,6 +35,7 @@ use parent qw{Elevate::Components::Base};
 sub _get_packages_to_check () {
     return qw{
       net-snmp
+      sys-snap
     };
 }
 
@@ -48,6 +49,8 @@ sub pre_distro_upgrade ($self) {
             push @installed_packages, $package;
         }
     }
+
+    Elevate::PkgMgr::remove(@installed_packages);
 
     my $config_files = Elevate::PkgMgr::get_config_files( \@installed_packages );
 

--- a/t/components-PackageRestore.t
+++ b/t/components-PackageRestore.t
@@ -55,6 +55,7 @@ my $pkg_restore = cpev->new->get_component('PackageRestore');
             $pkgs_checked_for_config_files = $_[1];
             return \%config_files;
         },
+        remove => 1,
     );
 
     my $mock_upsf = Test::MockModule->new('Elevate::StageFile');


### PR DESCRIPTION
Case RE-952: This adds 'sys-snap' to the list of packages that the PackageRestore component handles.  It also now explicitely removes the packages as it was previously relying on leapp to implicitely remove them.

Changelog: Add 'sys-snap' to the list of packages that the
 PackageRestore component handles

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

