### PR TITLE
Update DiskSpace check to account for Ubuntu

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1590,9 +1590,11 @@ BEGIN {    # Suppress load of all of these at earliest point.
     sub _disk_space_check ($self) {
 
         my $need_space = {
-            '/boot'             => 120 * MEG,
+            '/boot'             => 200 * MEG,
             '/usr/local/cpanel' => 1.5 * GIG,    #
             '/var/lib'          => 5 * GIG,
+            '/tmp'              => 5 * MEG,
+            '/'                 => 5 * GIG,
         };
 
         my @keys = ( sort keys %$need_space );

--- a/lib/Elevate/Components/DiskSpace.pm
+++ b/lib/Elevate/Components/DiskSpace.pm
@@ -48,9 +48,11 @@ sub _disk_space_check ($self) {
     #   - /boot is small enough
     #   - /usr/local/cpanel is not going to be used at the same time than /var/lib
     my $need_space = {
-        '/boot'             => 120 * MEG,
+        '/boot'             => 200 * MEG,
         '/usr/local/cpanel' => 1.5 * GIG,    #
         '/var/lib'          => 5 * GIG,
+        '/tmp'              => 5 * MEG,
+        '/'                 => 5 * GIG,
     };
 
     my @keys = ( sort keys %$need_space );

--- a/t/components-DiskSpace.t
+++ b/t/components-DiskSpace.t
@@ -50,43 +50,49 @@ EOS
 
 like(
     dies { check_blocker() },
-    qr{expected 3 lines ; got 1 lines},
+    qr{expected 5 lines ; got 1 lines},
     "_disk_space_check"
 );
 
 $saferun_output = <<EOS;
 Filesystem     1K-blocks     Used Available Use% Mounted on
-/dev/vda1       83874796 76307692   7567104  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/loop6        714624       92    677364   1% /tmp
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
 EOS
 
 is( check_blocker(), 1, "_disk_space_check ok" );
 
-my $boot = 121 * MEG;
+my $boot = 201 * MEG;
 
 $saferun_output = <<"EOS";
 Filesystem     1K-blocks     Used Available Use% Mounted on
-/dev/vda1       83874796 76307692   $boot  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   $boot    56% /
+/dev/loop6        714624       92    677364   1% /tmp
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
 EOS
 
-is( check_blocker(), 1, "_disk_space_check ok - /boot 121 M" );
+is( check_blocker(), 1, "_disk_space_check ok - /boot 201 M" );
 
-$boot = 119 * MEG;
+$boot = 199 * MEG;
 
 $saferun_output = <<"EOS";
 Filesystem     1K-blocks     Used Available Use% Mounted on
-/dev/vda1       83874796 76307692   $boot  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   $boot    56% /
+/dev/loop6        714624       92    677364   1% /tmp
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
 EOS
 
 my $check;
 like(
     warnings { $check = check_blocker() },
-    [qr{/boot needs 120 M => available 119 M}],
+    [qr{/boot needs 200 M => available 199 M}],
     q[Got expected warnings]
 );
 
@@ -96,9 +102,11 @@ my $usr_local_cpanel = 2 * GIG;
 
 $saferun_output = <<"EOS";
 Filesystem     1K-blocks     Used Available Use% Mounted on
-/dev/vda1       83874796 76307692   7567104 91% /
-/dev/vda1       83874796 76307692   $usr_local_cpanel  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/loop6        714624       92    677364   1% /tmp
+/dev/vda1       20134592 11245932   $usr_local_cpanel  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
 EOS
 
 is( check_blocker(), 1, "_disk_space_check ok - /usr/local/cpanel 2 G" );
@@ -107,9 +115,11 @@ $usr_local_cpanel = 1.4 * GIG;
 
 $saferun_output = <<"EOS";
 Filesystem     1K-blocks     Used Available Use% Mounted on
-/dev/vda1       83874796 76307692   7567104 91% /
-/dev/vda1       83874796 76307692   $usr_local_cpanel  91% /
-/dev/vda1       83874796 76307692   7567104  91% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
+/dev/loop6        714624       92    677364   1% /tmp
+/dev/vda1       20134592 11245932   $usr_local_cpanel  56% /
+/dev/vda1       20134592 11245932   8872276  56% /
 EOS
 
 like(


### PR DESCRIPTION
Case RE-672: This increasing the amount of free space needed on '/boot'. It also adds a check for '/tmp' and '/' ensuring that they have a minimally amount of free space as well.

Changelog: Update DiskSpace check to account for Ubuntu

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

