### PR TITLE
Update the target OS for the EA4 blocker on Ubuntu 20 upgrades

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -2018,6 +2018,7 @@ EOS
             my $type = $dropped_pkgs->{$pkg} // '';
             next if $type eq 'exp';                          # use of experimental packages is a non blocker
             next if $pkg =~ m/^ea-openssl(?:11)?-devel$/;    # ignore these packages, as they can be orphans
+            next if $pkg =~ m/^ea-noop-u20$/;                # ignore this package since it is specifically for ubuntu 20
 
             if ( $pkg =~ m/^(ea-php[0-9]+)/ ) {
                 my $php_pkg = $1;
@@ -7232,7 +7233,7 @@ deb https://wp-toolkit.plesk.com/cPanel/Ubuntu-22.04-x86_64/latest/thirdparty/ .
 
     use constant default_upgrade_to => 'Ubuntu';
 
-    use constant ea_alias => 'Ubuntu_20.04';
+    use constant ea_alias => 'Ubuntu_22.04';
 
     use constant expected_post_upgrade_major => 22;
     use constant is_experimental             => 1;

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -271,6 +271,7 @@ sub _get_incompatible_packages ($self) {
         my $type = $dropped_pkgs->{$pkg} // '';
         next if $type eq 'exp';                          # use of experimental packages is a non blocker
         next if $pkg =~ m/^ea-openssl(?:11)?-devel$/;    # ignore these packages, as they can be orphans
+        next if $pkg =~ m/^ea-noop-u20$/;                # ignore this package since it is specifically for ubuntu 20
 
         if ( $pkg =~ m/^(ea-php[0-9]+)/ ) {
             my $php_pkg = $1;

--- a/lib/Elevate/OS/Ubuntu20.pm
+++ b/lib/Elevate/OS/Ubuntu20.pm
@@ -61,11 +61,7 @@ use constant supported_cpanel_nameserver_types => qw{
 
 use constant default_upgrade_to => 'Ubuntu';
 
-# TODO: This should be 'Ubuntu_22.04' but support does not exist
-#       for that target yet.  Leaving this as 'Ubuntu_20.04'
-#       for the MVP release
-#       Update it to Ubuntu_22.04 via RE-954 once it is unblocked
-use constant ea_alias => 'Ubuntu_20.04';
+use constant ea_alias => 'Ubuntu_22.04';
 
 use constant expected_post_upgrade_major => 22;
 use constant is_experimental             => 1;

--- a/t/components-ea4.t
+++ b/t/components-ea4.t
@@ -230,11 +230,10 @@ sub test_get_ea4_profile_check_mode : Test(26) ($self) {
         my $ea4 = $cpev->get_component('EA4');
         is( Elevate::EA4::_get_ea4_profile(1), $expected_profile, "_get_ea4_profile uses a temporary file for the profile" );
 
-        # TODO: Update this to Ubuntu_22.04 via RE-954
         my $expected_target =
             $os eq 'cent'  ? 'CentOS_8'
           : $os eq 'cloud' ? 'CloudLinux_8'
-          :                  'Ubuntu_20.04';
+          :                  'Ubuntu_22.04';
         message_seen( 'INFO' => "Running: /usr/local/bin/ea_current_to_profile --target-os=$expected_target --output=$expected_profile" );
         message_seen( 'INFO' => "Backed up EA4 profile to $expected_profile" );
 


### PR DESCRIPTION
Case RE-954: This change updates it so that we check against 'Ubuntu_22.04' instead of 'Ubuntu_20.04' for upgrades from u20->u22.  It also ignore the package 'ea-noop-u20' from the dropped packages list since this package is specific for u20.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

