### PR TITLE
Switch to Alma8 for testsuite

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -43,15 +43,15 @@ jobs:
 
       - run: perl -V
 
-      - name: Install Perl dependencies
+      - name: cpanel-setup
+        run: /bin/bash t/cpanel-setup
+
+      - name: Install Extra Perl dependencies
         uses: perl-actions/install-with-cpm@v1
         with:
           sudo: false
           cpanfile: "t/cpanfile"
           args: "--with-all"
-
-      - name: cpanel-setup
-        run: /bin/bash t/cpanel-setup
 
       - name: which prove
         run: ls -l $(which prove)

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -21,36 +21,43 @@ jobs:
       PERL_USE_UNSAFE_INC: 1
       CPANEL_BIN_PATH: /usr/local/cpanel/3rdparty/bin
       CPANEL_PERL: /usr/local/cpanel/3rdparty/perl/536/bin/perl
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-
+    # Note: the container is not a CentOS 7 distro
+    #       this is ok if we use it for unit test purpose
+    #       we are also relying on e2e test using C7 VM on self-hosted runner.
     container:
-      image: cpanelos/perl-compiler:perl-v5.36.0
+      image: cpanelos/perl-compiler:alma8-perl-v5.36.0
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+
       - name: Setup PATH
         run: |
-          echo $CPANEL_BIN_PATH >> $GITHUB_PATH;
-          $CPANEL_PERL -MConfig -E 'say $Config{sitebin}'   >> $GITHUB_PATH
-          $CPANEL_PERL -MConfig -E 'say $Config{vendorbin}' >> $GITHUB_PATH
+            echo $CPANEL_BIN_PATH >> $GITHUB_PATH;
+            $CPANEL_PERL -MConfig -E 'say $Config{sitebin}'   >> $GITHUB_PATH
+            $CPANEL_PERL -MConfig -E 'say $Config{vendorbin}' >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - run: perl -V
-      - name: install Perl dependencies
-        uses: perl-actions/install-with-cpm@v1.7
+
+      - name: Install Perl dependencies
+        uses: perl-actions/install-with-cpm@v1
         with:
           sudo: false
           cpanfile: "t/cpanfile"
           args: "--with-all"
+
       - name: cpanel-setup
         run: /bin/bash t/cpanel-setup
+
       - name: which prove
         run: ls -l $(which prove)
+
       - run: perl -cw elevate-cpanel
+
       - name: Run tests
         run: prove -lv -It/lib t/*.t
 

--- a/t/00_load.t
+++ b/t/00_load.t
@@ -5,8 +5,7 @@
 # copyright@cpanel.net                                         http://cpanel.net
 # This code is subject to the cPanel license. Unauthorized copying is prohibited.
 
-use strict;
-use warnings;
+use cPstrict;
 use FindBin;
 
 use version;

--- a/t/cpanel-setup
+++ b/t/cpanel-setup
@@ -5,55 +5,11 @@
 # copyright@cpanel.net                                         http://cpanel.net
 # This code is subject to the cPanel license. Unauthorized copying is prohibited.
 
-set -e
+set -ex
 
 ULC=/usr/local/cpanel
 VERSION=11.110.0.17
 REPO=$(pwd)
-
-rm -f /etc/yum.repos.d/CentOS-Base.repo
-cat <<'EOF' > /etc/yum.repos.d/CentOS-Base.repo
-# CentOS-Base.repo
-#
-# The mirror system uses the connecting IP address of the client and the
-# update status of each mirror to pick mirrors that are updated to and
-# geographically close to the client.  You should use this for CentOS updates
-# unless you are manually picking other mirrors.
-#
-# If the mirrorlist= does not work for you, as a fall back you can try the
-# remarked out baseurl= line instead.
-#
-#
-
-[base]
-name=CentOS-$releasever - Base
-baseurl=https://vault.centos.org/7.9.2009/os/$basearch
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-
-#released updates
-[updates]
-name=CentOS-$releasever - Updates
-baseurl=https://vault.centos.org/7.9.2009/updates/$basearch
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-
-#additional packages that may be useful
-[extras]
-name=CentOS-$releasever - Extras
-baseurl=https://vault.centos.org/7.9.2009/extras/$basearch
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-
-#additional packages that extend functionality of existing packages
-[centosplus]
-name=CentOS-$releasever - Plus
-baseurl=https://vault.centos.org/7.9.2009/centosplus/$basearch
-gpgcheck=1
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
-
-EOF
 
 yum clean all
 
@@ -66,6 +22,7 @@ wget http://httpupdate.cpanel.net/cpanelsync/${VERSION}/install/common/cpanel.ta
     -o wget.log \
     -O cpanel.tar.xz
 
+ls -l cpanel.tar.xz
 unxz cpanel.tar.xz
 
 mkdir -p $ULC
@@ -75,6 +32,10 @@ mkdir -p $ULC/3rdparty/bin
 tar xf cpanel.tar -C $ULC
 
 pushd $ULC
+
+export CPANEL_BASE_INSTALL=1
+
+echo 'signature_validation=Off' >> /var/cpanel/cpanel.config
 
 echo "# ............. setup symlinks"
 ln -sf usr/local/cpanel/scripts /scripts
@@ -94,17 +55,13 @@ which perl
 ls -l /usr/local/cpanel/3rdparty/perl/536/bin/perl
 
 echo "# ............. cpanm round 2"
-#perl bin/cpanm -n Params::Util
 perl bin/cpanm -n --cpanfile ${REPO}/t/cpanfile --installdeps .
-#Crypt::Cracklib
 
 echo "# ............. scripts/cpservice"
 scripts/cpservice cpanel install ||:
 
 echo "# ............. install fake tailwatchd service"
 install ${REPO}/t/setup/tailwatchd.fake.service /etc/systemd/system/tailwatchd.service
-#systemctl daemon-reload
-#systemctl start tailwatchd
 
 echo "# ............. scripts/sysup"
 /scripts/sysup ||:

--- a/t/cpanel-setup
+++ b/t/cpanel-setup
@@ -54,9 +54,6 @@ echo "# ............. which perl"
 which perl
 ls -l /usr/local/cpanel/3rdparty/perl/536/bin/perl
 
-echo "# ............. cpanm round 2"
-perl bin/cpanm -n --cpanfile ${REPO}/t/cpanfile --installdeps .
-
 echo "# ............. scripts/cpservice"
 scripts/cpservice cpanel install ||:
 

--- a/t/cpanfile
+++ b/t/cpanfile
@@ -5,139 +5,16 @@
 # copyright@cpanel.net                                         http://cpanel.net
 # This code is subject to the cPanel license. Unauthorized copying is prohibited.
 
-requires "Algorithm::Dependency::Ordered";
-requires "Config::Tiny";
-requires "File::Copy::Recursive";
-requires "File::Slurper";
-requires "Hash::Merge";
-requires "HTTP::Tiny::UA::Response";
-requires "Log::Log4perl";
-requires "Moo";
-requires "Params::Util";
-requires "Simple::Accessor";
-requires "Sub::Identify";
-requires "Net::CIDR";
-requires "IO::Prompt";
+##
+## This file is listing extra dependencies not provided by the default cPanel stack
+##
 
 # test
 on 'test' => sub {
-    requires "File::Temp";
-    requires "Overload::FileCheck";
-    requires "Pod::PlainText";
-    requires "Test2::Bundle::Extended";
-    requires "Test2::Plugin::NoWarnings";
-    requires "Test2::Tools::Explain";
-    requires "Test::MockFile" => "0.032";
-    requires "Test::MockModule";
-    requires "Test::More";
-    requires "Test::Class";
-    requires "Test::Simple";
 
-    # perlcritic
-    recommends "Perl::Critic::Policy::CodeLayout::ProhibitFatCommaNewline";
-    recommends "Perl::Critic::Policy::CodeLayout::ProhibitIfIfSameLine";
-    recommends "Perl::Critic::Policy::CodeLayout::RequireFinalSemicolon";
-    recommends "Perl::Critic::Policy::CodeLayout::RequireTrailingCommaAtNewline";
-    recommends "Perl::Critic::Policy::Community::AmpersandSubCalls";
-    recommends "Perl::Critic::Policy::Community::ArrayAssignAref";
-    recommends "Perl::Critic::Policy::Community::BarewordFilehandles";
-    recommends "Perl::Critic::Policy::Community::ConditionalDeclarations";
-    recommends "Perl::Critic::Policy::Community::ConditionalImplicitReturn";
-    recommends "Perl::Critic::Policy::Community::DeprecatedFeatures";
-    recommends "Perl::Critic::Policy::Community::DiscouragedModules";
-    recommends "Perl::Critic::Policy::Community::DollarAB";
-    recommends "Perl::Critic::Policy::Community::Each";
-    recommends "Perl::Critic::Policy::Community::EmptyReturn";
-    recommends "Perl::Critic::Policy::Community::IndirectObjectNotation";
-    recommends "Perl::Critic::Policy::Community::LexicalForeachIterator";
-    recommends "Perl::Critic::Policy::Community::LoopOnHash";
-    recommends "Perl::Critic::Policy::Community::ModPerl";
-    recommends "Perl::Critic::Policy::Community::MultidimensionalArrayEmulation";
-    recommends "Perl::Critic::Policy::Community::OverloadOptions";
-    recommends "Perl::Critic::Policy::Community::POSIXImports";
-    recommends "Perl::Critic::Policy::Community::PackageMatchesFilename";
-    recommends "Perl::Critic::Policy::Community::PreferredAlternatives";
-    recommends "Perl::Critic::Policy::Community::StrictWarnings";
-    recommends "Perl::Critic::Policy::Community::Threads";
-    recommends "Perl::Critic::Policy::Community::WarningsSwitch";
-    recommends "Perl::Critic::Policy::Community::WarningsSwitch";
-    recommends "Perl::Critic::Policy::Compatibility::ConstantLeadingUnderscore";
-    recommends "Perl::Critic::Policy::Compatibility::ConstantPragmaHash";
-    recommends "Perl::Critic::Policy::Compatibility::Gtk2Constants";
-    recommends "Perl::Critic::Policy::Compatibility::PerlMinimumVersionAndWhy";
-    recommends "Perl::Critic::Policy::Compatibility::PodMinimumVersion";
-    recommends "Perl::Critic::Policy::Compatibility::ProhibitUnixDevNull";
-    recommends "Perl::Critic::Policy::CompileTime";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitAdjacentLinks";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitBadAproposMarkup";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitDuplicateHeadings";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitDuplicateSeeAlso";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitLinkToSelf";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitParagraphEndComma";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitParagraphTwoDots";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitUnbalancedParens";
-    recommends "Perl::Critic::Policy::Documentation::ProhibitVerbatimMarkup";
-    recommends "Perl::Critic::Policy::Documentation::RequireEndBeforeLastPod";
-    recommends "Perl::Critic::Policy::Documentation::RequireFilenameMarkup";
-    recommends "Perl::Critic::Policy::Documentation::RequireFinalCut";
-    recommends "Perl::Critic::Policy::Documentation::RequireLinkedURLs";
-    recommends "Perl::Critic::Policy::Freenode::AmpersandSubCalls";
-    recommends "Perl::Critic::Policy::Freenode::ArrayAssignAref";
-    recommends "Perl::Critic::Policy::Freenode::BarewordFilehandles";
-    recommends "Perl::Critic::Policy::Freenode::ConditionalDeclarations";
-    recommends "Perl::Critic::Policy::Freenode::ConditionalImplicitReturn";
-    recommends "Perl::Critic::Policy::Freenode::DeprecatedFeatures";
-    recommends "Perl::Critic::Policy::Freenode::DiscouragedModules";
-    recommends "Perl::Critic::Policy::Freenode::DollarAB";
-    recommends "Perl::Critic::Policy::Freenode::Each";
-    recommends "Perl::Critic::Policy::Freenode::EmptyReturn";
-    recommends "Perl::Critic::Policy::Freenode::IndirectObjectNotation";
-    recommends "Perl::Critic::Policy::Freenode::LexicalForeachIterator";
-    recommends "Perl::Critic::Policy::Freenode::LoopOnHash";
-    recommends "Perl::Critic::Policy::Freenode::ModPerl";
-    recommends "Perl::Critic::Policy::Freenode::MultidimensionalArrayEmulation";
-    recommends "Perl::Critic::Policy::Freenode::OpenArgs";
-    recommends "Perl::Critic::Policy::Freenode::OverloadOptions";
-    recommends "Perl::Critic::Policy::Freenode::POSIXImports";
-    recommends "Perl::Critic::Policy::Freenode::PackageMatchesFilename";
-    recommends "Perl::Critic::Policy::Freenode::PreferredAlternatives";
-    recommends "Perl::Critic::Policy::Freenode::Prototypes";
-    recommends "Perl::Critic::Policy::Freenode::StrictWarnings";
-    recommends "Perl::Critic::Policy::Freenode::Threads";
-    recommends "Perl::Critic::Policy::Freenode::Wantarray";
-    recommends "Perl::Critic::Policy::Freenode::WarningsSwitch";
-    recommends "Perl::Critic::Policy::Freenode::WhileDiamondDefaultAssignment";
-    recommends "Perl::Critic::Policy::Miscellanea::TextDomainPlaceholders";
-    recommends "Perl::Critic::Policy::Miscellanea::TextDomainUnused";
-    recommends "Perl::Critic::Policy::Modules::ProhibitModuleShebang";
-    recommends "Perl::Critic::Policy::Modules::ProhibitPOSIXimport";
-    recommends "Perl::Critic::Policy::Modules::ProhibitUseQuotedVersion";
-    recommends "Perl::Critic::Policy::Modules::RequireExplicitInclusion";
-    recommends "Perl::Critic::Policy::Subroutines::ProhibitCallsToUndeclaredSubs";
-    recommends "Perl::Critic::Policy::Subroutines::ProhibitCallsToUnexportedSubs";
-    recommends "Perl::Critic::Policy::Subroutines::ProhibitExportingUndeclaredSubs";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ConstantBeforeLt";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::NotWithCompare";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitBarewordDoubleColon";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitDuplicateHashKeys";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitEmptyCommas";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitFiletest_f";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitNullStatements";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::ProhibitUnknownBackslash";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::RequireNumericVersion";
-    recommends "Perl::Critic::Policy::ValuesAndExpressions::UnexpandedSpecialLiteral";
-    recommends "Perl::Critic::Policy::Variables::ProhibitLoopOnHash";
-    recommends "Perl::Critic::Policy::Community::OpenArgs";
-    recommends "Perl::Critic::Policy::Community::Prototypes";
-    recommends "Perl::Critic::Policy::Community::Wantarray";
-    recommends "Perl::Critic::Policy::Subroutines::ProhibitQualifiedSubDeclarations";
+    requires "Test::MockFile" => "0.032";
 
     # test coverage
-    recommends "Devel::Cover";
-    recommends "Template";
-    recommends "JSON::MaybeXS";
-    recommends "Perl::Critic::Policy::TestingAndDebugging::ProhibitNoWarnings";
     recommends "Test::Perl::Critic";
     recommends "Test::PerlTidy";
     recommends "Test::Pod";

--- a/t/cpanfile
+++ b/t/cpanfile
@@ -31,6 +31,7 @@ on 'test' => sub {
     requires "Test::MockModule";
     requires "Test::More";
     requires "Test::Class";
+    requires "Test::Simple";
 
     # perlcritic
     recommends "Perl::Critic::Policy::CodeLayout::ProhibitFatCommaNewline";


### PR DESCRIPTION
We originally used a CentOS 7 container. But it cannot be used to run native GitHub Actions relying on `node20`.
With this change we bump the container to use a more modern Almalinux 8 flavor, which is used for running our unit tests.

Note that we preserve the e2e test using a self-hosted runner relying on C7 VMs.
