### PR TITLE
Avoid Perl error in 'Elevate::Components::Repositories'

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -5585,7 +5585,7 @@ EOS
         $self->{_yum_repos_path_using_invalid_syntax} = [];
         $self->{_yum_repos_to_disable}                = [];
         $self->{_yum_repos_unsupported_with_packages} = [];
-        $self->{_duplicate_repoids}                   = [];
+        $self->{_duplicate_repoids}                   = {};
 
         my @vetted_repos = Elevate::OS::vetted_yum_repo();
 
@@ -5713,6 +5713,7 @@ EOS
     }
 
     sub _autofix_duplicate_repoids ($self) {
+        return unless ref $self->{_duplicate_repoids} && ref $self->{_duplicate_repoids} eq 'HASH';
         my %duplicate_ids = $self->{_duplicate_repoids}->%*;
         foreach my $id ( keys %duplicate_ids ) {
             if ( $id =~ m/^MariaDB[0-9]+/ ) {

--- a/lib/Elevate/Components/Repositories.pm
+++ b/lib/Elevate/Components/Repositories.pm
@@ -326,7 +326,7 @@ sub _check_yum_repos ($self) {
     $self->{_yum_repos_path_using_invalid_syntax} = [];
     $self->{_yum_repos_to_disable}                = [];
     $self->{_yum_repos_unsupported_with_packages} = [];
-    $self->{_duplicate_repoids}                   = [];
+    $self->{_duplicate_repoids}                   = {};
 
     my @vetted_repos = Elevate::OS::vetted_yum_repo();
 
@@ -458,6 +458,7 @@ sub _check_yum_repos ($self) {
 }
 
 sub _autofix_duplicate_repoids ($self) {
+    return unless ref $self->{_duplicate_repoids} && ref $self->{_duplicate_repoids} eq 'HASH';
     my %duplicate_ids = $self->{_duplicate_repoids}->%*;
     foreach my $id ( keys %duplicate_ids ) {
         if ( $id =~ m/^MariaDB[0-9]+/ ) {


### PR DESCRIPTION
Case RE-964: This change adds a better guard in
'Elevate::Components::Repositories::_autofix_duplicate_repoids'. It also initializes '$self->{__duplicate_repoids} as a href instead of an aref.

Changelog: Avoid Perl error in 'Elevate::Components::Repositories'

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

