### PR TITLE
Remove backtick from check command

### DIFF
--- a/docs-website-src/content/blockers.md
+++ b/docs-website-src/content/blockers.md
@@ -42,7 +42,7 @@ We **strongly** recommend that you have multiple ways to access your server befo
 To identify many blockers, [download the `elevate-cpanel`](https://cpanel.github.io/elevate/getting-started/#updating-your-server) script and run the following command:
 
 ```
- /scripts/elevate-cpanel --check`
+ /scripts/elevate-cpanel --check
 ```
 
 ## Major blockers


### PR DESCRIPTION
This was left by mistake in https://github.com/cpanel/elevate/commit/9b0e20f94aa0562928250b5dd45bc65b236f2f8f.