### PR TITLE
Only perform mysql database is corrupted check in start mode

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4020,6 +4020,8 @@ EOS
 
     sub _blocker_mysql_database_corrupted ($self) {
 
+        return 0 if $self->is_check_mode();
+
         return 0 unless Cpanel::MysqlUtils::MyCnf::Basic::is_local_mysql();
 
         if ( !Cpanel::MysqlUtils::Running::is_mysql_running() ) {

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -369,6 +369,8 @@ sub _blocker_mysql_upgrade_in_progress ($self) {
 
 sub _blocker_mysql_database_corrupted ($self) {
 
+    return 0 if $self->is_check_mode();
+
     # Do not perform this check for remote mysql
     return 0 unless Cpanel::MysqlUtils::MyCnf::Basic::is_local_mysql();
 

--- a/t/components-MySQL.t
+++ b/t/components-MySQL.t
@@ -271,6 +271,17 @@ EOS
     $restart_mysql    = 0;
     @ssystem_output   = ();
 
+    my $mock_elevate_comp = Test::MockModule->new('Elevate::Components');
+    $mock_elevate_comp->redefine(
+        is_check_mode => 1,
+    );
+
+    is( $db->_blocker_mysql_database_corrupted(), 0, 'The check is a noop in check mode' );
+
+    $mock_elevate_comp->redefine(
+        is_check_mode => 0,
+    );
+
     like(
         $db->_blocker_mysql_database_corrupted(),
         {


### PR DESCRIPTION
Case RE-974: The database corrupted check was being executed in check mode which runs via security advisor on a nightly basis.  This can cause additional load on servers with large databases.  It is also only relevant during start mode since a database can become corrupt at any given time.  As such, this change makes it so that this check is only performed during start mode.

Changelog: Only perform the check to determine if MySQL has any
 corrupted databases while in start mode

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

