### PR TITLE
Prefer using apt-get over apt in Elevate::PkgMgr

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -7413,7 +7413,6 @@ deb https://wp-toolkit.plesk.com/cPanel/Ubuntu-22.04-x86_64/latest/thirdparty/ .
       -o Dpkg::Options::=--force-confold
     };
 
-    our $apt        = '/usr/bin/apt';
     our $apt_get    = '/usr/bin/apt-get';
     our $apt_mark   = '/usr/bin/apt-mark';
     our $dpkg       = '/usr/bin/dpkg';
@@ -7535,10 +7534,11 @@ deb https://wp-toolkit.plesk.com/cPanel/Ubuntu-22.04-x86_64/latest/thirdparty/ .
 
         my @apt_args = (
             '-y',
+            '--with-new-pkgs',
             APT_NON_INTERACTIVE_ARGS,
         );
 
-        $self->ssystem_and_die( $apt, @apt_args, 'upgrade' );
+        $self->ssystem_and_die( $apt_get, @apt_args, 'upgrade' );
 
         return;
     }
@@ -7548,13 +7548,13 @@ deb https://wp-toolkit.plesk.com/cPanel/Ubuntu-22.04-x86_64/latest/thirdparty/ .
     }
 
     sub update_allow_erasing ( $self, @additional_args ) {
-        $self->ssystem_and_die( $apt, '-y', 'autoremove', '--purge' );
+        $self->ssystem_and_die( $apt_get, '-y', 'autoremove', '--purge' );
         $self->update();
         return;
     }
 
     sub makecache ($self) {
-        my $out    = $self->ssystem_capture_output( $apt, 'update' );
+        my $out    = $self->ssystem_capture_output( $apt_get, 'update' );
         my @errors = grep { $_ !~ m/apt does not have a stable CLI interface/ } @{ $out->{stderr} };
         my $stderr = join "\n", @errors;
         return $stderr;

--- a/lib/Elevate/PkgMgr/APT.pm
+++ b/lib/Elevate/PkgMgr/APT.pm
@@ -25,7 +25,6 @@ use constant APT_NON_INTERACTIVE_ARGS => qw{
   -o Dpkg::Options::=--force-confold
 };
 
-our $apt        = '/usr/bin/apt';
 our $apt_get    = '/usr/bin/apt-get';
 our $apt_mark   = '/usr/bin/apt-mark';
 our $dpkg       = '/usr/bin/dpkg';
@@ -197,10 +196,11 @@ sub update ($self) {
 
     my @apt_args = (
         '-y',
+        '--with-new-pkgs',
         APT_NON_INTERACTIVE_ARGS,
     );
 
-    $self->ssystem_and_die( $apt, @apt_args, 'upgrade' );
+    $self->ssystem_and_die( $apt_get, @apt_args, 'upgrade' );
 
     return;
 }
@@ -218,13 +218,13 @@ sub update_with_options ( $self, $options, $pkgs ) {
 }
 
 sub update_allow_erasing ( $self, @additional_args ) {
-    $self->ssystem_and_die( $apt, '-y', 'autoremove', '--purge' );
+    $self->ssystem_and_die( $apt_get, '-y', 'autoremove', '--purge' );
     $self->update();
     return;
 }
 
 sub makecache ($self) {
-    my $out    = $self->ssystem_capture_output( $apt, 'update' );
+    my $out    = $self->ssystem_capture_output( $apt_get, 'update' );
     my @errors = grep { $_ !~ m/apt does not have a stable CLI interface/ } @{ $out->{stderr} };
     my $stderr = join "\n", @errors;
     return $stderr;


### PR DESCRIPTION
Case RE-980: apt will throw a warning to STDERR that it is not intended for scripts which causes unnecessary noise in the elevate logs.  This change updates Elevate::PkgMgr to prefer apt-get over apt in order to avoid this warning and help make parsing output more consistent

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

