### PR TITLE
Add auto retry for package manager based commands

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -9174,7 +9174,22 @@ EOS
 
     sub ssystem_and_die ( $self, @args ) {
         $self->ssystem(@args) or return 0;
-        Carp::croak("command failed. Fix it and run command.");
+
+        my $cmd = join ' ', @args;
+        if ( $args[0] =~ m/yum|dnf|apt|rpm|dpkg/ ) {
+            WARN("Initial attempt to execute '$cmd' failed. Attempting again");
+
+            $self->sleep();
+
+            $self->ssystem(@args) or return 0;
+        }
+
+        Carp::croak("‘$cmd’ failed. Review and fix the error, then try again with ‘/scripts/elevate-cpanel --continue’");
+    }
+
+    sub sleep ($self) {
+        sleep 15;
+        return;
     }
 
     sub _ssystem ( $command, %opts ) {


### PR DESCRIPTION
Case RE-996: This makes it so that we automatically retry package manager commands that fail on the first attempt.  The reason for this change is that there is a network element involved that can sometimes fail due to temporary mirror problems and the command can pass after waiting for a few seconds.

Changelog: Add auto retry for package manager based commands

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

