### PR TITLE
The `Openstack Pruner` job is consistently failing

### DIFF
--- a/.github/workflows/openstack/prune_openstack
+++ b/.github/workflows/openstack/prune_openstack
@@ -5,19 +5,10 @@ use POSIX    ();
 use strict;
 use warnings;
 
-# Environment constants
-our $OS_APPLICATION_CREDENTIAL_ID     = $ENV{OS_APPLICATION_CREDENTIAL_ID};
-our $OS_APPLICATION_CREDENTIAL_SECRET = $ENV{OS_APPLICATION_CREDENTIAL_SECRET};
-
 # Static constants
 use constant {
-    OS_AUTH_TYPE            => 'v3applicationcredential',
-    OS_AUTH_URL             => 'https://keystone.hou-01.cloud.prod.cpanel.net:5000/v3',
-    OS_IDENTITY_API_VERSION => '3',
-    OS_REGION_NAME          => 'RegionOne',
-    OS_INTERFACE            => 'public',
-    KEY_NAME                => "deletethis",
-    VM_NAME                 => "elevate.github.cpanel.net",
+    KEY_NAME => "deletethis",
+    VM_NAME  => "elevate.github.cpanel.net",
 };
 
 my $openstack_path = "/usr/bin/openstack" if -x "/usr/bin/openstack";

--- a/.github/workflows/pruner.yml
+++ b/.github/workflows/pruner.yml
@@ -10,6 +10,11 @@ jobs:
         ACTIONS_STEP_DEBUG: true
         OS_APPLICATION_CREDENTIAL_ID: ${{ secrets.OS_APPLICATION_CREDENTIAL_ID }}
         OS_APPLICATION_CREDENTIAL_SECRET: ${{ secrets.OS_APPLICATION_CREDENTIAL_SECRET }}
+        OS_AUTH_TYPE: 'v3applicationcredential'
+        OS_AUTH_URL: 'https://keystone.hou-01.cloud.prod.cpanel.net:5000/v3'
+        OS_IDENTITY_API_VERSION: '3'
+        OS_INTERFACE: 'public'
+        OS_REGION_NAME: 'RegionOne'
       steps:
         - uses: actions/checkout@v4
         - name: Run Openstack Pruner


### PR DESCRIPTION
Case RE-1000: The `Openstack Pruner` job is consistently failing
 - Moved all ENV exports to workflow file for export

Changelog:

