### PR TITLE
Update strings to be language agnostic for Ubuntu

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -600,7 +600,15 @@ BEGIN {    # Suppress load of all of these at earliest point.
 
     sub check ($self) {
         my %links = $self->get_abs_symlinks();
-        WARN( "Symlinks with absolute paths have been found in /:\n\t" . join( ", ", sort keys(%links) ) . "\n" . "This can cause problems during the leapp run, so\n" . 'these will be corrected to be relative symlinks before elevation.' ) if %links;
+
+        my $ln_string = join ", ", sort keys %links;
+        WARN( <<~"EOS" );
+    Symlinks with absolute paths were found in /:
+        $ln_string
+    This can cause problems during the upgrade, and
+    the script will correct them to relative symlinks before elevation.
+    EOS
+
         return;
     }
 
@@ -1721,7 +1729,7 @@ EOS
 
     sub _blocker_is_experimental_os ($self) {
         if ( -e '/var/cpanel/caches/Cpanel-OS.custom' ) {
-            return $self->has_blocker('Experimental OS detected. This script only supports CentOS 7 upgrades');
+            return $self->has_blocker('Experimental operating system detected. This script does not support experimental OS upgrades.');
         }
 
         return 0;
@@ -3091,7 +3099,7 @@ EOS
         if ( _is_container_envtype() ) {
             return $self->has_blocker( <<~'EOS');
         cPanel thinks that this is a container-like environment.
-        This cannot be upgraded by the native leapp tool.
+        This script cannot upgrade container environments.
         Consider contacting your hypervisor provider for alternative solutions.
         EOS
         }
@@ -6300,8 +6308,10 @@ EOS
 
         if ( $setup !~ m{^\s*PermitRootLogin\b}m ) {
             WARN( <<~"EOS" );
-        OpenSSH configuration file does not explicitly state the option PermitRootLogin in sshd_config file, which will default in RHEL8 to "prohibit-password".
-        We will set the 'PermitRootLogin' value in $sshd_config to 'yes' before upgrading.
+        The OpenSSH configuration file does not explicitly state the PermitRootLogin
+        option in the sshd_config file. This option may default to "prohibit-password"
+        after the upgrade is complete. We will set the 'PermitRootLogin' value in
+        $sshd_config to 'yes' before upgrading.
 
         EOS
 
@@ -10538,9 +10548,9 @@ sub start ($self) {
         WARN( <<~"EOS");
         Automated upgrade of the distro has been disabled.
         Please wait for the file '$touchfile' to be created.
-        At that stage, the ELevate process is paused, and you can upgrade from 7 to 8 on your own.
+        When this file is created, the ELevate process is paused and you can upgrade on your own.
 
-        Once the system has been successfully upgraded from 7 to 8, you can then remove that file
+        After the system completes the upgrade, you can remove the '$touchfile' file.
         to let the ELevate process continue and update cPanel for the new distribution.
         EOS
         Elevate::StageFile::update_stage_file( { upgrade_distro_manually => 1 } );
@@ -11028,7 +11038,28 @@ sub run_stage_3 ($self) {
         $self->ssystem_and_die( '/usr/bin/mount', '-o', 'remount,exec', '/tmp' );
 
         INFO('Running do-release-upgrade');
-        $self->ssystem_and_die( '/usr/bin/do-release-upgrade', '-f', 'DistUpgradeViewNonInteractive' );
+        my $ret = $self->ssystem_capture_output( '/usr/bin/do-release-upgrade', '-f', 'DistUpgradeViewNonInteractive' );
+
+        if ( $ret->{status} != 0 ) {
+            my $stderr = join "\n", @{ $ret->{stderr} };
+
+            my $error_message = <<~"EOS";
+            The do-release-upgrade script failed with the following error message:
+
+            $stderr
+
+            You may need to investigate the logs in /var/log/dist-upgrade
+            to find the cause.
+
+            After you resolve the issue(s), run the following command to continue
+            the elevation process:
+
+            /scripts/elevate-cpanel --continue
+
+            EOS
+
+            die $error_message;
+        }
     }
 
     WARN(<<~'EOS');
@@ -11093,7 +11124,7 @@ sub run_stage_4 ($self) {
         }
 
         my $msg = <<~"END";
-        Server is currently running $current_distro $major after leapp upgrade.
+        Server is currently running $current_distro $major after distro upgrade.
         Upgrade to $pretty_distro_name did not succeed.
 
         END

--- a/lib/Elevate/Components/AbsoluteSymlinks.pm
+++ b/lib/Elevate/Components/AbsoluteSymlinks.pm
@@ -73,7 +73,15 @@ sub _absolute_symlinks ($self) {
 
 sub check ($self) {
     my %links = $self->get_abs_symlinks();
-    WARN( "Symlinks with absolute paths have been found in /:\n\t" . join( ", ", sort keys(%links) ) . "\n" . "This can cause problems during the leapp run, so\n" . 'these will be corrected to be relative symlinks before elevation.' ) if %links;
+
+    my $ln_string = join ", ", sort keys %links;
+    WARN( <<~"EOS" );
+    Symlinks with absolute paths were found in /:
+        $ln_string
+    This can cause problems during the upgrade, and
+    the script will correct them to relative symlinks before elevation.
+    EOS
+
     return;
 }
 

--- a/lib/Elevate/Components/Distros.pm
+++ b/lib/Elevate/Components/Distros.pm
@@ -72,7 +72,7 @@ sub _blocker_is_old_centos7 ($self) {
 
 sub _blocker_is_experimental_os ($self) {
     if ( -e '/var/cpanel/caches/Cpanel-OS.custom' ) {
-        return $self->has_blocker('Experimental OS detected. This script only supports CentOS 7 upgrades');
+        return $self->has_blocker('Experimental operating system detected. This script does not support experimental OS upgrades.');
     }
 
     return 0;

--- a/lib/Elevate/Components/IsContainer.pm
+++ b/lib/Elevate/Components/IsContainer.pm
@@ -32,7 +32,7 @@ sub check ($self) {    # $self is a cpev object here
     if ( _is_container_envtype() ) {
         return $self->has_blocker( <<~'EOS');
         cPanel thinks that this is a container-like environment.
-        This cannot be upgraded by the native leapp tool.
+        This script cannot upgrade container environments.
         Consider contacting your hypervisor provider for alternative solutions.
         EOS
     }

--- a/lib/Elevate/Components/SSH.pm
+++ b/lib/Elevate/Components/SSH.pm
@@ -69,8 +69,10 @@ sub _check_ssh_config ($self) {
 
     if ( $setup !~ m{^\s*PermitRootLogin\b}m ) {
         WARN( <<~"EOS" );
-        OpenSSH configuration file does not explicitly state the option PermitRootLogin in sshd_config file, which will default in RHEL8 to "prohibit-password".
-        We will set the 'PermitRootLogin' value in $sshd_config to 'yes' before upgrading.
+        The OpenSSH configuration file does not explicitly state the PermitRootLogin
+        option in the sshd_config file. This option may default to "prohibit-password"
+        after the upgrade is complete. We will set the 'PermitRootLogin' value in
+        $sshd_config to 'yes' before upgrading.
 
         EOS
 

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -554,9 +554,9 @@ sub start ($self) {
         WARN( <<~"EOS");
         Automated upgrade of the distro has been disabled.
         Please wait for the file '$touchfile' to be created.
-        At that stage, the ELevate process is paused, and you can upgrade from 7 to 8 on your own.
+        When this file is created, the ELevate process is paused and you can upgrade on your own.
 
-        Once the system has been successfully upgraded from 7 to 8, you can then remove that file
+        After the system completes the upgrade, you can remove the '$touchfile' file.
         to let the ELevate process continue and update cPanel for the new distribution.
         EOS
         Elevate::StageFile::update_stage_file( { upgrade_distro_manually => 1 } );
@@ -1044,7 +1044,28 @@ sub run_stage_3 ($self) {
         $self->ssystem_and_die( '/usr/bin/mount', '-o', 'remount,exec', '/tmp' );
 
         INFO('Running do-release-upgrade');
-        $self->ssystem_and_die( '/usr/bin/do-release-upgrade', '-f', 'DistUpgradeViewNonInteractive' );
+        my $ret = $self->ssystem_capture_output( '/usr/bin/do-release-upgrade', '-f', 'DistUpgradeViewNonInteractive' );
+
+        if ( $ret->{status} != 0 ) {
+            my $stderr = join "\n", @{ $ret->{stderr} };
+
+            my $error_message = <<~"EOS";
+            The do-release-upgrade script failed with the following error message:
+
+            $stderr
+
+            You may need to investigate the logs in /var/log/dist-upgrade
+            to find the cause.
+
+            After you resolve the issue(s), run the following command to continue
+            the elevation process:
+
+            /scripts/elevate-cpanel --continue
+
+            EOS
+
+            die $error_message;
+        }
     }
 
     WARN(<<~'EOS');
@@ -1109,7 +1130,7 @@ sub run_stage_4 ($self) {
         }
 
         my $msg = <<~"END";
-        Server is currently running $current_distro $major after leapp upgrade.
+        Server is currently running $current_distro $major after distro upgrade.
         Upgrade to $pretty_distro_name did not succeed.
 
         END

--- a/t/components-Distros.t
+++ b/t/components-Distros.t
@@ -82,7 +82,7 @@ my $distros = $cpev->get_blocker('Distros');
         $distros->check(),
         {
             id  => q[Elevate::Components::Distros::_blocker_is_experimental_os],
-            msg => 'Experimental OS detected. This script only supports CentOS 7 upgrades',
+            msg => 'Experimental operating system detected. This script does not support experimental OS upgrades.',
         },
         'Custom OS is not supported.'
     );

--- a/t/components-IsContainer.t
+++ b/t/components-IsContainer.t
@@ -35,7 +35,7 @@ my $mock = Test::MockModule->new('Elevate::Components::IsContainer');
     my $cpev = cpev->new();
     my $msg  = <<~'EOS';
     cPanel thinks that this is a container-like environment.
-    This cannot be upgraded by the native leapp tool.
+    This script cannot upgrade container environments.
     Consider contacting your hypervisor provider for alternative solutions.
     EOS
 

--- a/t/components-SSH.t
+++ b/t/components-SSH.t
@@ -73,8 +73,10 @@ my $ssh = bless {}, 'Elevate::Components::SSH';
     my $mock_sshd_cfg = Test::MockFile->file(q[/etc/ssh/sshd_config]);
 
     my $sshd_error_message = <<~'EOS';
-    OpenSSH configuration file does not explicitly state the option PermitRootLogin in sshd_config file, which will default in RHEL8 to "prohibit-password".
-    We will set the 'PermitRootLogin' value in /etc/ssh/sshd_config to 'yes' before upgrading.
+    The OpenSSH configuration file does not explicitly state the PermitRootLogin
+    option in the sshd_config file. This option may default to "prohibit-password"
+    after the upgrade is complete. We will set the 'PermitRootLogin' value in
+    /etc/ssh/sshd_config to 'yes' before upgrading.
 
     EOS
 


### PR DESCRIPTION
Case RE-945:

Audited all the strings for RHEL specific language & updated to be inclusive for Ubuntu. (However, strings output by code that only runs on RHEL systems were not updated. Also, the --help output was not updated as that is to be addressed in another case.)

Changelog: Update strings to be language agnostic for Ubuntu

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

