### PR TITLE
Remove experimental status for u20->u22 upgrades

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -7403,7 +7403,7 @@ deb https://wp-toolkit.plesk.com/cPanel/Ubuntu-22.04-x86_64/latest/thirdparty/ .
     use constant ea_alias => 'Ubuntu_22.04';
 
     use constant expected_post_upgrade_major => 22;
-    use constant is_experimental             => 1;
+    use constant is_experimental             => 0;
     use constant name                        => 'Ubuntu20';
     use constant original_os_major           => 20;
     use constant pretty_name                 => 'Ubuntu 20.04';

--- a/lib/Elevate/OS/Ubuntu20.pm
+++ b/lib/Elevate/OS/Ubuntu20.pm
@@ -67,7 +67,7 @@ use constant default_upgrade_to => 'Ubuntu';
 use constant ea_alias => 'Ubuntu_22.04';
 
 use constant expected_post_upgrade_major => 22;
-use constant is_experimental             => 1;
+use constant is_experimental             => 0;
 use constant name                        => 'Ubuntu20';
 use constant original_os_major           => 20;
 use constant pretty_name                 => 'Ubuntu 20.04';

--- a/t/is_experimental.t
+++ b/t/is_experimental.t
@@ -23,7 +23,7 @@ use Test::Elevate;
 my %os_designation = (
     cent   => 0,
     cloud  => 0,
-    ubuntu => 1,
+    ubuntu => 0,
 );
 
 foreach my $os ( sort keys %os_designation ) {


### PR DESCRIPTION
Case RE-1160: Remove experimental status for u20->u22 upgrades

Changelog: Remove experimental status for u20->u22 upgrades

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

