### PR TITLE
Do not restore config files for dropped packages

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -1915,6 +1915,12 @@ EOS
 
         my $ea4_config_files = Elevate::PkgMgr::get_config_files_for_pkg_prefix('ea-*');
 
+        my $stash        = Elevate::StageFile::read_stage_file();
+        my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
+        foreach my $pkg ( sort keys %$dropped_pkgs ) {
+            delete $ea4_config_files->{$pkg};
+        }
+
         Elevate::StageFile::update_stage_file( { ea4_config_files => $ea4_config_files } );
 
         return;

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -148,6 +148,14 @@ sub _backup_config_files ($self) {
 
     my $ea4_config_files = Elevate::PkgMgr::get_config_files_for_pkg_prefix('ea-*');
 
+    # Filter out any dropped packages since they will be installed
+    # post distro upgrade
+    my $stash        = Elevate::StageFile::read_stage_file();
+    my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
+    foreach my $pkg ( sort keys %$dropped_pkgs ) {
+        delete $ea4_config_files->{$pkg};
+    }
+
     Elevate::StageFile::update_stage_file( { ea4_config_files => $ea4_config_files } );
 
     return;


### PR DESCRIPTION
Case RE-1179: Previously, we did not filter out dropped packages from the list of EA4 packages that had config files that needed restored. This could result in odd bugs where a file was put in place that should not have been.

Changelog: Do not restore config files for dropped packages

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

