### PR TITLE
Force mysqlcheck to use UTF-8

### DIFF
--- a/elevate-cpanel
+++ b/elevate-cpanel
@@ -4135,7 +4135,7 @@ EOS
         }
 
         my $mysqlcheck_path = Cpanel::Binaries::path('mysqlcheck');
-        my $output          = $self->ssystem_capture_output( $mysqlcheck_path, '-c', '-m', '-A', '--silent' );
+        my $output          = $self->ssystem_capture_output( $mysqlcheck_path, '--default-character-set=utf8mb4', '-c', '-m', '-A', '--silent' );
 
         if ( scalar grep { /^error/i } @{ $output->{stdout} } ) {
 

--- a/lib/Elevate/Components/MySQL.pm
+++ b/lib/Elevate/Components/MySQL.pm
@@ -397,7 +397,7 @@ sub _blocker_mysql_database_corrupted ($self) {
 
     # Perform a medium check on all databases and only output errors
     my $mysqlcheck_path = Cpanel::Binaries::path('mysqlcheck');
-    my $output          = $self->ssystem_capture_output( $mysqlcheck_path, '-c', '-m', '-A', '--silent' );
+    my $output          = $self->ssystem_capture_output( $mysqlcheck_path, '--default-character-set=utf8mb4', '-c', '-m', '-A', '--silent' );
 
     # mysqlcheck doesn't return an error code
     # We check for lines that actually begin with "Error" (or "error")


### PR DESCRIPTION
Case RE-1262: The `-A` option for the `mysqlcheck` utility provided by MySQL/MariaDB gets the full list of databases/tables using the `SHOW DATABASES/TABLES` commands.  Names of databases, tables, columns, and other objects are permitted to contain any Unicode codepoint, but they are documented to be stored as UTF-8, meaning that it should be safe to assume that there won't be non-ASCII-compatible single-byte encodings in use. Our use of the `C` locale in ELevate turns off UTF-8 support and thus breaks `mysqlcheck`, because the environment variables we use to enforce this cause `mysqlcheck` to also use this locale for client-server communication, meaning that when a name of something has Unicode characters, the server can't return it properly as part of `SHOW DATABASES/TABLES`, and `mysqlcheck` thus can't direct the server to check it.

The easiest way to get `mysqlcheck` to use UTF-8 is to use the `--default-character-set=` flag. Pass the `utf8mb4` charset as the argument for this option.

Changelog: Default MySQL/MariaDB database checks to a UTF-8 character
 set.

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

